### PR TITLE
Fix some issues when rolling out on ArgoCD

### DIFF
--- a/docs/modules/ROOT/pages/references/composite-objectstorage.adoc
+++ b/docs/modules/ROOT/pages/references/composite-objectstorage.adoc
@@ -6,6 +6,6 @@ The parent key for all of the following parameters is `pkg.appcat.composite.obje
 
 [horizontal]
 type:: string
-default:: `objectstorage-${facts:cloud}`
+default:: `${facts:cloud}.objectbuckets.appcat.vshn.io`
 
 The default composition to use when a user creates a Claim of the composite resource.

--- a/docs/modules/ROOT/pages/tutorials/install-cloudscale.adoc
+++ b/docs/modules/ROOT/pages/tutorials/install-cloudscale.adoc
@@ -39,7 +39,7 @@ vault login -method=oidc
 [source,bash]
 ----
 parent="clusters/kv/${TENANT_ID}/${CLUSTER_ID}/appcat/objectstorage/provider-cloudscale"
-vault kv patch "${parent}" token=<the-cloudscale-token>
+vault kv put "${parent}" token=<the-cloudscale-token>
 ----
 
 == Configuration
@@ -50,25 +50,25 @@ vault kv patch "${parent}" token=<the-cloudscale-token>
 ----
 classes:
   - appcat.provider.cloudscale <1>
-  - appcat.composite.objectstorage <2>
-  - appcat.composition.objectstorage.cloudscale <3>
-applications: <4>
-  - pkg.appcat.provider.cloudscale
-  - pkg.appcat.composite.objectstorage
-  - pkg.appcat.composition.objectstorage.cloudscale
+  - appcat.provider.kubernetes <2>
+  - appcat.composite.objectstorage <3>
+  - appcat.composition.objectstorage.cloudscale <4>
+applications: <5>
+  - pkg.appcat
 
 parameters:
   packages:
     appcat:
-      version: master <5>
+      version: master <6>
       url: {page-origin-url}
       path: packages
 ----
 <1> The config for the operator (provider) that talks to cloudscale.ch API.
-<2> The XRD is configured in this package.
-<3> The composition is configured in this package.
-<4> We need to enable the packages as part of the applications.
+<2> The config for the provider-kubernetes is required as a dependency.
+<3> The XRD is configured in this package.
+<4> The composition is configured in this package.
+<5> We need to enable the packages as part of the applications.
     This gives us access to the provided classes.
-<5> The version of the package (applies to all appcat packages!).
+<6> The version of the package (applies to all appcat packages!).
 
 . Compile and push cluster catalog

--- a/packages/composite/objectstorage.yml
+++ b/packages/composite/objectstorage.yml
@@ -4,7 +4,7 @@ classes:
 parameters:
 
   pkg.appcat.composite.objectstorage:
-    defaultCompositionRef: objectbucket-${facts:cloud}
+    defaultCompositionRef: "${facts:cloud}.objectbuckets.appcat.vshn.io"
 
   appcat:
     composites:

--- a/packages/composition/objectstorage/cloudscale.yml
+++ b/packages/composition/objectstorage/cloudscale.yml
@@ -9,7 +9,7 @@ parameters:
 
   appcat:
     compositions:
-      objectbucket-cloudscale:
+      "cloudscale.objectbuckets.appcat.vshn.io":
         spec:
           compositeTypeRef:
             apiVersion: appcat.vshn.io/v1

--- a/packages/composition/objectstorage/cloudscale.yml
+++ b/packages/composition/objectstorage/cloudscale.yml
@@ -4,7 +4,7 @@ classes:
 parameters:
   pkg.appcat.composition.objectstorage.cloudscale:
     secretNamespaces:
-      objectsusers: provider-cloudscale-secrets
+      objectsusers: syn-provider-cloudscale-secrets
     bucketDeletionPolicy: DeleteAll
 
   appcat:
@@ -37,31 +37,32 @@ parameters:
                     manifest:
                       apiVersion: v1
                       kind: Namespace
-                      metadata:
-                        name: '' # patched
+                      metadata: {} # patched
                   providerConfigRef:
-                    name: provider-config
+                    name: kubernetes
               patches:
                 # set which namespace to observe
-                - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
+                - type: FromCompositeFieldPath
+                  fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
                   toFieldPath: spec.forProvider.manifest.metadata.name
                 # copy the appuio organization label to a label on the XR
                 - type: ToCompositeFieldPath
                   fromFieldPath: status.atProvider.manifest.metadata.labels[appuio.io/organization]
                   toFieldPath: metadata.labels[appuio.io/organization]
                 # append suffix to the observer name
-                - fromFieldPath: metadata.labels[crossplane.io/composite]
+                - type: FromCompositeFieldPath
+                  fromFieldPath: metadata.labels[crossplane.io/composite]
                   toFieldPath: metadata.name
                   transforms:
                     - type: string
                       string:
                         fmt: "%s-ns-observer"
+                        type: Format
 
             - base:
                 apiVersion: cloudscale.crossplane.io/v1
                 kind: ObjectsUser
-                metadata:
-                  name: ""
+                metadata: {} # patched
                 spec:
                   forProvider:
                     displayName: "" # patched
@@ -72,7 +73,7 @@ parameters:
                     name: ""
                     namespace: ${pkg.appcat.composition.objectstorage.cloudscale:secretNamespaces:objectsusers}
                   providerConfigRef:
-                    name: provider-config
+                    name: cloudscale
               connectionDetails:
                 - fromConnectionSecretKey: AWS_ACCESS_KEY_ID
                   type: FromConnectionSecretKey
@@ -88,7 +89,8 @@ parameters:
                 - type: FromCompositeFieldPath
                   fromFieldPath: metadata.labels[crossplane.io/composite]
                   toFieldPath: metadata.name
-                - fromFieldPath: metadata.labels[crossplane.io/composite]
+                - type: FromCompositeFieldPath
+                  fromFieldPath: metadata.labels[crossplane.io/composite]
                   toFieldPath: spec.writeConnectionSecretToRef.name
                 # Set display name
                 - type: CombineFromComposite
@@ -112,8 +114,7 @@ parameters:
             - base:
                 apiVersion: cloudscale.crossplane.io/v1
                 kind: Bucket
-                metadata:
-                  name: ""
+                metadata: {} # patched
                 spec:
                   forProvider:
                     bucketName: ""
@@ -147,17 +148,21 @@ parameters:
                 - type: FromCompositeFieldPath
                   fromFieldPath: spec.parameters.bucketName
                   toFieldPath: spec.forProvider.bucketName
-                - fromFieldPath: metadata.labels[crossplane.io/composite]
+                - type: FromCompositeFieldPath
+                  fromFieldPath: metadata.labels[crossplane.io/composite]
                   toFieldPath: spec.forProvider.credentialsSecretRef.name
                 # Set endpoint
-                - fromFieldPath: spec.parameters.region
+                - type: FromCompositeFieldPath
+                  fromFieldPath: spec.parameters.region
                   toFieldPath: spec.forProvider.endpointURL
                   transforms:
                     - type: string
                       string:
                         fmt: "objects.%s.cloudscale.ch"
+                        type: Format
                 # Set region
-                - fromFieldPath: spec.parameters.region
+                - type: FromCompositeFieldPath
+                  fromFieldPath: spec.parameters.region
                   toFieldPath: spec.forProvider.region
                   transforms:
                     # The Map transformation ensures we use only supported regions by cloudscale.

--- a/packages/provider/kubernetes.yml
+++ b/packages/provider/kubernetes.yml
@@ -23,7 +23,7 @@ parameters:
             source: InjectedIdentity
 
     controllerConfigs:
-      provider-kubernetes:
+      kubernetes:
         spec:
           # We need to set a different SA name than the generated one, to allow RBAC permissions for reading namespaces.
           serviceAccountName: provider-kubernetes

--- a/packages/tests/golden/composite-objectstorage/appcat/appcat/composites.yaml
+++ b/packages/tests/golden/composite-objectstorage/appcat/appcat/composites.yaml
@@ -18,7 +18,7 @@ spec:
     - ENDPOINT
     - BUCKET_NAME
   defaultCompositionRef:
-    name: objectbucket-cloudscale
+    name: cloudscale.objectbuckets.appcat.vshn.io
   group: appcat.vshn.io
   names:
     kind: XObjectBucket

--- a/packages/tests/golden/composition-objectstorage-cloudscale/appcat/appcat/additionalResources.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/appcat/appcat/additionalResources.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    name: provider-cloudscale-secrets
-  name: provider-cloudscale-secrets
+    name: syn-provider-cloudscale-secrets
+  name: syn-provider-cloudscale-secrets

--- a/packages/tests/golden/composition-objectstorage-cloudscale/appcat/appcat/compositions.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/appcat/appcat/compositions.yaml
@@ -5,8 +5,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
   labels:
-    name: objectbucket-cloudscale
-  name: objectbucket-cloudscale
+    name: cloudscale.objectbuckets.appcat.vshn.io
+  name: cloudscale.objectbuckets.appcat.vshn.io
 spec:
   compositeTypeRef:
     apiVersion: appcat.vshn.io/v1

--- a/packages/tests/golden/composition-objectstorage-cloudscale/appcat/appcat/compositions.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/appcat/appcat/compositions.yaml
@@ -31,14 +31,14 @@ spec:
             manifest:
               apiVersion: v1
               kind: Namespace
-              metadata:
-                name: ''
+              metadata: {}
           managementPolicy: Observe
           providerConfigRef:
-            name: provider-config
+            name: kubernetes
       patches:
         - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
           toFieldPath: spec.forProvider.manifest.metadata.name
+          type: FromCompositeFieldPath
         - fromFieldPath: status.atProvider.manifest.metadata.labels[appuio.io/organization]
           toFieldPath: metadata.labels[appuio.io/organization]
           type: ToCompositeFieldPath
@@ -47,12 +47,13 @@ spec:
           transforms:
             - string:
                 fmt: '%s-ns-observer'
+                type: Format
               type: string
+          type: FromCompositeFieldPath
     - base:
         apiVersion: cloudscale.crossplane.io/v1
         kind: ObjectsUser
-        metadata:
-          name: ''
+        metadata: {}
         spec:
           forProvider:
             displayName: ''
@@ -60,10 +61,10 @@ spec:
               namespace: null
               tenant: null
           providerConfigRef:
-            name: provider-config
+            name: cloudscale
           writeConnectionSecretToRef:
             name: ''
-            namespace: provider-cloudscale-secrets
+            namespace: syn-provider-cloudscale-secrets
       connectionDetails:
         - fromConnectionSecretKey: AWS_ACCESS_KEY_ID
           name: AWS_ACCESS_KEY_ID
@@ -81,6 +82,7 @@ spec:
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: spec.writeConnectionSecretToRef.name
+          type: FromCompositeFieldPath
         - combine:
             strategy: string
             string:
@@ -99,15 +101,14 @@ spec:
     - base:
         apiVersion: cloudscale.crossplane.io/v1
         kind: Bucket
-        metadata:
-          name: ''
+        metadata: {}
         spec:
           forProvider:
             bucketDeletionPolicy: DeleteAll
             bucketName: ''
             credentialsSecretRef:
               name: ''
-              namespace: provider-cloudscale-secrets
+              namespace: syn-provider-cloudscale-secrets
             endpointURL: ''
             region: ''
       connectionDetails:
@@ -133,12 +134,15 @@ spec:
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: spec.forProvider.credentialsSecretRef.name
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.endpointURL
           transforms:
             - string:
                 fmt: objects.%s.cloudscale.ch
+                type: Format
               type: string
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.region
           transforms:
@@ -146,4 +150,5 @@ spec:
                 lpg: lpg
                 rma: rma
               type: map
+          type: FromCompositeFieldPath
   writeConnectionSecretsToNamespace: syn-crossplane

--- a/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/30_controller_configs.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/crossplane/crossplane/30_controller_configs.yaml
@@ -5,7 +5,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
   labels:
-    name: provider-kubernetes
-  name: provider-kubernetes
+    name: kubernetes
+  name: kubernetes
 spec:
   serviceAccountName: provider-kubernetes


### PR DESCRIPTION
* Fixes a bunch of Diffing issues when deploying with ArgoCD, otherwise Kubernetes and Argo "fight" over the manifest
* Renames the composition form `objectbucket-cloudscale` to `cloudscale.objectbuckets.appcat.vshn.io`.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
