### PR TITLE
Don't pass the annotations and labels to the managed resources

### DIFF
--- a/component/exoscale_kafka.jsonnet
+++ b/component/exoscale_kafka.jsonnet
@@ -67,17 +67,11 @@ local composition =
     spec: {
       compositeTypeRef: comp.CompositeRef(xrd),
       writeConnectionSecretsToNamespace: kafkaParams.secretNamespace,
-      patchSets: [
-        comp.PatchSet('annotations'),
-        comp.PatchSet('labels'),
-      ],
       resources: [
         {
           base: kafkaBase,
           connectionDetails: comp.conn.AllFromSecretKeys(connectionSecretKeys),
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.writeConnectionSecretToRef.name'),
 

--- a/component/exoscale_mysql.jsonnet
+++ b/component/exoscale_mysql.jsonnet
@@ -71,17 +71,11 @@ local composition =
     spec: {
       compositeTypeRef: comp.CompositeRef(xrd),
       writeConnectionSecretsToNamespace: mysqlParams.secretNamespace,
-      patchSets: [
-        comp.PatchSet('annotations'),
-        comp.PatchSet('labels'),
-      ],
       resources: [
         {
           base: mysqlBase,
           connectionDetails: comp.conn.AllFromSecretKeys(connectionSecretKeys),
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.writeConnectionSecretToRef.name'),
 

--- a/component/exoscale_opensearch.jsonnet
+++ b/component/exoscale_opensearch.jsonnet
@@ -70,17 +70,11 @@ local composition =
     spec: {
       compositeTypeRef: comp.CompositeRef(xrd),
       writeConnectionSecretsToNamespace: osParams.secretNamespace,
-      patchSets: [
-        comp.PatchSet('annotations'),
-        comp.PatchSet('labels'),
-      ],
       resources: [
         {
           base: osBase,
           connectionDetails: comp.conn.AllFromSecretKeys(connectionSecretKeys),
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.writeConnectionSecretToRef.name'),
 

--- a/component/exoscale_postgres.jsonnet
+++ b/component/exoscale_postgres.jsonnet
@@ -71,17 +71,11 @@ local composition =
     spec: {
       compositeTypeRef: comp.CompositeRef(xrd),
       writeConnectionSecretsToNamespace: pgParams.secretNamespace,
-      patchSets: [
-        comp.PatchSet('annotations'),
-        comp.PatchSet('labels'),
-      ],
       resources: [
         {
           base: pgBase,
           connectionDetails: comp.conn.AllFromSecretKeys(connectionSecretKeys),
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.writeConnectionSecretToRef.name'),
 

--- a/component/exoscale_redis.jsonnet
+++ b/component/exoscale_redis.jsonnet
@@ -65,17 +65,11 @@ local composition =
     spec: {
       compositeTypeRef: comp.CompositeRef(xrd),
       writeConnectionSecretsToNamespace: redisParams.secretNamespace,
-      patchSets: [
-        comp.PatchSet('annotations'),
-        comp.PatchSet('labels'),
-      ],
       resources: [
         {
           base: redisBase,
           connectionDetails: comp.conn.AllFromSecretKeys(connectionSecretKeys),
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.writeConnectionSecretToRef.name'),
 

--- a/component/objectstorage.jsonnet
+++ b/component/objectstorage.jsonnet
@@ -76,10 +76,6 @@ local compositionCloudscale =
     spec: {
       compositeTypeRef: comp.CompositeRef(xrd),
       writeConnectionSecretsToNamespace: compParams.secretNamespace,
-      patchSets: [
-        comp.PatchSet('annotations'),
-        comp.PatchSet('labels'),
-      ],
       resources: [
         {
           base: baseUser,
@@ -88,8 +84,6 @@ local compositionCloudscale =
             comp.conn.FromSecretKey('AWS_SECRET_ACCESS_KEY'),
           ],
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
             comp.ToCompositeFieldPath('status.conditions', 'status.accessUserConditions'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.writeConnectionSecretToRef.name'),
@@ -122,8 +116,6 @@ local compositionCloudscale =
             comp.conn.FromFieldPath('BUCKET_NAME', 'status.atProvider.bucketName'),
           ],
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
             comp.ToCompositeFieldPath('status.conditions', 'status.bucketConditions'),
             comp.FromCompositeFieldPath('spec.parameters.bucketName', 'spec.forProvider.bucketName'),
@@ -197,10 +189,6 @@ local compositionExoscale =
     spec: {
       compositeTypeRef: comp.CompositeRef(xrd),
       writeConnectionSecretsToNamespace: compParams.secretNamespace,
-      patchSets: [
-        comp.PatchSet('annotations'),
-        comp.PatchSet('labels'),
-      ],
       resources: [
         {
           base: IAMKeyBase,
@@ -209,8 +197,6 @@ local compositionExoscale =
             comp.conn.FromSecretKey('AWS_SECRET_ACCESS_KEY'),
           ],
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
             comp.ToCompositeFieldPath('status.conditions', 'status.accessUserConditions'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.writeConnectionSecretToRef.name'),
@@ -245,8 +231,6 @@ local compositionExoscale =
             comp.conn.FromFieldPath('BUCKET_NAME', 'status.atProvider.bucketName'),
           ],
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
             comp.ToCompositeFieldPath('status.conditions', 'status.bucketConditions'),
             comp.FromCompositeFieldPath('spec.parameters.bucketName', 'spec.forProvider.bucketName'),

--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -265,10 +265,6 @@ local composition =
     spec: {
       compositeTypeRef: comp.CompositeRef(xrd),
       writeConnectionSecretsToNamespace: pgParams.secretNamespace,
-      patchSets: [
-        comp.PatchSet('annotations'),
-        comp.PatchSet('labels'),
-      ],
       resources: [
         {
           base: namespace {
@@ -285,8 +281,6 @@ local composition =
         {
           base: namespace,
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.ToCompositeFieldPath('status.conditions', 'status.namespaceDebug'),
             comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'vshn-postgresql'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/claim-namespace]', 'spec.forProvider.manifest.metadata.labels[%s]' % serviceNamespaceLabelKey),
@@ -296,8 +290,6 @@ local composition =
         {
           base: sgInstanceProfile,
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.ToCompositeFieldPath('status.conditions', 'status.profileDebug'),
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'profile'),
             comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
@@ -310,8 +302,6 @@ local composition =
         {
           base: sgPostgresConfig,
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.ToCompositeFieldPath('status.conditions', 'status.pgconfigDebug'),
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'pgconf'),
             comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
@@ -324,8 +314,6 @@ local composition =
         {
           base: sgCluster,
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.ToCompositeFieldPath('status.conditions', 'status.pgclusterDebug'),
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'cluster'),
             comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
@@ -346,8 +334,6 @@ local composition =
           base: secret,
           connectionDetails: comp.conn.AllFromSecretKeys(connectionSecretKeys),
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.ToCompositeFieldPath('status.conditions', 'status.secretDebug'),
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'connection'),
             comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
@@ -364,8 +350,6 @@ local composition =
         {
           base: xobjectBucket,
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.ToCompositeFieldPath('status.conditions', 'status.s3BucketDebug'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.parameters.bucketName'),
@@ -378,8 +362,6 @@ local composition =
         {
           base: sgObjectStorage,
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.ToCompositeFieldPath('status.conditions', 'status.s3BackupConfigDebug'),
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'object-storage'),
             comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'sgbackup'),
@@ -396,8 +378,6 @@ local composition =
         {
           base: networkPolicy,
           patches: [
-            comp.PatchSetRef('annotations'),
-            comp.PatchSetRef('labels'),
             comp.ToCompositeFieldPath('status.conditions', 'status.networkPolicyDebug'),
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'network-policy'),
             comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),

--- a/lib/appcat-compositions.libsonnet
+++ b/lib/appcat-compositions.libsonnet
@@ -73,16 +73,7 @@ local toCompositeFieldPath(from, to) = {
 };
 
 local availablePatchSets = {
-  annotations: {
-    patches: [
-      fromCompositeFieldPath('metadata.annotations', 'metadata.annotations'),
-    ],
-  },
-  labels: {
-    patches: [
-      fromCompositeFieldPath('metadata.labels', 'metadata.labels'),
-    ],
-  },
+
 };
 
 local patchSetRef(name) = {

--- a/lib/appcat-compositions.libsonnet
+++ b/lib/appcat-compositions.libsonnet
@@ -72,15 +72,6 @@ local toCompositeFieldPath(from, to) = {
   toFieldPath: to,
 };
 
-local availablePatchSets = {
-
-};
-
-local patchSetRef(name) = {
-  type: 'PatchSet',
-  patchSetName: name,
-};
-
 local commonResources = {
   observeClaimNamespace: {
     // This resource "observes" the namespace of the Claim.
@@ -157,9 +148,6 @@ local kubeObject(apiVersion, kind) = {
 };
 
 {
-  PatchSet(name):
-    assert std.objectHas(availablePatchSets, name) : "common patch set '%s' doesn't exist" % name;
-    availablePatchSets[name] { name: name },
   CommonResource(name):
     assert std.objectHas(commonResources, name) : "common resources set '%s' doesn't exist" % name;
     commonResources[name],
@@ -175,8 +163,6 @@ local kubeObject(apiVersion, kind) = {
     fromCompositeFieldPathWithTransform(from, to, prefix, suffix),
   ToCompositeFieldPath(from, to):
     toCompositeFieldPath(from, to),
-  PatchSetRef(name):
-    patchSetRef(name),
   CompositeRef(xrd, version=''):
     compositeRef(xrd, version=version),
   KubeObject(apiVersion, kind):

--- a/tests/golden/cloudscale/appcat/appcat/21_composition_objectstorage_cloudscale.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/21_composition_objectstorage_cloudscale.yaml
@@ -18,17 +18,6 @@ spec:
   compositeTypeRef:
     apiVersion: appcat.vshn.io/v1
     kind: XObjectBucket
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: cloudscale.crossplane.io/v1
@@ -53,10 +42,6 @@ spec:
           name: AWS_SECRET_ACCESS_KEY
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath
@@ -102,10 +87,6 @@ spec:
           name: BUCKET_NAME
           type: FromFieldPath
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_kafka.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_kafka.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: exoscale.appcat.vshn.io/v1
     kind: XExoscaleKafka
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -75,10 +64,6 @@ spec:
           name: ca.crt
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_mysql.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_mysql.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: exoscale.appcat.vshn.io/v1
     kind: XExoscaleMySQL
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -77,10 +66,6 @@ spec:
           name: ca.crt
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_opensearch.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_opensearch.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: exoscale.appcat.vshn.io/v1
     kind: XExoscaleOpenSearch
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -74,10 +63,6 @@ spec:
           name: OPENSEARCH_PORT
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_postgres.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_postgres.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: exoscale.appcat.vshn.io/v1
     kind: XExoscalePostgreSQL
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -77,10 +66,6 @@ spec:
           name: ca.crt
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_redis.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_redis.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: exoscale.appcat.vshn.io/v1
     kind: XExoscaleRedis
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -68,10 +57,6 @@ spec:
           name: REDIS_URL
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/exoscale/appcat/appcat/21_composition_objectstorage_exoscale.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_objectstorage_exoscale.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: appcat.vshn.io/v1
     kind: XObjectBucket
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -56,10 +45,6 @@ spec:
           name: AWS_SECRET_ACCESS_KEY
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath
@@ -109,10 +94,6 @@ spec:
           name: BUCKET_NAME
           type: FromFieldPath
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/openshift/appcat/appcat/21_composition_exoscale_kafka.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_exoscale_kafka.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: exoscale.appcat.vshn.io/v1
     kind: XExoscaleKafka
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -75,10 +64,6 @@ spec:
           name: ca.crt
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/openshift/appcat/appcat/21_composition_exoscale_mysql.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_exoscale_mysql.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: exoscale.appcat.vshn.io/v1
     kind: XExoscaleMySQL
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -77,10 +66,6 @@ spec:
           name: ca.crt
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/openshift/appcat/appcat/21_composition_exoscale_opensearch.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_exoscale_opensearch.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: exoscale.appcat.vshn.io/v1
     kind: XExoscaleOpenSearch
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -74,10 +63,6 @@ spec:
           name: OPENSEARCH_PORT
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/openshift/appcat/appcat/21_composition_exoscale_postgres.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_exoscale_postgres.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: exoscale.appcat.vshn.io/v1
     kind: XExoscalePostgreSQL
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -77,10 +66,6 @@ spec:
           name: ca.crt
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/openshift/appcat/appcat/21_composition_exoscale_redis.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_exoscale_redis.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: exoscale.appcat.vshn.io/v1
     kind: XExoscaleRedis
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -68,10 +57,6 @@ spec:
           name: REDIS_URL
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/openshift/appcat/appcat/21_composition_objectstorage_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_objectstorage_exoscale.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: appcat.vshn.io/v1
     kind: XObjectBucket
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: exoscale.crossplane.io/v1
@@ -56,10 +45,6 @@ spec:
           name: AWS_SECRET_ACCESS_KEY
           type: FromConnectionSecretKey
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath
@@ -109,10 +94,6 @@ spec:
           name: BUCKET_NAME
           type: FromFieldPath
       patches:
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -68,16 +68,9 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
-<<<<<<< HEAD
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: status.conditions
           toFieldPath: status.namespaceDebug
           type: ToCompositeFieldPath
-=======
->>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -123,16 +116,9 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
-<<<<<<< HEAD
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: status.conditions
           toFieldPath: status.profileDebug
           type: ToCompositeFieldPath
-=======
->>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -172,16 +158,9 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
-<<<<<<< HEAD
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: status.conditions
           toFieldPath: status.pgconfigDebug
           type: ToCompositeFieldPath
-=======
->>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -232,16 +211,9 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
-<<<<<<< HEAD
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: status.conditions
           toFieldPath: status.pgclusterDebug
           type: ToCompositeFieldPath
-=======
->>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -335,16 +307,9 @@ spec:
           name: ca.crt
           type: FromConnectionSecretKey
       patches:
-<<<<<<< HEAD
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: status.conditions
           toFieldPath: status.secretDebug
           type: ToCompositeFieldPath
-=======
->>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -412,16 +377,9 @@ spec:
             name: ''
             namespace: ''
       patches:
-<<<<<<< HEAD
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: status.conditions
           toFieldPath: status.s3BucketDebug
           type: ToCompositeFieldPath
-=======
->>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath
@@ -472,16 +430,9 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
-<<<<<<< HEAD
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: status.conditions
           toFieldPath: status.s3BackupConfigDebug
           type: ToCompositeFieldPath
-=======
->>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -545,16 +496,9 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
-<<<<<<< HEAD
-        - patchSetName: annotations
-          type: PatchSet
-        - patchSetName: labels
-          type: PatchSet
         - fromFieldPath: status.conditions
           toFieldPath: status.networkPolicyDebug
           type: ToCompositeFieldPath
-=======
->>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -19,17 +19,6 @@ spec:
   compositeTypeRef:
     apiVersion: vshn.appcat.vshn.io/v1
     kind: XVSHNPostgreSQL
-  patchSets:
-    - name: annotations
-      patches:
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-          type: FromCompositeFieldPath
-    - name: labels
-      patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-          type: FromCompositeFieldPath
   resources:
     - base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
@@ -79,6 +68,7 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
+<<<<<<< HEAD
         - patchSetName: annotations
           type: PatchSet
         - patchSetName: labels
@@ -86,6 +76,8 @@ spec:
         - fromFieldPath: status.conditions
           toFieldPath: status.namespaceDebug
           type: ToCompositeFieldPath
+=======
+>>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -131,6 +123,7 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
+<<<<<<< HEAD
         - patchSetName: annotations
           type: PatchSet
         - patchSetName: labels
@@ -138,6 +131,8 @@ spec:
         - fromFieldPath: status.conditions
           toFieldPath: status.profileDebug
           type: ToCompositeFieldPath
+=======
+>>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -177,6 +172,7 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
+<<<<<<< HEAD
         - patchSetName: annotations
           type: PatchSet
         - patchSetName: labels
@@ -184,6 +180,8 @@ spec:
         - fromFieldPath: status.conditions
           toFieldPath: status.pgconfigDebug
           type: ToCompositeFieldPath
+=======
+>>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -234,6 +232,7 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
+<<<<<<< HEAD
         - patchSetName: annotations
           type: PatchSet
         - patchSetName: labels
@@ -241,6 +240,8 @@ spec:
         - fromFieldPath: status.conditions
           toFieldPath: status.pgclusterDebug
           type: ToCompositeFieldPath
+=======
+>>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -334,6 +335,7 @@ spec:
           name: ca.crt
           type: FromConnectionSecretKey
       patches:
+<<<<<<< HEAD
         - patchSetName: annotations
           type: PatchSet
         - patchSetName: labels
@@ -341,6 +343,8 @@ spec:
         - fromFieldPath: status.conditions
           toFieldPath: status.secretDebug
           type: ToCompositeFieldPath
+=======
+>>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -408,6 +412,7 @@ spec:
             name: ''
             namespace: ''
       patches:
+<<<<<<< HEAD
         - patchSetName: annotations
           type: PatchSet
         - patchSetName: labels
@@ -415,6 +420,8 @@ spec:
         - fromFieldPath: status.conditions
           toFieldPath: status.s3BucketDebug
           type: ToCompositeFieldPath
+=======
+>>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           type: FromCompositeFieldPath
@@ -465,6 +472,7 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
+<<<<<<< HEAD
         - patchSetName: annotations
           type: PatchSet
         - patchSetName: labels
@@ -472,6 +480,8 @@ spec:
         - fromFieldPath: status.conditions
           toFieldPath: status.s3BackupConfigDebug
           type: ToCompositeFieldPath
+=======
+>>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:
@@ -535,6 +545,7 @@ spec:
           providerConfigRef:
             name: kubernetes
       patches:
+<<<<<<< HEAD
         - patchSetName: annotations
           type: PatchSet
         - patchSetName: labels
@@ -542,6 +553,8 @@ spec:
         - fromFieldPath: status.conditions
           toFieldPath: status.networkPolicyDebug
           type: ToCompositeFieldPath
+=======
+>>>>>>> 60f0c0a (Remove harmful annotation and label patchsets)
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
           transforms:


### PR DESCRIPTION
* Removed the patchsets that pass all annotations and labels
* Removed patchset functions as they provide not much benefit when using jsonnet

This removes the user's ability to set any annotations and labels on the managed resources. This resolves security problems with the `external-name`.

Resolves #92

## Checklist

- [X] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [X] PR contains a single logical change (to build a better changelog).
- [X] Update the documentation.
- [X] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [X] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
