### PR TITLE
Add endpoint to Bucket status

### DIFF
--- a/packages/composite/objectstorage.yml
+++ b/packages/composite/objectstorage.yml
@@ -19,6 +19,7 @@ parameters:
             - AWS_SECRET_ACCESS_KEY
             - AWS_REGION
             - ENDPOINT
+            - ENDPOINT_URL
             - BUCKET_NAME
           defaultCompositionRef:
             name: ${pkg.appcat.composite.objectstorage:defaultCompositionRef}

--- a/packages/composition/objectstorage/cloudscale.yml
+++ b/packages/composition/objectstorage/cloudscale.yml
@@ -94,9 +94,12 @@ parameters:
                     region: ""
                     bucketDeletionPolicy: ${pkg.appcat.composition.objectstorage.cloudscale:bucketDeletionPolicy}
               connectionDetails:
-                - fromFieldPath: spec.forProvider.endpointURL
+                - fromFieldPath: status.endpoint
                   type: FromFieldPath
                   name: ENDPOINT
+                - fromFieldPath: status.endpointURL
+                  type: FromFieldPath
+                  name: ENDPOINT_URL
                 - fromFieldPath: spec.forProvider.region
                   type: FromFieldPath
                   name: AWS_REGION
@@ -120,15 +123,6 @@ parameters:
                 - type: FromCompositeFieldPath
                   fromFieldPath: metadata.labels[crossplane.io/composite]
                   toFieldPath: spec.forProvider.credentialsSecretRef.name
-                # Set endpoint
-                - type: FromCompositeFieldPath
-                  fromFieldPath: spec.parameters.region
-                  toFieldPath: spec.forProvider.endpointURL
-                  transforms:
-                    - type: string
-                      string:
-                        fmt: "objects.%s.cloudscale.ch"
-                        type: Format
                 # Set region
                 - type: FromCompositeFieldPath
                   fromFieldPath: spec.parameters.region

--- a/packages/composition/objectstorage/exoscale.yml
+++ b/packages/composition/objectstorage/exoscale.yml
@@ -87,16 +87,18 @@ parameters:
                 spec:
                   forProvider:
                     bucketName: "" # patched
-                    endpointURL: "" # patched
                     # The zone is exposed as region in XRD
                     zone: "" # patched
                     bucketDeletionPolicy: ${pkg.appcat.composition.objectstorage.exoscale:bucketDeletionPolicy}
                   providerConfigRef:
                     name: exoscale
               connectionDetails:
-                - fromFieldPath: spec.forProvider.endpointURL
+                - fromFieldPath: status.endpoint
                   type: FromFieldPath
                   name: ENDPOINT
+                - fromFieldPath: status.endpointURL
+                  type: FromFieldPath
+                  name: ENDPOINT_URL
                 - fromFieldPath: spec.forProvider.zone
                   type: FromFieldPath
                   name: AWS_REGION
@@ -117,15 +119,6 @@ parameters:
                 - type: FromCompositeFieldPath
                   fromFieldPath: spec.parameters.bucketName
                   toFieldPath: spec.forProvider.bucketName
-                # Set endpoint
-                - type: FromCompositeFieldPath
-                  fromFieldPath: spec.parameters.region
-                  toFieldPath: spec.forProvider.endpointURL
-                  transforms:
-                    - type: string
-                      string:
-                        fmt: "sos-%s.exo.io"
-                        type: Format
                 # Set region
                 - type: FromCompositeFieldPath
                   fromFieldPath: spec.parameters.region

--- a/packages/provider/cloudscale.yml
+++ b/packages/provider/cloudscale.yml
@@ -8,7 +8,7 @@ parameters:
       provider-cloudscale:
         registry: ghcr.io
         repository: vshn/provider-cloudscale/provider
-        tag: v0.3.0
+        tag: v0.5.0
 
   crossplane:
     providers:

--- a/packages/provider/exoscale.yml
+++ b/packages/provider/exoscale.yml
@@ -8,7 +8,7 @@ parameters:
       provider-exoscale:
         registry: ghcr.io
         repository: vshn/provider-exoscale/provider
-        tag: v0.1.1
+        tag: v0.2.0
 
   crossplane:
     providers:

--- a/packages/tests/golden/composite-objectstorage-cloudscale/appcat/appcat/composites.yaml
+++ b/packages/tests/golden/composite-objectstorage-cloudscale/appcat/appcat/composites.yaml
@@ -16,6 +16,7 @@ spec:
     - AWS_SECRET_ACCESS_KEY
     - AWS_REGION
     - ENDPOINT
+    - ENDPOINT_URL
     - BUCKET_NAME
   defaultCompositionRef:
     name: cloudscale.objectbuckets.appcat.vshn.io

--- a/packages/tests/golden/composite-objectstorage-exoscale/appcat/appcat/composites.yaml
+++ b/packages/tests/golden/composite-objectstorage-exoscale/appcat/appcat/composites.yaml
@@ -16,6 +16,7 @@ spec:
     - AWS_SECRET_ACCESS_KEY
     - AWS_REGION
     - ENDPOINT
+    - ENDPOINT_URL
     - BUCKET_NAME
   defaultCompositionRef:
     name: exoscale.objectbuckets.appcat.vshn.io

--- a/packages/tests/golden/composition-objectstorage-cloudscale/appcat/appcat/compositions.yaml
+++ b/packages/tests/golden/composition-objectstorage-cloudscale/appcat/appcat/compositions.yaml
@@ -88,8 +88,11 @@ spec:
             endpointURL: ''
             region: ''
       connectionDetails:
-        - fromFieldPath: spec.forProvider.endpointURL
+        - fromFieldPath: status.endpoint
           name: ENDPOINT
+          type: FromFieldPath
+        - fromFieldPath: status.endpointURL
+          name: ENDPOINT_URL
           type: FromFieldPath
         - fromFieldPath: spec.forProvider.region
           name: AWS_REGION
@@ -113,14 +116,6 @@ spec:
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: spec.forProvider.credentialsSecretRef.name
-          type: FromCompositeFieldPath
-        - fromFieldPath: spec.parameters.region
-          toFieldPath: spec.forProvider.endpointURL
-          transforms:
-            - string:
-                fmt: objects.%s.cloudscale.ch
-                type: Format
-              type: string
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.region

--- a/packages/tests/golden/composition-objectstorage-exoscale/appcat/appcat/compositions.yaml
+++ b/packages/tests/golden/composition-objectstorage-exoscale/appcat/appcat/compositions.yaml
@@ -84,13 +84,15 @@ spec:
           forProvider:
             bucketDeletionPolicy: DeleteAll
             bucketName: ''
-            endpointURL: ''
             zone: ''
           providerConfigRef:
             name: exoscale
       connectionDetails:
-        - fromFieldPath: spec.forProvider.endpointURL
+        - fromFieldPath: status.endpoint
           name: ENDPOINT
+          type: FromFieldPath
+        - fromFieldPath: status.endpointURL
+          name: ENDPOINT_URL
           type: FromFieldPath
         - fromFieldPath: spec.forProvider.zone
           name: AWS_REGION
@@ -111,14 +113,6 @@ spec:
           type: ToCompositeFieldPath
         - fromFieldPath: spec.parameters.bucketName
           toFieldPath: spec.forProvider.bucketName
-          type: FromCompositeFieldPath
-        - fromFieldPath: spec.parameters.region
-          toFieldPath: spec.forProvider.endpointURL
-          transforms:
-            - string:
-                fmt: sos-%s.exo.io
-                type: Format
-              type: string
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.zone

--- a/packages/tests/golden/provider-cloudscale/crossplane/crossplane/10_providers.yaml
+++ b/packages/tests/golden/provider-cloudscale/crossplane/crossplane/10_providers.yaml
@@ -8,4 +8,4 @@ metadata:
     name: cloudscale
   name: cloudscale
 spec:
-  package: ghcr.io/vshn/provider-cloudscale/provider:v0.3.0
+  package: ghcr.io/vshn/provider-cloudscale/provider:v0.5.0

--- a/packages/tests/golden/provider-exoscale/crossplane/crossplane/10_providers.yaml
+++ b/packages/tests/golden/provider-exoscale/crossplane/crossplane/10_providers.yaml
@@ -8,4 +8,4 @@ metadata:
     name: exoscale
   name: exoscale
 spec:
-  package: ghcr.io/vshn/provider-exoscale/provider:v0.1.1
+  package: ghcr.io/vshn/provider-exoscale/provider:v0.2.0

--- a/tests/kuttl/cloudscale-status-test/00-install-cloudscale-composite.yaml
+++ b/tests/kuttl/cloudscale-status-test/00-install-cloudscale-composite.yaml
@@ -16,6 +16,7 @@ spec:
     - AWS_SECRET_ACCESS_KEY
     - AWS_REGION
     - ENDPOINT
+    - ENDPOINT_URL
     - BUCKET_NAME
   defaultCompositionRef:
     name: cloudscale.objectbuckets.appcat.vshn.io

--- a/tests/kuttl/cloudscale-status-test/00-install-cloudscale-composition.yaml
+++ b/tests/kuttl/cloudscale-status-test/00-install-cloudscale-composition.yaml
@@ -88,8 +88,11 @@ spec:
             endpointURL: ''
             region: ''
       connectionDetails:
-        - fromFieldPath: spec.forProvider.endpointURL
+        - fromFieldPath: status.endpoint
           name: ENDPOINT
+          type: FromFieldPath
+        - fromFieldPath: status.endpointURL
+          name: ENDPOINT_URL
           type: FromFieldPath
         - fromFieldPath: spec.forProvider.region
           name: AWS_REGION
@@ -113,14 +116,6 @@ spec:
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: spec.forProvider.credentialsSecretRef.name
-          type: FromCompositeFieldPath
-        - fromFieldPath: spec.parameters.region
-          toFieldPath: spec.forProvider.endpointURL
-          transforms:
-            - string:
-                fmt: objects.%s.cloudscale.ch
-                type: Format
-              type: string
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.region

--- a/tests/kuttl/cloudscale-status-test/01-assert-managed-resources.yaml
+++ b/tests/kuttl/cloudscale-status-test/01-assert-managed-resources.yaml
@@ -13,7 +13,6 @@ spec:
     bucketName: my-bucket-change-name
     credentialsSecretRef:
       namespace: syn-provider-cloudscale-secrets
-    endpointURL: objects.rma.cloudscale.ch
     region: rma
   providerConfigRef:
     name: default

--- a/tests/kuttl/exoscale-status-test/00-install-exoscale-composite.yaml
+++ b/tests/kuttl/exoscale-status-test/00-install-exoscale-composite.yaml
@@ -16,6 +16,7 @@ spec:
     - AWS_SECRET_ACCESS_KEY
     - AWS_REGION
     - ENDPOINT
+    - ENDPOINT_URL
     - BUCKET_NAME
   defaultCompositionRef:
     name: exoscale.objectbuckets.appcat.vshn.io

--- a/tests/kuttl/exoscale-status-test/00-install-exoscale-composition.yaml
+++ b/tests/kuttl/exoscale-status-test/00-install-exoscale-composition.yaml
@@ -84,13 +84,15 @@ spec:
           forProvider:
             bucketDeletionPolicy: DeleteAll
             bucketName: ''
-            endpointURL: ''
             zone: ''
           providerConfigRef:
             name: exoscale
       connectionDetails:
-        - fromFieldPath: spec.forProvider.endpointURL
+        - fromFieldPath: status.endpoint
           name: ENDPOINT
+          type: FromFieldPath
+        - fromFieldPath: status.endpointURL
+          name: ENDPOINT_URL
           type: FromFieldPath
         - fromFieldPath: spec.forProvider.zone
           name: AWS_REGION
@@ -111,14 +113,6 @@ spec:
           type: ToCompositeFieldPath
         - fromFieldPath: spec.parameters.bucketName
           toFieldPath: spec.forProvider.bucketName
-          type: FromCompositeFieldPath
-        - fromFieldPath: spec.parameters.region
-          toFieldPath: spec.forProvider.endpointURL
-          transforms:
-            - string:
-                fmt: sos-%s.exo.io
-                type: Format
-              type: string
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.zone

--- a/tests/kuttl/exoscale-status-test/01-assert-managed-resources.yaml
+++ b/tests/kuttl/exoscale-status-test/01-assert-managed-resources.yaml
@@ -31,7 +31,6 @@ spec:
   forProvider:
     bucketDeletionPolicy: DeleteAll
     bucketName: my-bucket-change-name
-    endpointURL: sos-rma.exo.io
     zone: rma
   providerConfigRef:
     name: exoscale


### PR DESCRIPTION
Add new "endpoint" parameter which contains the host name of the endpoint. Repurpose the current "endpointURL" parameter to contain the endpoint URL including the scheme. This works in conjunction with https://github.com/vshn/provider-cloudscale/pull/51 and https://github.com/vshn/provider-exoscale/pull/42