### PR TITLE
Don't render common patches and resources if key undefined

### DIFF
--- a/component/component/main.jsonnet
+++ b/component/component/main.jsonnet
@@ -51,14 +51,14 @@ local compositions = std.filter(function(it) it != null, [
     { metadata+: com.makeMergeable(std.get(composition, 'metadata', {})) } +
     {
       spec+: {
-        patchSets+: [
+        patchSets+: if std.objectHas(composition, 'commonPatchSets') then [
           compositionHelpers.PatchSet(name)
           for name in std.objectFields(composition.commonPatchSets)
-        ],
-        resources+: [
+        ] else [],
+        resources+: if std.objectHas(composition, 'commonResources') then [
           compositionHelpers.CommonResource(name)
           for name in std.objectFields(composition.commonResources)
-        ],
+        ] else [],
       },
     }
 

--- a/component/tests/defaults.yml
+++ b/component/tests/defaults.yml
@@ -15,7 +15,7 @@ parameters:
         kind: Namespace
 
     composites:
-      "test.appcat.vshn.io.1":
+      "test.no.default.rbac.rules":
         createDefaultRBACRoles: false
         spec:
           group: appcat.vshn.io
@@ -30,8 +30,7 @@ parameters:
               schema:
                 openAPIV3Schema:
                   type: object
-      "test.appcat.vshn.io.2":
-        createDefaultRBACRoles: true
+      "test.with.default.rbac.rules":
         spec:
           group: appcat.vshn.io
           names:
@@ -47,27 +46,14 @@ parameters:
                   type: object
 
     compositions:
-      "test-composition-1":
+      "test-common-resources":
         commonPatchSets:
           annotations: {}
           labels: {}
         commonResources:
           observeClaimNamespace: {}
         spec:
-          compositeTypeRef:
-            apiVersion: appcat.vshn.io/v1
-            kind: XTest-1
-          writeConnectionSecretsToNamespace: crossplane-system
           resources: []
-      "test-composition-2":
-        commonPatchSets:
-          annotations: {}
-          labels: {}
-        commonResources:
-          observeClaimNamespace: {}
+      "test-no-common-resources":
         spec:
-          compositeTypeRef:
-            apiVersion: appcat.vshn.io/v1
-            kind: XTest-2
-          writeConnectionSecretsToNamespace: default
           resources: []

--- a/component/tests/golden/defaults/appcat/appcat/clusterRoles.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/clusterRoles.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations: {}
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: 'true'
-  name: appcat:composite:test.appcat.vshn.io.2:claim-view
+  name: appcat:composite:test.with.default.rbac.rules:claim-view
 rules:
   - apiGroups:
       - appcat.vshn.io
@@ -24,7 +24,7 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'
-  name: appcat:composite:test.appcat.vshn.io.2:claim-edit
+  name: appcat:composite:test.with.default.rbac.rules:claim-edit
 rules:
   - apiGroups:
       - appcat.vshn.io

--- a/component/tests/golden/defaults/appcat/appcat/composites.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/composites.yaml
@@ -6,8 +6,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
   labels:
-    name: test.appcat.vshn.io.1
-  name: test.appcat.vshn.io.1
+    name: test.no.default.rbac.rules
+  name: test.no.default.rbac.rules
 spec:
   claimNames:
     kind: Test-1
@@ -23,15 +23,14 @@ spec:
           type: object
 ---
 apiVersion: apiextensions.crossplane.io/v1
-createDefaultRBACRoles: true
 kind: CompositeResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
   labels:
-    name: test.appcat.vshn.io.2
-  name: test.appcat.vshn.io.2
+    name: test.with.default.rbac.rules
+  name: test.with.default.rbac.rules
 spec:
   claimNames:
     kind: Test-2

--- a/component/tests/golden/defaults/appcat/appcat/compositions.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/compositions.yaml
@@ -5,12 +5,9 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
   labels:
-    name: test-composition-1
-  name: test-composition-1
+    name: test-common-resources
+  name: test-common-resources
 spec:
-  compositeTypeRef:
-    apiVersion: appcat.vshn.io/v1
-    kind: XTest-1
   patchSets:
     - name: annotations
       patches:
@@ -51,7 +48,6 @@ spec:
                 type: Format
               type: string
           type: FromCompositeFieldPath
-  writeConnectionSecretsToNamespace: crossplane-system
 ---
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
@@ -60,50 +56,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
   labels:
-    name: test-composition-2
-  name: test-composition-2
+    name: test-no-common-resources
+  name: test-no-common-resources
 spec:
-  compositeTypeRef:
-    apiVersion: appcat.vshn.io/v1
-    kind: XTest-2
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
-  resources:
-    - base:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
-        kind: Object
-        spec:
-          forProvider:
-            manifest:
-              apiVersion: v1
-              kind: Namespace
-              metadata:
-                name: ''
-          managementPolicy: Observe
-          providerConfigRef:
-            name: provider-config
-      patches:
-        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace
-          toFieldPath: spec.forProvider.manifest.metadata.name
-          type: FromCompositeFieldPath
-        - fromFieldPath: status.atProvider.manifest.metadata.labels[appuio.io/organization]
-          toFieldPath: metadata.labels[appuio.io/organization]
-          type: ToCompositeFieldPath
-        - fromFieldPath: metadata.labels[crossplane.io/composite]
-          toFieldPath: metadata.name
-          transforms:
-            - string:
-                fmt: '%s-ns-observer'
-                type: Format
-              type: string
-          type: FromCompositeFieldPath
-  writeConnectionSecretsToNamespace: default
+  patchSets: []
+  resources: []


### PR DESCRIPTION
Fixes cases where compilations failed when there are no `commonPatchSets` or `commonResources` defined in compositions.

(Previous workaround: 4566aa458ea3c701404dc14105737f598f0cba7f)

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
