### PR TITLE
Add package for provider-kubernetes

### DIFF
--- a/docs/modules/ROOT/pages/references/provider-kubernetes.adoc
+++ b/docs/modules/ROOT/pages/references/provider-kubernetes.adoc
@@ -1,0 +1,11 @@
+= pkg.appcat.provider.kubernetes
+
+The parent key for all of the following parameters is `pkg.appcat.provider.kubernetes`.
+
+== `images:provider-kubernetes`
+
+[horizontal]
+type:: dict
+default:: see `packages/provider/kubernetes.yml`
+
+The package image repository for https://github.com/crossplane-contrib/provider-kubernetes[provider-kubernetes].

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -6,6 +6,7 @@
 .Technical reference
 * xref:references/component-parameters.adoc[Component Parameters]
 * xref:references/provider-cloudscale.adoc[Parameters For provider.cloudscale]
+* xref:references/provider-kubernetes.adoc[Parameters For provider.kubernetes]
 * xref:references/composite-objectstorage.adoc[Parameters For composite.objectstorage]
 
 * Compositions

--- a/packages/provider/kubernetes.yml
+++ b/packages/provider/kubernetes.yml
@@ -1,0 +1,76 @@
+classes:
+  - .common
+
+parameters:
+
+  pkg.appcat.provider.kubernetes:
+    images:
+      provider-kubernetes:
+        registry: docker.io
+        repository: crossplane/provider-kubernetes
+        tag: v0.4.0
+
+  crossplane:
+    providers:
+      kubernetes:
+        package: ${pkg.appcat.provider.kubernetes:images:provider-kubernetes:registry}/${pkg.appcat.provider.kubernetes:images:provider-kubernetes:repository}:${pkg.appcat.provider.kubernetes:images:provider-kubernetes:tag}
+
+    providerConfigs:
+      kubernetes:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        spec:
+          credentials:
+            source: InjectedIdentity
+
+    controllerConfigs:
+      provider-kubernetes:
+        spec:
+          # We need to set a different SA name than the generated one, to allow RBAC permissions for reading namespaces.
+          serviceAccountName: provider-kubernetes
+
+    serviceAccounts:
+      provider-kubernetes: {}
+
+    clusterRoles:
+      "crossplane:provider:provider-kubernetes:system:custom":
+        rules:
+          - verbs:
+              - get
+              - list
+              - watch
+              - update
+              - patch
+              - create
+            apiGroups:
+              - kubernetes.crossplane.io
+            resources:
+              - '*'
+          - verbs:
+              - '*'
+            apiGroups:
+              - ''
+              - coordination.k8s.io
+            resources:
+              - secrets
+              - configmaps
+              - events
+              - leases
+          - verbs:
+              - 'get'
+              - 'list'
+              - 'watch'
+            apiGroups:
+              - ''
+            resources:
+              - namespaces
+
+    clusterRoleBindings:
+      "crossplane:provider:provider-kubernetes:system:custom":
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: crossplane:provider:provider-kubernetes:system:custom
+        subjects:
+          - kind: ServiceAccount
+            name: provider-kubernetes
+            namespace: ${crossplane:namespace}

--- a/packages/tests/composition-objectstorage-cloudscale.yml
+++ b/packages/tests/composition-objectstorage-cloudscale.yml
@@ -1,5 +1,7 @@
 classes:
   - ..composition.objectstorage.cloudscale
+  # composition requires provider-kubernetes as dependency
+  - ..provider.kubernetes
 
 parameters:
   crossplane:

--- a/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/10_providers.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/10_providers.yaml
@@ -1,0 +1,11 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '10'
+  labels:
+    name: kubernetes
+  name: kubernetes
+spec:
+  package: docker.io/crossplane/provider-kubernetes:v0.4.0

--- a/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/30_controller_configs.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/30_controller_configs.yaml
@@ -1,0 +1,11 @@
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '10'
+  labels:
+    name: provider-kubernetes
+  name: provider-kubernetes
+spec:
+  serviceAccountName: provider-kubernetes

--- a/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/40_service_accounts.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/40_service_accounts.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: provider-kubernetes
+  name: provider-kubernetes

--- a/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/50_cluster_roles.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/50_cluster_roles.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: crossplane-provider-provider-kubernetes-system-custom
+  name: crossplane:provider:provider-kubernetes:system:custom
+rules:
+  - apiGroups:
+      - kubernetes.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+  - apiGroups:
+      - ''
+      - coordination.k8s.io
+    resources:
+      - secrets
+      - configmaps
+      - events
+      - leases
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch

--- a/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/60_cluster_role_bindings.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/60_cluster_role_bindings.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: crossplane-provider-provider-kubernetes-system-custom
+  name: crossplane:provider:provider-kubernetes:system:custom
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane:provider:provider-kubernetes:system:custom
+subjects:
+  - kind: ServiceAccount
+    name: provider-kubernetes
+    namespace: syn-crossplane

--- a/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/70_provider_configs.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/70_provider_configs.yaml
@@ -13,3 +13,16 @@ spec:
       name: cloudscale-api-token
       namespace: syn-crossplane
     source: InjectedIdentity
+---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '10'
+  labels:
+    name: kubernetes
+  name: kubernetes
+spec:
+  credentials:
+    source: InjectedIdentity


### PR DESCRIPTION
The cloudscale S3 composition needs `provider-kubernetes` as a dependency.
This PR adds a package to configure this provider and give RBAC permissions to observe namespaces.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
