### PR TITLE
Fix config name for provider-kubernetes

### DIFF
--- a/component/lib/appcat-compositions.libsonnet
+++ b/component/lib/appcat-compositions.libsonnet
@@ -48,7 +48,7 @@ local commonResources = {
           },
         },
         providerConfigRef: {
-          name: 'provider-config',
+          name: 'kubernetes',
         },
       },
     },

--- a/component/tests/golden/defaults/appcat/appcat/compositions.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/compositions.yaml
@@ -32,7 +32,7 @@ spec:
                 name: ''
           managementPolicy: Observe
           providerConfigRef:
-            name: provider-config
+            name: kubernetes
       patches:
         - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
           toFieldPath: spec.forProvider.manifest.metadata.name

--- a/packages/tests/golden/composition-objectstorage-cloudscale/appcat/appcat/compositions.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/appcat/appcat/compositions.yaml
@@ -142,9 +142,9 @@ spec:
                 name: ''
           managementPolicy: Observe
           providerConfigRef:
-            name: provider-config
+            name: kubernetes
       patches:
-        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace
+        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
           toFieldPath: spec.forProvider.manifest.metadata.name
           type: FromCompositeFieldPath
         - fromFieldPath: status.atProvider.manifest.metadata.labels[appuio.io/organization]

--- a/packages/tests/golden/composition-objectstorage-exoscale/appcat/appcat/compositions.yaml
+++ b/packages/tests/golden/composition-objectstorage-exoscale/appcat/appcat/compositions.yaml
@@ -135,9 +135,9 @@ spec:
                 name: ''
           managementPolicy: Observe
           providerConfigRef:
-            name: provider-config
+            name: kubernetes
       patches:
-        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace
+        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
           toFieldPath: spec.forProvider.manifest.metadata.name
           type: FromCompositeFieldPath
         - fromFieldPath: status.atProvider.manifest.metadata.labels[appuio.io/organization]


### PR DESCRIPTION
* Fixes a wrong naming on the compositions, which causes claims to not become ready.
* With the wrong name, namespaces cannot be observed to patch the appuio.io/organization label.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
