### PR TITLE
Add support for adding compositions in component

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -4,3 +4,4 @@ parameters:
     secrets: {}
     additionalResources: {}
     composites: {}
+    compositions: {}

--- a/component/component/app.jsonnet
+++ b/component/component/app.jsonnet
@@ -3,7 +3,7 @@ local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local argocd = import 'lib/argocd.libjsonnet';
 
-local app = argocd.App('appcat', params.namespace);
+local app = argocd.App('appcat', '');
 
 {
   appcat: app,

--- a/component/component/main.jsonnet
+++ b/component/component/main.jsonnet
@@ -17,16 +17,19 @@ local sync_options = {
 
 // https://syn.tools/syn/explanations/commodore-components/secrets.html
 local secrets = std.filter(function(it) it != null, [
-  if params.secrets[s] != null then
-    kube.Secret(s) {} + com.makeMergeable(params.secrets[s])
-  for s in std.objectFields(params.secrets)
+  if params.secrets[name] != null then
+    local secret = params.secrets[name];
+    assert std.objectHas(secret, 'metadata') : "missing `.metadata` in secret '%s'" % name;
+    assert std.get(secret.metadata, 'namespace', '') != '' : "`.metadata.namespace` in secret '%s' cannot be empty" % name;
+    kube.Secret(name) {} + com.makeMergeable(secret)
+  for name in std.objectFields(params.secrets)
 ]);
 
 local additionalResources = std.filter(function(it) it != null, [
-  if params.additionalResources[s] != null then
-    local res = params.additionalResources[s];
-    kube._Object(res.apiVersion, res.kind, s) + com.makeMergeable(res)
-  for s in std.objectFields(params.additionalResources)
+  if params.additionalResources[name] != null then
+    local res = params.additionalResources[name];
+    kube._Object(res.apiVersion, res.kind, name) + com.makeMergeable(res)
+  for name in std.objectFields(params.additionalResources)
 ]);
 
 local composites = std.filter(function(it) it != null, [

--- a/component/component/main.jsonnet
+++ b/component/component/main.jsonnet
@@ -36,9 +36,17 @@ local composites = [
   for name in std.objectFields(params.composites)
 ];
 
+local compositions = [
+  if params.compositions[name] != null then
+    local composition = params.compositions[name];
+    kube._Object('apiextensions.crossplane.io/v1', 'Composition', name) + sync_options + com.makeMergeable(composition)
+  for name in std.objectFields(params.compositions)
+];
+
 // Define outputs below
 {
   secrets: std.filter(function(it) it != null, secrets),
   additionalResources: std.filter(function(it) it != null, additionalResources),
   composites: std.filter(function(it) it != null, composites),
+  compositions: std.filter(function(it) it != null, compositions),
 }

--- a/component/component/main.jsonnet
+++ b/component/component/main.jsonnet
@@ -16,37 +16,37 @@ local sync_options = {
 };
 
 // https://syn.tools/syn/explanations/commodore-components/secrets.html
-local secrets = [
+local secrets = std.filter(function(it) it != null, [
   if params.secrets[s] != null then
     kube.Secret(s) {} + com.makeMergeable(params.secrets[s])
   for s in std.objectFields(params.secrets)
-];
+]);
 
-local additionalResources = [
+local additionalResources = std.filter(function(it) it != null, [
   if params.additionalResources[s] != null then
     local res = params.additionalResources[s];
     kube._Object(res.apiVersion, res.kind, s) + com.makeMergeable(res)
   for s in std.objectFields(params.additionalResources)
-];
+]);
 
-local composites = [
+local composites = std.filter(function(it) it != null, [
   if params.composites[name] != null then
     local res = params.composites[name];
     kube._Object('apiextensions.crossplane.io/v1', 'CompositeResourceDefinition', name) + sync_options + com.makeMergeable(res)
   for name in std.objectFields(params.composites)
-];
+]);
 
-local compositions = [
+local compositions = std.filter(function(it) it != null, [
   if params.compositions[name] != null then
     local composition = params.compositions[name];
     kube._Object('apiextensions.crossplane.io/v1', 'Composition', name) + sync_options + com.makeMergeable(composition)
   for name in std.objectFields(params.compositions)
-];
+]);
 
 // Define outputs below
 {
-  secrets: std.filter(function(it) it != null, secrets),
-  additionalResources: std.filter(function(it) it != null, additionalResources),
-  composites: std.filter(function(it) it != null, composites),
-  compositions: std.filter(function(it) it != null, compositions),
+  [if std.length(secrets) > 0 then 'secrets']: secrets,
+  [if std.length(additionalResources) > 0 then 'additionalResources']: additionalResources,
+  [if std.length(composites) > 0 then 'composites']: composites,
+  [if std.length(compositions) > 0 then 'compositions']: compositions,
 }

--- a/component/tests/defaults.yml
+++ b/component/tests/defaults.yml
@@ -29,3 +29,50 @@ parameters:
               schema:
                 openAPIV3Schema:
                   type: object
+
+    compositions:
+      test-composition:
+        spec:
+          compositeTypeRef:
+            apiVersion: appcat.vshn.io/v1
+            kind: XTest
+          writeConnectionSecretsToNamespace: crossplane-system
+          patchSets:
+            - name: annotations
+              patches:
+                - type: FromCompositeFieldPath
+                  fromFieldPath: metadata.annotations
+            - name: labels
+              patches:
+                - type: FromCompositeFieldPath
+                  fromFieldPath: metadata.labels
+          resources:
+
+            - base:
+                apiVersion: kubernetes.crossplane.io/v1alpha1
+                kind: Object
+                spec:
+                  managementPolicy: Observe
+                  forProvider:
+                    manifest:
+                      apiVersion: v1
+                      kind: Namespace
+                      metadata:
+                        name: '' # patched
+                  providerConfigRef:
+                    name: provider-config
+              patches:
+                # set which namespace to observe
+                - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
+                  toFieldPath: spec.forProvider.manifest.metadata.name
+                # copy the appuio organization label to a label on the XR
+                - type: ToCompositeFieldPath
+                  fromFieldPath: status.atProvider.manifest.metadata.labels[appuio.io/organization]
+                  toFieldPath: metadata.labels[appuio.io/organization]
+                # append suffix to the observer name
+                - fromFieldPath: metadata.labels[crossplane.io/composite]
+                  toFieldPath: metadata.name
+                  transforms:
+                    - type: string
+                      string:
+                        fmt: "%s-ns-observer"

--- a/component/tests/golden/defaults/appcat/appcat/compositions.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/compositions.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '10'
+  labels:
+    name: test-composition
+  name: test-composition
+spec:
+  compositeTypeRef:
+    apiVersion: appcat.vshn.io/v1
+    kind: XTest
+  patchSets:
+    - name: annotations
+      patches:
+        - fromFieldPath: metadata.annotations
+          type: FromCompositeFieldPath
+    - name: labels
+      patches:
+        - fromFieldPath: metadata.labels
+          type: FromCompositeFieldPath
+  resources:
+    - base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        spec:
+          forProvider:
+            manifest:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: ''
+          managementPolicy: Observe
+          providerConfigRef:
+            name: provider-config
+      patches:
+        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
+          toFieldPath: spec.forProvider.manifest.metadata.name
+        - fromFieldPath: status.atProvider.manifest.metadata.labels[appuio.io/organization]
+          toFieldPath: metadata.labels[appuio.io/organization]
+          type: ToCompositeFieldPath
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: metadata.name
+          transforms:
+            - string:
+                fmt: '%s-ns-observer'
+              type: string
+  writeConnectionSecretsToNamespace: crossplane-system

--- a/docs/modules/ROOT/pages/references/component-parameters.adoc
+++ b/docs/modules/ROOT/pages/references/component-parameters.adoc
@@ -78,3 +78,18 @@ composites:
 <2> `spec` of a composite ("XRD") verbatim
 
 Deploys the composite resource definitions (XRDs) to the cluster.
+
+== `compositions`
+
+[horizontal]
+type:: dict
+default:: `{}`
+example::
+[source,yaml]
+----
+compositions:
+  test-composition: <1>
+    spec: {...} <2>
+----
+<1> `metadata.name` of the object
+<2> `spec` of a composition


### PR DESCRIPTION
* Adds a feature where Crossplane compositions can be rendered using the component, by providing the full composition spec in `appcat.compositions`.
* Adds parameter reference docs

This PR is preparation for a package that adds a composition for cloudscale objectstorage in a follow-up

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
