### PR TITLE
Allow provider kubernetes to delete created resources

### DIFF
--- a/component/provider.jsonnet
+++ b/component/provider.jsonnet
@@ -122,7 +122,7 @@ local controllerConfigRef(config) =
         {
           apiGroups: [ 'kubernetes.crossplane.io' ],
           resources: [ '*' ],
-          verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create' ],
+          verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
         },
         {
           apiGroups: [ '', 'coordination.k8s.io' ],
@@ -132,17 +132,17 @@ local controllerConfigRef(config) =
         {
           apiGroups: [ '' ],
           resources: [ 'namespaces' ],
-          verbs: [ 'get', 'list', 'watch', 'create', 'watch', 'update' ],
+          verbs: [ 'get', 'list', 'watch', 'create', 'watch', 'update', 'delete' ],
         },
         {
           apiGroups: [ 'stackgres.io' ],
           resources: [ 'sginstanceprofiles', 'sgclusters', 'sgpgconfigs' ],
-          verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create' ],
+          verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
         },
         {
           apiGroups: [ 'networking.k8s.io' ],
           resources: [ 'networkpolicies' ],
-          verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create' ],
+          verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
         },
       ],
     };

--- a/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -65,6 +65,7 @@ rules:
       - update
       - patch
       - create
+      - delete
   - apiGroups:
       - ''
       - coordination.k8s.io
@@ -86,6 +87,7 @@ rules:
       - create
       - watch
       - update
+      - delete
   - apiGroups:
       - stackgres.io
     resources:
@@ -99,6 +101,7 @@ rules:
       - update
       - patch
       - create
+      - delete
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -110,6 +113,7 @@ rules:
       - update
       - patch
       - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -65,6 +65,7 @@ rules:
       - update
       - patch
       - create
+      - delete
   - apiGroups:
       - ''
       - coordination.k8s.io
@@ -86,6 +87,7 @@ rules:
       - create
       - watch
       - update
+      - delete
   - apiGroups:
       - stackgres.io
     resources:
@@ -99,6 +101,7 @@ rules:
       - update
       - patch
       - create
+      - delete
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -110,6 +113,7 @@ rules:
       - update
       - patch
       - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
@@ -67,6 +67,7 @@ rules:
       - update
       - patch
       - create
+      - delete
   - apiGroups:
       - ''
       - coordination.k8s.io
@@ -88,6 +89,7 @@ rules:
       - create
       - watch
       - update
+      - delete
   - apiGroups:
       - stackgres.io
     resources:
@@ -101,6 +103,7 @@ rules:
       - update
       - patch
       - create
+      - delete
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -112,6 +115,7 @@ rules:
       - update
       - patch
       - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
@@ -65,6 +65,7 @@ rules:
       - update
       - patch
       - create
+      - delete
   - apiGroups:
       - ''
       - coordination.k8s.io
@@ -86,6 +87,7 @@ rules:
       - create
       - watch
       - update
+      - delete
   - apiGroups:
       - stackgres.io
     resources:
@@ -99,6 +101,7 @@ rules:
       - update
       - patch
       - create
+      - delete
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -110,6 +113,7 @@ rules:
       - update
       - patch
       - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Currently the provider kubernetes can create multiple resources, but can't delete them. This causes the deployed VSHN postgres instance to stay around, even if the claim is deleted.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
