### PR TITLE
Support rendering composites in component

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -3,3 +3,4 @@ parameters:
     =_metadata: {}
     secrets: {}
     additionalResources: {}
+    composites: {}

--- a/component/tests/defaults.yml
+++ b/component/tests/defaults.yml
@@ -13,3 +13,19 @@ parameters:
       test-namespace:
         apiVersion: v1
         kind: Namespace
+
+    composites:
+      "test.appcat.vshn.io":
+        spec:
+          group: appcat.vshn.io
+          names:
+            kind: XTest
+            plural: xtest
+          claimNames:
+            kind: Test
+            plural: tests
+          versions:
+            - name: v1
+              schema:
+                openAPIV3Schema:
+                  type: object

--- a/component/tests/golden/defaults/appcat/appcat/composites.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/composites.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '10'
+  labels:
+    name: test.appcat.vshn.io
+  name: test.appcat.vshn.io
+spec:
+  claimNames:
+    kind: Test
+    plural: tests
+  group: appcat.vshn.io
+  names:
+    kind: XTest
+    plural: xtest
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object

--- a/docs/modules/ROOT/pages/references/component-parameters.adoc
+++ b/docs/modules/ROOT/pages/references/component-parameters.adoc
@@ -2,7 +2,7 @@
 
 The parent key for all of the following parameters is `appcat`.
 
-== secrets
+== `secrets`
 
 [horizontal]
 type:: dict
@@ -22,7 +22,7 @@ secrets:
 Deploys Secrets as shown in the example.
 If a key under `secrets.*` is set to `null` (for example through hierarchy), then the Secret is removed.
 
-== additionalResources
+== `additionalResources`
 
 [horizontal]
 type:: dict
@@ -50,3 +50,31 @@ This can be used to deploy single ad-hoc resources, but it's not intended to man
 ====
 Consider adding dedicated parameters if there's a pattern of commonly deployed resources.
 ====
+
+== `composites`
+
+[horizontal]
+type:: dict
+default:: `{}`
+example::
+[source,yaml]
+----
+composites:
+  "xobjectbuckets.appcat.vshn.io": <1>
+    spec: <2>
+      group: appcat.vshn.io
+      names:
+        kind: XObjectBucket
+        plural: xobjectbuckets
+      claimNames:
+        kind: ObjectBucket
+        plural: objectbuckets
+      versions:
+        - name: v1
+          schema:
+            openAPIV3Schema: {...}
+----
+<1> `metadata.name` of the object
+<2> `spec` of a composite ("XRD") verbatim
+
+Deploys the composite resource definitions (XRDs) to the cluster.


### PR DESCRIPTION
Adds support for rendering composite resources.
Currently, I don't see good cases where jsonnet could help out in reducing YAML.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
