### PR TITLE
Local dev S3 composition

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_redis.go
+++ b/apis/vshn/v1/dbaas_vshn_redis.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	v1 "github.com/vshn/component-appcat/apis/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/component/provider.jsonnet
+++ b/component/provider.jsonnet
@@ -8,7 +8,6 @@ local crossplane = import 'lib/crossplane.libsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.appcat;
 
-
 local addCredentials(config, credentials) = config {
   credentials: std.get(config, 'credentials', default=credentials),
 };

--- a/dev/component/objectstorage.jsonnet
+++ b/dev/component/objectstorage.jsonnet
@@ -1,0 +1,182 @@
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local comp = import 'lib/appcat-compositions.libsonnet';
+local crossplane = import 'lib/crossplane.libsonnet';
+
+local common = import '../component/common.libsonnet';
+local xrds = import '../component/xrds.libsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.appcat;
+local objStoParams = params.services.generic.objectstorage;
+
+local xrd = xrds.XRDFromCRD(
+  'xobjectbuckets.appcat.vshn.io',
+  xrds.LoadCRD('appcat.vshn.io_objectbuckets.yaml'),
+  defaultComposition='%s.objectbuckets.appcat.vshn.io' % objStoParams.defaultComposition,
+  connectionSecretKeys=[
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_REGION',
+    'ENDPOINT',
+    'ENDPOINT_URL',
+    'BUCKET_NAME',
+  ]
+);
+
+local minioRbac =
+  local provider = params.providers.helm;
+
+  local sa = kube.ServiceAccount(provider.controllerConfig.serviceAccountName) {
+    metadata+: {
+      namespace: provider.namespace,
+    },
+  };
+  local role = kube.ClusterRole('crossplane:provider:provider-helm:system:dev') {
+    rules: [
+      {
+        apiGroups: [ '' ],
+        resources: [ 'persistentvolumeclaims', 'deployments' ],
+        verbs: [ 'get', 'list', 'watch', 'create', 'watch', 'patch', 'update', 'delete' ],
+      },
+      {
+        apiGroups: [ 'apps' ],
+        resources: [ 'deployments' ],
+        verbs: [ 'get', 'list', 'watch', 'create', 'watch', 'patch', 'update', 'delete' ],
+      },
+      {
+        apiGroups: [ 'batch' ],
+        resources: [ 'jobs' ],
+        verbs: [ 'get', 'list', 'watch', 'create', 'watch', 'patch', 'update', 'delete' ],
+      },
+    ],
+  };
+  local rolebinding = kube.ClusterRoleBinding('crossplane:provider:provider-helm:system:dev') {
+    roleRef_: role,
+    subjects_: [ sa ],
+  };
+
+  [
+    role,
+    rolebinding,
+  ];
+
+local compositionMinioDev =
+
+  local namespace = comp.KubeObject('v1', 'Namespace');
+
+  local devMinioHelmChart =
+    {
+      apiVersion: 'helm.crossplane.io/v1beta1',
+      kind: 'Release',
+      spec+: {
+        deletionPolicy: 'Delete',
+        rollbackLimit: 3,
+        connectionDetails: [
+          {
+            apiVersion: 'v1',
+            kind: 'Service',
+            name: 'minio-server',
+            fieldPath: 'spec.clusterIP',
+            toConnectionSecretKey: 'ENDPOINT_URL',
+            namespace: 'minio',
+          },
+          {
+            apiVersion: 'v1',
+            kind: 'Secret',
+            name: 'minio-server',
+            fieldPath: 'data.rootUser',
+            toConnectionSecretKey: 'AWS_ACCESS_KEY_ID',
+            namespace: 'minio',
+          },
+          {
+            apiVersion: 'v1',
+            kind: 'Secret',
+            name: 'minio-server',
+            fieldPath: 'data.rootPassword',
+            toConnectionSecretKey: 'AWS_SECRET_ACCESS_KEY',
+            namespace: 'minio',
+          },
+        ],
+        writeConnectionSecretToRef: {
+          name: '',
+          namespace: 'syn-crossplane',
+        },
+        forProvider+: {
+          namespace: 'minio',
+          chart: {
+            name: 'minio',
+            repository: 'https://charts.min.io/',
+            version: '5.0.7',
+          },
+          set: [
+            {
+              name: 'rootUser',
+              value: 'minioadmin',
+            },
+            {
+              name: 'rootPassword',
+              value: 'minioadmin',
+            },
+          ],
+          values: {
+            fullnameOverride: 'minio-server',
+            replicas: 1,
+            resources: {
+              requests: {
+                memory: '128Mi',
+              },
+            },
+            persistence: {
+              size: '1Gi',
+            },
+            mode: 'standalone',
+            buckets: [
+              {
+                name: '',
+                policy: 'none',
+              },
+            ],
+          },
+        },
+        providerConfigRef: {
+          name: 'helm',
+        },
+      },
+    };
+
+  kube._Object('apiextensions.crossplane.io/v1', 'Composition', 'dev.objectbuckets.appcat.vshn.io') +
+  common.SyncOptions +
+  {
+    spec: {
+      compositeTypeRef: comp.CompositeRef(xrd),
+      writeConnectionSecretsToNamespace: 'syn-crossplane',
+      resources: [
+        {
+          base: namespace,
+          patches: [
+            comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name'),
+          ],
+        },
+        {
+          base: devMinioHelmChart,
+          connectionDetails: [
+            { fromConnectionSecretKey: 'AWS_SECRET_ACCESS_KEY' },
+            { fromConnectionSecretKey: 'ENDPOINT_URL' },
+            { fromConnectionSecretKey: 'AWS_ACCESS_KEY_ID' },
+          ],
+          patches: [
+            comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.values.buckets[0].name'),
+            comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.writeConnectionSecretToRef.name'),
+          ],
+        },
+      ],
+    },
+  };
+
+if objStoParams.enabled then {
+  '20_rbac_helm_provider_dev': minioRbac,
+  '21_composition_objectstorage_minio_dev': compositionMinioDev,
+} else {}

--- a/tests/golden/vshn/appcat/appcat/20_rbac_helm_provider_dev.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_rbac_helm_provider_dev.yaml
@@ -1,0 +1,64 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: crossplane-provider-provider-helm-system-dev
+  name: crossplane:provider:provider-helm:system:dev
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - watch
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - watch
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - watch
+      - patch
+      - update
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: crossplane-provider-provider-helm-system-dev
+  name: crossplane:provider:provider-helm:system:dev
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane:provider:provider-helm:system:dev
+subjects:
+  - kind: ServiceAccount
+    name: provider-helm
+    namespace: syn-crossplane

--- a/tests/golden/vshn/appcat/appcat/20_rbac_objectstorage.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_rbac_objectstorage.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: appcat:composite:xobjectbuckets.appcat.vshn.io:claim-view
+rules:
+  - apiGroups:
+      - appcat.vshn.io
+    resources:
+      - objectbuckets
+      - objectbuckets/status
+      - objectbuckets/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: appcat:composite:xobjectbuckets.appcat.vshn.io:claim-edit
+rules:
+  - apiGroups:
+      - appcat.vshn.io
+    resources:
+      - objectbuckets
+      - objectbuckets/status
+      - objectbuckets/finalizers
+    verbs:
+      - '*'

--- a/tests/golden/vshn/appcat/appcat/20_xrd_objectstorage.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_xrd_objectstorage.yaml
@@ -1,0 +1,161 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '10'
+  labels:
+    name: xobjectbuckets.appcat.vshn.io
+  name: xobjectbuckets.appcat.vshn.io
+spec:
+  claimNames:
+    kind: ObjectBucket
+    plural: objectbuckets
+  connectionSecretKeys:
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_REGION
+    - ENDPOINT
+    - ENDPOINT_URL
+    - BUCKET_NAME
+  defaultCompositionRef:
+    name: dev.objectbuckets.appcat.vshn.io
+  group: appcat.vshn.io
+  names:
+    kind: XObjectBucket
+    plural: xobjectbuckets
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.parameters.bucketName
+          name: Bucket Name
+          type: string
+        - jsonPath: .spec.parameters.region
+          name: Region
+          type: string
+      name: v1
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          description: ObjectBucket is the API for creating S3 buckets.
+          properties:
+            spec:
+              description: ObjectBucketSpec defines the desired state of a ObjectBucket.
+              properties:
+                parameters:
+                  description: ObjectBucketParameters are the configurable fields
+                    of a ObjectBucket.
+                  properties:
+                    bucketName:
+                      description: BucketName is the name of the bucket to create.
+                        Cannot be changed after bucket is created. Name must be acceptable
+                        by the S3 protocol, which follows RFC 1123. Be aware that
+                        S3 providers may require a unique name across the platform
+                        or region.
+                      type: string
+                    region:
+                      description: Region is the name of the region where the bucket
+                        shall be created. The region must be available in the S3 endpoint.
+                      type: string
+                  required:
+                    - bucketName
+                    - region
+                  type: object
+              type: object
+            status:
+              description: ObjectBucketStatus reflects the observed state of a ObjectBucket.
+              properties:
+                accessUserConditions:
+                  description: AccessUserConditions contains a copy of the claim's
+                    underlying user account conditions.
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about the transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if
+                          .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: Reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition.
+                        maxLength: 1024
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        enum:
+                          - 'True'
+                          - 'False'
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of condition.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    type: object
+                  type: array
+                bucketConditions:
+                  description: BucketConditions contains a copy of the claim's underlying
+                    bucket conditions.
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about the transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if
+                          .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: Reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition.
+                        maxLength: 1024
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        enum:
+                          - 'True'
+                          - 'False'
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of condition.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          required:
+            - spec
+          type: object
+      served: true

--- a/tests/golden/vshn/appcat/appcat/21_composition_objectstorage_minio_dev.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_objectstorage_minio_dev.yaml
@@ -1,0 +1,94 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '10'
+  labels:
+    name: dev.objectbuckets.appcat.vshn.io
+  name: dev.objectbuckets.appcat.vshn.io
+spec:
+  compositeTypeRef:
+    apiVersion: appcat.vshn.io/v1
+    kind: XObjectBucket
+  resources:
+    - base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata: {}
+        spec:
+          forProvider:
+            manifest:
+              apiVersion: v1
+              kind: Namespace
+          providerConfigRef:
+            name: kubernetes
+      patches:
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.manifest.metadata.name
+          type: FromCompositeFieldPath
+    - base:
+        apiVersion: helm.crossplane.io/v1beta1
+        kind: Release
+        spec:
+          connectionDetails:
+            - apiVersion: v1
+              fieldPath: spec.clusterIP
+              kind: Service
+              name: minio-server
+              namespace: minio
+              toConnectionSecretKey: ENDPOINT_URL
+            - apiVersion: v1
+              fieldPath: data.rootUser
+              kind: Secret
+              name: minio-server
+              namespace: minio
+              toConnectionSecretKey: AWS_ACCESS_KEY_ID
+            - apiVersion: v1
+              fieldPath: data.rootPassword
+              kind: Secret
+              name: minio-server
+              namespace: minio
+              toConnectionSecretKey: AWS_SECRET_ACCESS_KEY
+          deletionPolicy: Delete
+          forProvider:
+            chart:
+              name: minio
+              repository: https://charts.min.io/
+              version: 5.0.7
+            namespace: minio
+            set:
+              - name: rootUser
+                value: minioadmin
+              - name: rootPassword
+                value: minioadmin
+            values:
+              buckets:
+                - name: ''
+                  policy: none
+              fullnameOverride: minio-server
+              mode: standalone
+              persistence:
+                size: 1Gi
+              replicas: 1
+              resources:
+                requests:
+                  memory: 128Mi
+          providerConfigRef:
+            name: helm
+          rollbackLimit: 3
+          writeConnectionSecretToRef:
+            name: ''
+            namespace: syn-crossplane
+      connectionDetails:
+        - fromConnectionSecretKey: AWS_SECRET_ACCESS_KEY
+        - fromConnectionSecretKey: ENDPOINT_URL
+        - fromConnectionSecretKey: AWS_ACCESS_KEY_ID
+      patches:
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.values.buckets[0].name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.writeConnectionSecretToRef.name
+          type: FromCompositeFieldPath
+  writeConnectionSecretsToNamespace: syn-crossplane

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -541,7 +541,7 @@ spec:
         spec:
           parameters:
             bucketName: ''
-            region: ch-gva-2
+            region: us-east-1
           writeConnectionSecretToRef:
             name: ''
             namespace: ''
@@ -593,8 +593,8 @@ spec:
                         name: ''
                   bucket: ''
                   enablePathStyleAddressing: true
-                  endpoint: https://sos-ch-gva-2.exo.io
-                  region: ch-gva-2
+                  endpoint: http://minio-server.minio:9000
+                  region: us-east-1
                 type: s3Compatible
           providerConfigRef:
             name: kubernetes

--- a/tests/vshn.yml
+++ b/tests/vshn.yml
@@ -4,6 +4,14 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-crossplane/v2.3.0/lib/crossplane.libsonnet
         output_path: vendor/lib/crossplane.libsonnet
+    compile:
+      - input_paths:
+          - ${_base_directory}/dev/component/objectstorage.jsonnet
+        input_type: jsonnet
+        output_path: appcat/
+
+  facts:
+    cloud: cloudscale
 
   crossplane:
     namespace: syn-crossplane
@@ -19,5 +27,15 @@ parameters:
       vshn:
         enabled: true
         postgres:
-          bucket_region: 'ch-gva-2'
-          bucket_endpoint: 'https://sos-ch-gva-2.exo.io'
+          bucket_region: 'us-east-1'
+          bucket_endpoint: 'http://minio-server.minio:9000'
+      generic:
+          objectstorage:
+            enabled: true
+
+            defaultComposition: dev
+            compositions:
+              exoscale:
+                enabled: false
+              cloudscale:
+                enabled: false


### PR DESCRIPTION
This commit adds a composition that implements our XObjectBucket XRD. It will provision a local minio instance and a bucket. Currently only supports creating one instance and bucket.

This relates to the implementation of the PostgreSQL backups, as the backup depends on the ObjectBucket.

## Checklist

- [X] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [X] PR contains a single logical change (to build a better changelog).
- [X] Update the documentation.
- [X] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [X] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
