### PR TITLE
Add custom User-facing RBAC rules to allow provisioning Claims

### DIFF
--- a/docs/modules/ROOT/pages/tutorials/install-cloudscale.adoc
+++ b/docs/modules/ROOT/pages/tutorials/install-cloudscale.adoc
@@ -62,6 +62,10 @@ parameters:
       version: master <6>
       url: {page-origin-url}
       path: packages
+  crossplane:
+    helmValues:
+      rbacManager:
+        managementPolicy: Basic <7>
 ----
 <1> The config for the operator (provider) that talks to cloudscale.ch API.
 <2> The config for the provider-kubernetes is required as a dependency.
@@ -70,5 +74,6 @@ parameters:
 <5> We need to enable the packages as part of the applications.
     This gives us access to the provided classes.
 <6> The version of the package (applies to all appcat packages!).
+<7> Ensure that RBAC management policy is set to `Basic` only.
 
 . Compile and push cluster catalog

--- a/packages/composite/common.yml
+++ b/packages/composite/common.yml
@@ -29,7 +29,7 @@ parameters:
             resources:
               - compositions
               - compositionrevisions
-              - compositeresourcedefnitions
+              - compositeresourcedefinitions
             verbs:
               - get
               - list

--- a/packages/composite/common.yml
+++ b/packages/composite/common.yml
@@ -1,4 +1,5 @@
 applications:
+  - crossplane
   - appcat
 
 parameters:
@@ -8,3 +9,28 @@ parameters:
       url: https://github.com/vshn/component-appcat.git
       version: master
       path: component
+
+    crossplane:
+      url: https://github.com/projectsyn/component-crossplane.git
+      version: v2.2.0
+
+  crossplane:
+    clusterRoles:
+      # Allow to discover which compositions and xrds are available
+      "appcat:browse":
+        metadata:
+          labels:
+            rbac.authorization.k8s.io/aggregate-to-view: 'true'
+            rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+            rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+        rules:
+          - apiGroups:
+              - apiextensions.crossplane.io
+            resources:
+              - compositions
+              - compositionrevisions
+              - compositeresourcedefnitions
+            verbs:
+              - get
+              - list
+              - watch

--- a/packages/composite/objectstorage.yml
+++ b/packages/composite/objectstorage.yml
@@ -55,3 +55,38 @@ parameters:
                                 be created. The region must be available in the S3 endpoint. Accepted
                                 values are LPG and RMA.
                               type: string
+
+  crossplane:
+    clusterRoles:
+      # Allow to view claims
+      "appcat:composite:objectstorage:claim-view":
+        metadata:
+          labels:
+            rbac.authorization.k8s.io/aggregate-to-view: 'true'
+        rules:
+          - apiGroups:
+              - appcat.vshn.io
+            resources:
+              - objectbuckets
+              - objectbuckets/status
+              - objectbuckets/finalizers
+            verbs:
+              - get
+              - list
+              - watch
+
+      # Allow to edit claims
+      "appcat:composite:objectstorage:claim-edit":
+        metadata:
+          labels:
+            rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+            rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+        rules:
+          - apiGroups:
+              - appcat.vshn.io
+            resources:
+              - objectbuckets
+              - objectbuckets/status
+              - objectbuckets/finalizers
+            verbs:
+              - '*'

--- a/packages/tests/golden/composite-objectstorage/crossplane/apps/crossplane.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/apps/crossplane.yaml
@@ -1,0 +1,7 @@
+spec:
+  ignoreDifferences:
+    - group: rbac.authorization.k8s.io
+      jsonPointers:
+        - /rules
+      kind: ClusterRole
+      name: crossplane

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/00_namespace.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/00_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-crossplane
+  name: syn-crossplane

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/clusterrole.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/clusterrole.yaml
@@ -1,0 +1,115 @@
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.crossplane.io/aggregate-to-crossplane: 'true'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: crossplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    crossplane.io/scope: system
+    helm.sh/chart: crossplane-1.9.0
+    rbac.crossplane.io/aggregate-to-crossplane: 'true'
+  name: crossplane:system:aggregate-to-crossplane
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+      - services
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.crossplane.io
+      - pkg.crossplane.io
+      - secrets.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
+      - watch
+  - apiGroups:
+      - ''
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - watch
+      - delete
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - watch
+      - delete

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: crossplane
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane
+subjects:
+  - kind: ServiceAccount
+    name: crossplane
+    namespace: syn-crossplane

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/deployment.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    release: crossplane
+  name: crossplane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crossplane
+      release: crossplane
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: '8080'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: crossplane
+        app.kubernetes.io/component: cloud-infrastructure-controller
+        app.kubernetes.io/instance: crossplane
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: crossplane
+        app.kubernetes.io/part-of: crossplane
+        app.kubernetes.io/version: 1.9.0
+        helm.sh/chart: crossplane-1.9.0
+        release: crossplane
+    spec:
+      containers:
+        - args:
+            - core
+            - start
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LEADER_ELECTION
+              value: 'true'
+          image: docker.io/crossplane/crossplane:v1.9.0
+          imagePullPolicy: IfNotPresent
+          name: crossplane
+          ports:
+            - containerPort: 8080
+              name: metrics
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsUser: 65532
+          volumeMounts:
+            - mountPath: /cache
+              name: package-cache
+      initContainers:
+        - args:
+            - core
+            - init
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          image: docker.io/crossplane/crossplane:v1.9.0
+          imagePullPolicy: IfNotPresent
+          name: crossplane-init
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsUser: 65532
+      securityContext: {}
+      serviceAccountName: crossplane
+      volumes:
+        - emptyDir:
+            medium: null
+            sizeLimit: 5Mi
+          name: package-cache

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -1,0 +1,17 @@
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.crossplane.io/aggregate-to-allowed-provider-permissions: 'true'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: crossplane:allowed-provider-permissions

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -1,0 +1,95 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: crossplane-rbac-manager
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.crossplane.io
+    resources:
+      - compositeresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - pkg.crossplane.io
+    resources:
+      - providerrevisions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - escalate
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - watch
+      - delete

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: crossplane-rbac-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-rbac-manager
+subjects:
+  - kind: ServiceAccount
+    name: rbac-manager
+    namespace: syn-crossplane

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: crossplane-rbac-manager
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    release: crossplane
+  name: crossplane-rbac-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crossplane-rbac-manager
+      release: crossplane
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: '8080'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: crossplane-rbac-manager
+        app.kubernetes.io/component: cloud-infrastructure-controller
+        app.kubernetes.io/instance: crossplane
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: crossplane
+        app.kubernetes.io/part-of: crossplane
+        app.kubernetes.io/version: 1.9.0
+        helm.sh/chart: crossplane-1.9.0
+        release: crossplane
+    spec:
+      containers:
+        - args:
+            - rbac
+            - start
+            - --manage=All
+            - --provider-clusterrole=crossplane:allowed-provider-permissions
+          env:
+            - name: LEADER_ELECTION
+              value: 'true'
+          image: docker.io/crossplane/crossplane:v1.9.0
+          imagePullPolicy: IfNotPresent
+          name: crossplane
+          ports:
+            - containerPort: 8080
+              name: metrics
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsUser: 65532
+      initContainers:
+        - args:
+            - rbac
+            - init
+          image: docker.io/crossplane/crossplane:v1.9.0
+          imagePullPolicy: IfNotPresent
+          name: crossplane-init
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsUser: 65532
+      securityContext: {}
+      serviceAccountName: rbac-manager

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -1,0 +1,400 @@
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.crossplane.io/aggregate-to-admin: 'true'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: crossplane-admin
+---
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.crossplane.io/aggregate-to-edit: 'true'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: crossplane-edit
+---
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.crossplane.io/aggregate-to-view: 'true'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: crossplane-view
+---
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.crossplane.io/aggregate-to-browse: 'true'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: crossplane-browse
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    rbac.crossplane.io/aggregate-to-admin: 'true'
+  name: crossplane:aggregate-to-admin
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+      - namespaces
+    verbs:
+      - '*'
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - rolebindings
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - pkg.crossplane.io
+    resources:
+      - providers
+      - configurations
+      - providerrevisions
+      - configurationrevisions
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    rbac.crossplane.io/aggregate-to-edit: 'true'
+  name: crossplane:aggregate-to-edit
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - pkg.crossplane.io
+    resources:
+      - providers
+      - configurations
+      - providerrevisions
+      - configurationrevisions
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    rbac.crossplane.io/aggregate-to-view: 'true'
+  name: crossplane:aggregate-to-view
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - pkg.crossplane.io
+    resources:
+      - providers
+      - configurations
+      - providerrevisions
+      - configurationrevisions
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    rbac.crossplane.io/aggregate-to-browse: 'true'
+  name: crossplane:aggregate-to-browse
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    rbac.crossplane.io/aggregate-to-ns-admin: 'true'
+    rbac.crossplane.io/base-of-ns-admin: 'true'
+  name: crossplane:aggregate-to-ns-admin
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    rbac.crossplane.io/aggregate-to-ns-edit: 'true'
+    rbac.crossplane.io/base-of-ns-edit: 'true'
+  name: crossplane:aggregate-to-ns-edit
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+    rbac.crossplane.io/aggregate-to-ns-view: 'true'
+    rbac.crossplane.io/base-of-ns-view: 'true'
+  name: crossplane:aggregate-to-ns-view
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: crossplane-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: crossplane:masters

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+imagePullSecrets:
+  - name: dockerhub
+kind: ServiceAccount
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: rbac-manager

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/serviceaccount.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/01_helmchart/crossplane/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+imagePullSecrets:
+  - name: dockerhub
+kind: ServiceAccount
+metadata:
+  labels:
+    app: crossplane
+    app.kubernetes.io/component: cloud-infrastructure-controller
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: crossplane
+    app.kubernetes.io/part-of: crossplane
+    app.kubernetes.io/version: 1.9.0
+    helm.sh/chart: crossplane-1.9.0
+  name: crossplane

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/02_upgrade/00_upgrade.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/02_upgrade/00_upgrade.yaml
@@ -1,0 +1,138 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+  labels:
+    name: crossplane-crd-upgrade
+  name: crossplane-crd-upgrade
+  namespace: syn-crossplane
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - pkg.crossplane.io
+    resources:
+      - locks
+    verbs:
+      - get
+      - patch
+      - list
+  - apiGroups:
+      - pkg.crossplane.io
+    resources:
+      - providers
+    verbs:
+      - get
+      - patch
+      - list
+  - apiGroups:
+      - pkg.crossplane.io
+    resources:
+      - configurations
+    verbs:
+      - get
+      - patch
+      - list
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+  labels:
+    name: crossplane-crd-upgrade
+  name: crossplane-crd-upgrade
+  namespace: syn-crossplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+  labels:
+    name: crossplane-crd-upgrade
+  name: crossplane-crd-upgrade
+  namespace: syn-crossplane
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-crd-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: crossplane-crd-upgrade
+    namespace: syn-crossplane
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+  labels:
+    name: crossplane-crd-upgrade
+  name: crossplane-crd-upgrade
+  namespace: syn-crossplane
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        name: crossplane-crd-upgrade
+    spec:
+      containers:
+        - args:
+            - -eu
+            - -c
+            - "#!/bin/bash\nset -e\n\n#Patch CRDS so that ArgoCD does not delete them\
+              \ during upgrade\nfor crd in $CRDS_TO_PATCH; do\n\tif ! kubectl get\
+              \ crd \"${crd}\" >/dev/null 2>&1; then\n\t\techo >&2 \"WARNING: Skipping\
+              \ '${crd}': not found.\"\n\t\tcontinue\n\tfi\n\n\t#Remove ArgoCD managed-by\
+              \ label from the CRD\n\tkubectl label crd \"${crd}\" argocd.argoproj.io/instance-\n\
+              done\n\n#Locks are not managed anymore in the helm chart therefore remove\
+              \ them from ArgoCD sync cycle\nfor lock in $(kubectl get locks -o name);\
+              \ do\n\t#Remove ArgoCD managed-by label from the Lock\n\tkubectl label\
+              \ \"$lock\" argocd.argoproj.io/instance-\ndone\n\n#Patch providers so\
+              \ that ArgoCD does not delete them during upgrade\nfor provider in $(kubectl\
+              \ get providers -o name); do\n\t#Annotate ArgoCD sync-options\n\tkubectl\
+              \ annotate \"$provider\" --overwrite argocd.argoproj.io/sync-options=Prune=false\n\
+              done\n\n#Patch configurations so that ArgoCD does not delete them during\
+              \ upgrade\nfor configuration in $(kubectl get configurations -o name);\
+              \ do\n\t#Annotate ArgoCD sync-options\n\tkubectl annotate \"$configuration\"\
+              \ --overwrite argocd.argoproj.io/sync-options=Prune=false\ndone\n"
+          command:
+            - sh
+          env:
+            - name: CRDS_TO_PATCH
+              value: compositeresourcedefinitions.apiextensions.crossplane.io providerrevisions.pkg.crossplane.io
+                configurationrevisions.pkg.crossplane.io controllerconfigs.pkg.crossplane.io
+                configurations.pkg.crossplane.io locks.pkg.crossplane.io compositions.apiextensions.crossplane.io
+                providers.pkg.crossplane.io
+            - name: HOME
+              value: /upgrade
+          image: docker.io/bitnami/kubectl:1.24.3
+          imagePullPolicy: IfNotPresent
+          name: crossplane-crd-upgrade
+          ports: []
+          stdin: false
+          tty: false
+          volumeMounts:
+            - mountPath: /upgrade
+              name: upgrade
+      imagePullSecrets: []
+      initContainers: []
+      restartPolicy: OnFailure
+      serviceAccountName: crossplane-crd-upgrade
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir: {}
+          name: upgrade

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/20_monitoring.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/20_monitoring.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: crossplane
+    name: crossplane-metrics
+  name: crossplane-metrics
+  namespace: syn-crossplane
+spec:
+  ports:
+    - name: metrics
+      port: 8080
+  selector:
+    release: crossplane
+  type: ClusterIP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: crossplane
+    name: crossplane
+  name: crossplane
+  namespace: syn-crossplane
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: syn
+      app.kubernetes.io/name: crossplane
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: crossplane
+    name: crossplane
+    prometheus: platform
+    role: alert-rules
+  name: crossplane
+  namespace: syn-crossplane
+spec:
+  groups:
+    - name: crossplane.rules
+      rules:
+        - alert: CrossplaneDown
+          annotations:
+            description: Crossplane pod {{ $labels.pod }} in namespace {{ $labels.namespace
+              }} is down
+            summary: Crossplane controller is down
+          expr: up{namespace="syn-crossplane", job=~"^crossplane-.+$"} != 1
+          for: 10m
+          labels:
+            severity: critical
+            syn: 'true'

--- a/packages/tests/golden/composite-objectstorage/crossplane/crossplane/50_cluster_roles.yaml
+++ b/packages/tests/golden/composite-objectstorage/crossplane/crossplane/50_cluster_roles.yaml
@@ -1,0 +1,60 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-browse
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: appcat:browse
+rules:
+  - apiGroups:
+      - apiextensions.crossplane.io
+    resources:
+      - compositions
+      - compositionrevisions
+      - compositeresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-composite-objectstorage-claim-edit
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: appcat:composite:objectstorage:claim-edit
+rules:
+  - apiGroups:
+      - appcat.vshn.io
+    resources:
+      - objectbuckets
+      - objectbuckets/status
+      - objectbuckets/finalizers
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-composite-objectstorage-claim-view
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: appcat:composite:objectstorage:claim-view
+rules:
+  - apiGroups:
+      - appcat.vshn.io
+    resources:
+      - objectbuckets
+      - objectbuckets/status
+      - objectbuckets/finalizers
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Crossplane has a rather complex RBAC management design (see https://github.com/crossplane/crossplane/blob/master/design/design-doc-rbac-manager.md). However, we currently don't have the need to explicitly enable claims to be provisioned in certain namespaces. Thus, we can install Crossplane with Helm parameter `rbacManager.managementPolicy=Basic`, as that won't create 3 Roles in every Namespace across the cluster.

As a consequence, we need to manually add the permissions ourselves. This PR adds 3:
- A ruleset (`browse`) to allow discovery of compositions and XRDs (only the definitions, not the actual provisioned instances).
- A ruleset for viewing claims in namespaces
- A ruleset for editing claims in namespaces

The latter 2 get aggregated to the default Kubernetes `view`, `edit` and `admin` roles, enabling all users permissions to create claims in namespaces they have access to.

Currently, these ClusterRoles are managed verbatim using `component-crossplane`, later on we might consider creating these roles automatically in jsonnet in `component-appcat` when defining XRDs, but for now it's outside of scope.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
