### PR TITLE
remove ca.crt from Exoscale DBaaS redis

### DIFF
--- a/packages/composite/dbaas/exoscale/redis.yml
+++ b/packages/composite/dbaas/exoscale/redis.yml
@@ -18,7 +18,6 @@ parameters:
             - REDIS_USERNAME
             - REDIS_PASSWORD
             - REDIS_URL
-            - ca.crt
           defaultCompositionRef:
             name: exoscale.redis.appcat.vshn.io
           versions:

--- a/packages/composition/dbaas/exoscale/redis.yml
+++ b/packages/composition/dbaas/exoscale/redis.yml
@@ -57,9 +57,6 @@ parameters:
                 - fromConnectionSecretKey: REDIS_URL
                   type: FromConnectionSecretKey
                   name: REDIS_URL
-                - fromConnectionSecretKey: ca.crt
-                  type: FromConnectionSecretKey
-                  name: ca.crt
               patches:
                 - type: PatchSet
                   patchSetName: annotations

--- a/packages/tests/golden/composite-dbaas-redis-exoscale/appcat/appcat/composites.yaml
+++ b/packages/tests/golden/composite-dbaas-redis-exoscale/appcat/appcat/composites.yaml
@@ -17,7 +17,6 @@ spec:
     - REDIS_USERNAME
     - REDIS_PASSWORD
     - REDIS_URL
-    - ca.crt
   defaultCompositionRef:
     name: exoscale.redis.appcat.vshn.io
   group: appcat.vshn.io

--- a/packages/tests/golden/composition-dbaas-redis-exoscale/appcat/appcat/compositions.yaml
+++ b/packages/tests/golden/composition-dbaas-redis-exoscale/appcat/appcat/compositions.yaml
@@ -59,9 +59,6 @@ spec:
         - fromConnectionSecretKey: REDIS_URL
           name: REDIS_URL
           type: FromConnectionSecretKey
-        - fromConnectionSecretKey: ca.crt
-          name: ca.crt
-          type: FromConnectionSecretKey
       patches:
         - patchSetName: annotations
           type: PatchSet


### PR DESCRIPTION
ca.crt has no effect for redis since the certificate used to connect is a Let's Encrypt one and not a project based certificate. 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
