### PR TITLE
Fix nested defaulting for XRDs

### DIFF
--- a/apis/v1/dbaas_exoscale.go
+++ b/apis/v1/dbaas_exoscale.go
@@ -25,7 +25,7 @@ type ExoscaleDBaaSMaintenanceScheduleSpec struct {
 }
 
 type ExoscaleDBaaSSizeSpec struct {
-	// +kubebuilder:default="standard-4"
+	// +kubebuilder:default="startup-4"
 
 	// Plan is the name of the resource plan that defines the compute resources.
 	Plan string `json:"plan,omitempty"`

--- a/apis/v1/dbaas_exoscale_mysql.go
+++ b/apis/v1/dbaas_exoscale_mysql.go
@@ -10,6 +10,14 @@ import (
 //go:generate yq -i e ../generated/appcat.vshn.io_exoscalemysqls.yaml --expression "with(.spec.versions[].schema.openAPIV3Schema.properties; del(.metadata), del(.kind), del(.apiVersion))"
 //go:generate yq -i e ../generated/appcat.vshn.io_exoscalemysqls.yaml --expression "with(.spec.versions[]; .referenceable=true, del(.storage), del(.subresources))"
 
+// Workaround to make nested defaulting work.
+// kubebuilder is unable to set a {} default
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscalemysqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscalemysqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.maintenance.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscalemysqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscalemysqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.size.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscalemysqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.network.default={})"
+
 // Patch the XRD with this generated CRD scheme
 //go:generate yq -i e ../../packages/composite/dbaas/exoscale/mysql.yml --expression ".parameters.appcat.composites.\"xexoscalemysqls.appcat.vshn.io\".spec.versions=load(\"../generated/appcat.vshn.io_exoscalemysqls.yaml\").spec.versions"
 

--- a/apis/v1/dbaas_exoscale_postgresql.go
+++ b/apis/v1/dbaas_exoscale_postgresql.go
@@ -10,6 +10,14 @@ import (
 //go:generate yq -i e ../generated/appcat.vshn.io_exoscalepostgresqls.yaml --expression "with(.spec.versions[].schema.openAPIV3Schema.properties; del(.metadata), del(.kind), del(.apiVersion))"
 //go:generate yq -i e ../generated/appcat.vshn.io_exoscalepostgresqls.yaml --expression "with(.spec.versions[]; .referenceable=true, del(.storage), del(.subresources))"
 
+// Workaround to make nested defaulting work.
+// kubebuilder is unable to set a {} default
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscalepostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscalepostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.maintenance.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscalepostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscalepostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.size.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscalepostgresqls.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.network.default={})"
+
 // Patch the XRD with this generated CRD scheme
 //go:generate yq -i e ../../packages/composite/dbaas/exoscale/postgres.yml --expression ".parameters.appcat.composites.\"xexoscalepostgresqls.appcat.vshn.io\".spec.versions=load(\"../generated/appcat.vshn.io_exoscalepostgresqls.yaml\").spec.versions"
 

--- a/apis/v1/dbaas_exoscale_redis.go
+++ b/apis/v1/dbaas_exoscale_redis.go
@@ -10,6 +10,14 @@ import (
 //go:generate yq -i e ../generated/appcat.vshn.io_exoscaleredis.yaml --expression "with(.spec.versions[].schema.openAPIV3Schema.properties; del(.metadata), del(.kind), del(.apiVersion))"
 //go:generate yq -i e ../generated/appcat.vshn.io_exoscaleredis.yaml --expression "with(.spec.versions[]; .referenceable=true, del(.storage), del(.subresources))"
 
+// Workaround to make nested defaulting work.
+// kubebuilder is unable to set a {} default
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscaleredis.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscaleredis.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.maintenance.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscaleredis.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.service.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscaleredis.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.size.default={})"
+//go:generate yq -i e ../generated/appcat.vshn.io_exoscaleredis.yaml --expression "with(.spec.versions[]; .schema.openAPIV3Schema.properties.spec.properties.parameters.properties.network.default={})"
+
 // Patch the XRD with this generated CRD scheme
 //go:generate yq -i e ../../packages/composite/dbaas/exoscale/redis.yml --expression ".parameters.appcat.composites.\"xexoscaleredis.appcat.vshn.io\".spec.versions=load(\"../generated/appcat.vshn.io_exoscaleredis.yaml\").spec.versions"
 

--- a/packages/composite/dbaas/exoscale/mysql.yml
+++ b/packages/composite/dbaas/exoscale/mysql.yml
@@ -114,7 +114,7 @@ parameters:
                               description: Size contains settings to control the sizing of a service.
                               properties:
                                 plan:
-                                  default: standard-4
+                                  default: startup-4
                                   description: Plan is the name of the resource plan that defines the compute resources.
                                   type: string
                               type: object

--- a/packages/composite/dbaas/exoscale/mysql.yml
+++ b/packages/composite/dbaas/exoscale/mysql.yml
@@ -72,6 +72,7 @@ parameters:
                                   pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                                   type: string
                               type: object
+                              default: {}
                             network:
                               description: Network contains any network related settings.
                               properties:
@@ -83,6 +84,7 @@ parameters:
                                     type: string
                                   type: array
                               type: object
+                              default: {}
                             service:
                               description: Service contains Exoscale MySQL DBaaS specific properties
                               properties:
@@ -107,6 +109,7 @@ parameters:
                                     - bg-sof-1
                                   type: string
                               type: object
+                              default: {}
                             size:
                               description: Size contains settings to control the sizing of a service.
                               properties:
@@ -115,7 +118,9 @@ parameters:
                                   description: Plan is the name of the resource plan that defines the compute resources.
                                   type: string
                               type: object
+                              default: {}
                           type: object
+                          default: {}
                       type: object
                     status:
                       description: Status reflects the observed state of a ExoscaleMySQL.

--- a/packages/composite/dbaas/exoscale/postgres.yml
+++ b/packages/composite/dbaas/exoscale/postgres.yml
@@ -114,7 +114,7 @@ parameters:
                               description: Size contains settings to control the sizing of a service.
                               properties:
                                 plan:
-                                  default: standard-4
+                                  default: startup-4
                                   description: Plan is the name of the resource plan that defines the compute resources.
                                   type: string
                               type: object

--- a/packages/composite/dbaas/exoscale/postgres.yml
+++ b/packages/composite/dbaas/exoscale/postgres.yml
@@ -72,6 +72,7 @@ parameters:
                                   pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                                   type: string
                               type: object
+                              default: {}
                             network:
                               description: Network contains any network related settings.
                               properties:
@@ -83,6 +84,7 @@ parameters:
                                     type: string
                                   type: array
                               type: object
+                              default: {}
                             service:
                               description: Service contains Exoscale PostgreSQL DBaaS specific properties
                               properties:
@@ -107,6 +109,7 @@ parameters:
                                     - bg-sof-1
                                   type: string
                               type: object
+                              default: {}
                             size:
                               description: Size contains settings to control the sizing of a service.
                               properties:
@@ -115,7 +118,9 @@ parameters:
                                   description: Plan is the name of the resource plan that defines the compute resources.
                                   type: string
                               type: object
+                              default: {}
                           type: object
+                          default: {}
                       type: object
                     status:
                       description: Status reflects the observed state of a ExoscalePostgreSQL.

--- a/packages/composite/dbaas/exoscale/redis.yml
+++ b/packages/composite/dbaas/exoscale/redis.yml
@@ -61,6 +61,7 @@ parameters:
                                   pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                                   type: string
                               type: object
+                              default: {}
                             network:
                               description: Network contains any network related settings.
                               properties:
@@ -72,6 +73,7 @@ parameters:
                                     type: string
                                   type: array
                               type: object
+                              default: {}
                             service:
                               description: Service contains Exoscale Redis DBaaS specific properties
                               properties:
@@ -91,6 +93,7 @@ parameters:
                                     - bg-sof-1
                                   type: string
                               type: object
+                              default: {}
                             size:
                               description: Size contains settings to control the sizing of a service.
                               properties:
@@ -99,7 +102,9 @@ parameters:
                                   description: Plan is the name of the resource plan that defines the compute resources.
                                   type: string
                               type: object
+                              default: {}
                           type: object
+                          default: {}
                       type: object
                     status:
                       description: Status reflects the observed state of a ExoscaleRedis.

--- a/packages/composite/dbaas/exoscale/redis.yml
+++ b/packages/composite/dbaas/exoscale/redis.yml
@@ -98,7 +98,7 @@ parameters:
                               description: Size contains settings to control the sizing of a service.
                               properties:
                                 plan:
-                                  default: standard-4
+                                  default: startup-4
                                   description: Plan is the name of the resource plan that defines the compute resources.
                                   type: string
                               type: object

--- a/packages/tests/golden/composite-dbaas-mysql-exoscale/appcat/appcat/composites.yaml
+++ b/packages/tests/golden/composite-dbaas-mysql-exoscale/appcat/appcat/composites.yaml
@@ -43,6 +43,7 @@ spec:
               description: Spec defines the desired state of a ExoscaleMySQL.
               properties:
                 parameters:
+                  default: {}
                   description: Parameters are the configurable fields of a ExoscaleMySQL.
                   properties:
                     backup:
@@ -57,6 +58,7 @@ spec:
                           type: string
                       type: object
                     maintenance:
+                      default: {}
                       description: Maintenance contains settings to control the maintenance
                         of an instance.
                       properties:
@@ -83,6 +85,7 @@ spec:
                           type: string
                       type: object
                     network:
+                      default: {}
                       description: Network contains any network related settings.
                       properties:
                         ipFilter:
@@ -97,6 +100,7 @@ spec:
                           type: array
                       type: object
                     service:
+                      default: {}
                       description: Service contains Exoscale MySQL DBaaS specific
                         properties
                       properties:
@@ -125,6 +129,7 @@ spec:
                           type: string
                       type: object
                     size:
+                      default: {}
                       description: Size contains settings to control the sizing of
                         a service.
                       properties:

--- a/packages/tests/golden/composite-dbaas-mysql-exoscale/appcat/appcat/composites.yaml
+++ b/packages/tests/golden/composite-dbaas-mysql-exoscale/appcat/appcat/composites.yaml
@@ -134,7 +134,7 @@ spec:
                         a service.
                       properties:
                         plan:
-                          default: standard-4
+                          default: startup-4
                           description: Plan is the name of the resource plan that
                             defines the compute resources.
                           type: string

--- a/packages/tests/golden/composite-dbaas-postgres-exoscale/appcat/appcat/composites.yaml
+++ b/packages/tests/golden/composite-dbaas-postgres-exoscale/appcat/appcat/composites.yaml
@@ -43,6 +43,7 @@ spec:
               description: Spec defines the desired state of a ExoscalePostgreSQL.
               properties:
                 parameters:
+                  default: {}
                   description: Parameters are the configurable fields of a ExoscalePostgreSQL.
                   properties:
                     backup:
@@ -57,6 +58,7 @@ spec:
                           type: string
                       type: object
                     maintenance:
+                      default: {}
                       description: Maintenance contains settings to control the maintenance
                         of an instance.
                       properties:
@@ -83,6 +85,7 @@ spec:
                           type: string
                       type: object
                     network:
+                      default: {}
                       description: Network contains any network related settings.
                       properties:
                         ipFilter:
@@ -97,6 +100,7 @@ spec:
                           type: array
                       type: object
                     service:
+                      default: {}
                       description: Service contains Exoscale PostgreSQL DBaaS specific
                         properties
                       properties:
@@ -125,6 +129,7 @@ spec:
                           type: string
                       type: object
                     size:
+                      default: {}
                       description: Size contains settings to control the sizing of
                         a service.
                       properties:

--- a/packages/tests/golden/composite-dbaas-postgres-exoscale/appcat/appcat/composites.yaml
+++ b/packages/tests/golden/composite-dbaas-postgres-exoscale/appcat/appcat/composites.yaml
@@ -134,7 +134,7 @@ spec:
                         a service.
                       properties:
                         plan:
-                          default: standard-4
+                          default: startup-4
                           description: Plan is the name of the resource plan that
                             defines the compute resources.
                           type: string

--- a/packages/tests/golden/composite-dbaas-redis-exoscale/appcat/appcat/composites.yaml
+++ b/packages/tests/golden/composite-dbaas-redis-exoscale/appcat/appcat/composites.yaml
@@ -41,9 +41,11 @@ spec:
               description: Spec defines the desired state of a ExoscaleRedis.
               properties:
                 parameters:
+                  default: {}
                   description: Parameters are the configurable fields of a ExoscaleRedis.
                   properties:
                     maintenance:
+                      default: {}
                       description: Maintenance contains settings to control the maintenance
                         of an instance.
                       properties:
@@ -70,6 +72,7 @@ spec:
                           type: string
                       type: object
                     network:
+                      default: {}
                       description: Network contains any network related settings.
                       properties:
                         ipFilter:
@@ -84,6 +87,7 @@ spec:
                           type: array
                       type: object
                     service:
+                      default: {}
                       description: Service contains Exoscale Redis DBaaS specific
                         properties
                       properties:
@@ -105,6 +109,7 @@ spec:
                           type: string
                       type: object
                     size:
+                      default: {}
                       description: Size contains settings to control the sizing of
                         a service.
                       properties:

--- a/packages/tests/golden/composite-dbaas-redis-exoscale/appcat/appcat/composites.yaml
+++ b/packages/tests/golden/composite-dbaas-redis-exoscale/appcat/appcat/composites.yaml
@@ -114,7 +114,7 @@ spec:
                         a service.
                       properties:
                         plan:
-                          default: standard-4
+                          default: startup-4
                           description: Plan is the name of the resource plan that
                             defines the compute resources.
                           type: string


### PR DESCRIPTION
Kubebuilder cannot set empty objects as a default for CRDs. We might be able to fix this upstream, but I'll do this temporary hack to fix this here.

This could be done with less duplication, but as we want to move away from packages anyway, we should soon be able to do this in a cleaner way in Jsonnet.
So, I don't think investing more time to make this prettier is helpful at this point.


Conflicts with #57 and #56. Whoever merges later will need to rebase and fix this.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
