### PR TITLE
Add PostgreSQL Restore Ability

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -52,6 +52,9 @@ type VSHNPostgreSQLParameters struct {
 
 	// Backup contains settings to control the backups of an instance.
 	Backup VSHNPostgreSQLBackup `json:"backup,omitempty"`
+
+	// Restore contains settings to control the restore of an instance.
+	Restore VSHNPostgreSQLRestore `json:"restore,omitempty"`
 }
 
 // VSHNPostgreSQLServiceSpec contains PostgreSQL DBaaS specific properties
@@ -129,8 +132,26 @@ type VSHNPostgreSQLBackup struct {
 	Retention int `json:"retention,omitempty"`
 }
 
+// VSHNPostgreSQLRestore contains restore specific parameters.
+type VSHNPostgreSQLRestore struct {
+
+	// ClaimName specifies the name of the instance you want to restore from.
+	// The claim has to be in the same namespace as this new instance.
+	ClaimName string `json:"claimName,omitempty"`
+
+	// BackupName is the name of the specific backup you want to restore.
+	BackupName string `json:"backupName,omitempty"`
+
+	// RecoveryTimeStamp an ISO 8601 date, that holds UTC date indicating at which point-in-time the database has to be restored.
+	// This is optional and if no PIT recovery is required, it can be left empty.
+	// +kubebuilder:validation:Pattern=`^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$`
+	RecoveryTimeStamp string `json:"recoveryTimeStamp,omitempty"`
+}
+
 // VSHNPostgreSQLStatus reflects the observed state of a VSHNPostgreSQL.
 type VSHNPostgreSQLStatus struct {
+	// InstanceNamespace contains the name of the namespace where the instance resides
+	InstanceNamespace string `json:"instanceNamespace,omitempty"`
 	// PostgreSQLConditions contains the status conditions of the backing object.
 	PostgreSQLConditions []v1.Condition `json:"postgresqlConditions,omitempty"`
 	NamespaceDebug       []v1.Condition `json:"namespaceDebug,omitempty"`

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -96,6 +96,8 @@ parameters:
           enabled: true
           enableNetworkPolicy: true
           secretNamespace: ${appcat:services:vshn:secretNamespace}
+          # Used for deploying jobs during restores
+          controlNamespace: 'syn-appcat-control'
         redis:
           enabled: true
           enableNetworkPolicy: true

--- a/component/appcat_apiserver.jsonnet
+++ b/component/appcat_apiserver.jsonnet
@@ -18,16 +18,16 @@ local namespace = loadManifest('namespace.yaml') {
 local clusterRoleUsers = kube.ClusterRole('system:' + inv.parameters.facts.distribution + ':aggregate-appcat-to-basic-user') {
   metadata+: {
     labels+: {
-      "authorization.openshift.io/aggregate-to-basic-user": "true"
+      'authorization.openshift.io/aggregate-to-basic-user': 'true',
     },
   },
   rules+: [
     {
-      apiGroups: ["api.appcat.vshn.io"],
-      resources: ["appcats"],
-      verbs: ["get", "list", "watch"],
-    }
-  ]
+      apiGroups: [ 'api.appcat.vshn.io' ],
+      resources: [ 'appcats' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
+  ],
 };
 
 local serviceAccount = loadManifest('service-account.yaml') {
@@ -138,11 +138,11 @@ local apiService = loadManifest('apiservice.yaml') {
       then
         {
           caBundle: std.base64(params.apiserver.tls.serverCert),
-          insecureSkipTLSVerify:: null
+          insecureSkipTLSVerify:: null,
         }
       else
         {}
-    )
+    ),
 };
 
 

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -42,7 +42,7 @@ local vshnMetaDBaaSExoscale(dbname) = {
   },
 };
 
-local vshnMetaVshn(dbname, flavor) = {
+local vshnMetaVshn(dbname, flavor, offered) = {
   metadata+: {
     annotations+: {
       'metadata.appcat.vshn.io/displayname': 'VSHN Managed ' + dbname,
@@ -53,7 +53,7 @@ local vshnMetaVshn(dbname, flavor) = {
       'metadata.appcat.vshn.io/product-description': 'https://products.docs.vshn.ch/products/appcat/' + std.asciiLower(dbname) + '.html',
     },
     labels+: {
-      'metadata.appcat.vshn.io/offered': 'true',
+      'metadata.appcat.vshn.io/offered': offered,
       'metadata.appcat.vshn.io/serviceID': 'vshn-' + std.asciiLower(dbname),
     },
   },
@@ -92,8 +92,8 @@ local mergeArgs(args, additional) =
     vshnMetaDBaaSExoscale(dbname),
   VshnMetaObjectStorage(provider):
     vshnMetaObjectStorage(provider),
-  VshnMetaVshn(dbname, flavor):
-    vshnMetaVshn(dbname, flavor),
   MergeArgs(args, additional):
     mergeArgs(args, additional),
+  VshnMetaVshn(dbname, flavor, offered='true'):
+    vshnMetaVshn(dbname, flavor, offered),
 }

--- a/component/provider.jsonnet
+++ b/component/provider.jsonnet
@@ -130,12 +130,12 @@ local controllerConfigRef(config) =
         },
         {
           apiGroups: [ '' ],
-          resources: [ 'namespaces' ],
+          resources: [ 'namespaces', 'serviceaccounts', 'secrets' ],
           verbs: [ 'get', 'list', 'watch', 'create', 'watch', 'patch', 'update', 'delete' ],
         },
         {
           apiGroups: [ 'stackgres.io' ],
-          resources: [ 'sginstanceprofiles', 'sgclusters', 'sgpgconfigs', 'sgobjectstorages' ],
+          resources: [ 'sginstanceprofiles', 'sgclusters', 'sgpgconfigs', 'sgobjectstorages', 'sgbackups' ],
           verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
         },
         {
@@ -152,6 +152,21 @@ local controllerConfigRef(config) =
           apiGroups: [ 'cert-manager.io' ],
           resources: [ 'issuers', 'certificates' ],
           verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
+        },
+        {
+          apiGroups: [ 'batch' ],
+          resources: [ 'jobs' ],
+          verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
+        },
+        {
+          apiGroups: [ 'rbac.authorization.k8s.io' ],
+          resources: [ 'clusterrolebindings' ],
+          verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
+        },
+        {
+          apiGroups: [ 'vshn.appcat.vshn.io' ],
+          resources: [ 'vshnpostgresqls' ],
+          verbs: [ 'get' ],
         },
       ],
     };

--- a/component/scripts/copy-pg-backup.sh
+++ b/component/scripts/copy-pg-backup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+xrdname=$(kubectl -n "${CLAIM_NAMESPACE}" get vshnpostgresqls "${CLAIM_NAME}" -ojson | jq -r '.spec.resourceRef.name')
+
+source_namespace=$(kubectl -n "${CLAIM_NAMESPACE}" get vshnpostgresqls "${CLAIM_NAME}" -ojson | jq -r '.status.instanceNamespace')
+
+echo "copy secret"
+kubectl -n "${source_namespace}" get secret "pgbucket-${xrdname}" -ojson | jq 'del(.metadata.namespace) | del(.metadata.ownerReferences)' | kubectl -n "${TARGET_NAMESPACE}" apply -f -
+echo "copy sgObjectStorage"
+kubectl -n "${source_namespace}" get sgobjectstorages.stackgres.io "sgbackup-${xrdname}" -ojson | jq 'del(.metadata.namespace) | del(.metadata.ownerReferences)' | kubectl -n "$TARGET_NAMESPACE" apply -f -
+echo "copy sgBackup"
+kubectl -n "${source_namespace}" get sgbackups.stackgres.io "${BACKUP_NAME}" -ojson | jq '.spec.sgCluster = .metadata.namespace + "." + .spec.sgCluster | del(.metadata.namespace) | del(.metadata.ownerReferences)' | kubectl -n "${TARGET_NAMESPACE}" apply -f -

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -81,6 +81,20 @@ spec:
                             type: string
                           type: array
                       type: object
+                    restore:
+                      description: Restore contains settings to control the restore of an instance.
+                      properties:
+                        backupName:
+                          description: BackupName is the name of the specific backup you want to restore.
+                          type: string
+                        claimName:
+                          description: ClaimName specifies the name of the instance you want to restore from. The claim has to be in the same namespace as this new instance.
+                          type: string
+                        recoveryTimeStamp:
+                          description: RecoveryTimeStamp an ISO 8601 date, that holds UTC date indicating at which point-in-time the database has to be restored. This is optional and if no PIT recovery is required, it can be left empty.
+                          pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$
+                          type: string
+                      type: object
                     scheduling:
                       description: Scheduling contains settings to control the scheduling of an instance.
                       properties:
@@ -166,6 +180,9 @@ spec:
                         type: string
                     type: object
                   type: array
+                instanceNamespace:
+                  description: InstanceNamespace contains the name of the namespace where the instance resides
+                  type: string
                 localCADebug:
                   items:
                     properties:

--- a/docs/modules/ROOT/pages/explanations/restore.adoc
+++ b/docs/modules/ROOT/pages/explanations/restore.adoc
@@ -1,0 +1,22 @@
+= How the Restore Process Works
+
+The restore is defined by another composition `vshnpostgresqlrestore`.
+That composition patches some more information necessary to trigger a restore.
+It also deploys a copy job to the `syn-appcat-control` namespace.
+This is necessary so that we can access the backups from different namespaces.
+
+The copy job copies three things from the original instance namespace to the new namespace:
+
+* the secret containing bucket credentials
+* an sgObjectStorage that contains the endpoint and bucket name where the backup is stored
+* sgBackup this object contains the actual necessary information to successfully trigger a restore of the instance
+
+This job is deployed to a dedicated `syn-appcat-control` namespace that's not available to the user.
+
+These objects are necessary for StackGres to perform a succesful restore of the given backup.
+The remaining differences in the restore composition are to pass the necessary information to the `sgCluster` object.
+The actual restore is handled by StackGres.
+
+To ensure quicker reconciliation the `dependsOn` feature of `provider-kubernetes` is used on the `sgCluster` object.
+This ensures that the `sgCluster` is only applied after the job has been created.
+This cuts the reconcilation of the actual cluster in half.

--- a/docs/modules/ROOT/pages/references/services-vshn.adoc
+++ b/docs/modules/ROOT/pages/references/services-vshn.adoc
@@ -43,6 +43,11 @@ default:: `true`
 
 Whether to enable NetworkPolicy in the PostgreSQL instance namespace. This allows to establish connections from claim's namespace to the PostgreSQL instance.
 
+=== `postgres.controlNamespace`
+type:: string
+default:: `'appcat-control'`
+
+Name of the additional namespace that's needed to the backup copy job.
 
 === `postgres.bucket_region`
 type:: string

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -2,6 +2,7 @@
 
 .Explanations
 * xref:explanations/crossplane-secrets-non-provider.adoc[Manage secrets not coming from a provider]
+* xref:explanations/restore.adoc[]
 
 .Tutorials
 * xref:tutorials/install-cloudscale.adoc[Install Cloudscale Stack]

--- a/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -80,6 +80,8 @@ rules:
       - ''
     resources:
       - namespaces
+      - serviceaccounts
+      - secrets
     verbs:
       - get
       - list
@@ -96,6 +98,7 @@ rules:
       - sgclusters
       - sgpgconfigs
       - sgobjectstorages
+      - sgbackups
     verbs:
       - get
       - list
@@ -141,6 +144,36 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
+  - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnpostgresqls
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -80,6 +80,8 @@ rules:
       - ''
     resources:
       - namespaces
+      - serviceaccounts
+      - secrets
     verbs:
       - get
       - list
@@ -96,6 +98,7 @@ rules:
       - sgclusters
       - sgpgconfigs
       - sgobjectstorages
+      - sgbackups
     verbs:
       - get
       - list
@@ -141,6 +144,36 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
+  - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnpostgresqls
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
@@ -82,6 +82,8 @@ rules:
       - ''
     resources:
       - namespaces
+      - serviceaccounts
+      - secrets
     verbs:
       - get
       - list
@@ -98,6 +100,7 @@ rules:
       - sgclusters
       - sgpgconfigs
       - sgobjectstorages
+      - sgbackups
     verbs:
       - get
       - list
@@ -143,6 +146,36 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
+  - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnpostgresqls
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
@@ -80,6 +80,8 @@ rules:
       - ''
     resources:
       - namespaces
+      - serviceaccounts
+      - secrets
     verbs:
       - get
       - list
@@ -96,6 +98,7 @@ rules:
       - sgclusters
       - sgpgconfigs
       - sgobjectstorages
+      - sgbackups
     verbs:
       - get
       - list
@@ -141,6 +144,36 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
+  - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnpostgresqls
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/vshn/appcat/appcat/20_namespace_vshn_control.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_namespace_vshn_control.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-appcat-control
+  name: syn-appcat-control

--- a/tests/golden/vshn/appcat/appcat/20_role_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_role_vshn_postgresrestore.yaml
@@ -1,0 +1,55 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: crossplane-appcat-job-postgres-copybackups
+  name: crossplane:appcat:job:postgres:copybackups
+rules:
+  - apiGroups:
+      - stackgres.io
+    resources:
+      - sgbackups
+      - sgobjectstorages
+    verbs:
+      - get
+      - list
+      - create
+  - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnpostgresqls
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: copyserviceaccount
+  name: copyserviceaccount
+  namespace: syn-appcat-control
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-job-postgres-copybackup
+  name: appcat:job:postgres:copybackup
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane:appcat:job:postgres:copybackups
+subjects:
+  - kind: ServiceAccount
+    name: copyserviceaccount
+    namespace: syn-appcat-control

--- a/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -98,6 +98,27 @@ spec:
                             type: string
                           type: array
                       type: object
+                    restore:
+                      description: Restore contains settings to control the restore
+                        of an instance.
+                      properties:
+                        backupName:
+                          description: BackupName is the name of the specific backup
+                            you want to restore.
+                          type: string
+                        claimName:
+                          description: ClaimName specifies the name of the instance
+                            you want to restore from. The claim has to be in the same
+                            namespace as this new instance.
+                          type: string
+                        recoveryTimeStamp:
+                          description: RecoveryTimeStamp an ISO 8601 date, that holds
+                            UTC date indicating at which point-in-time the database
+                            has to be restored. This is optional and if no PIT recovery
+                            is required, it can be left empty.
+                          pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$
+                          type: string
+                      type: object
                     scheduling:
                       description: Scheduling contains settings to control the scheduling
                         of an instance.
@@ -199,6 +220,10 @@ spec:
                         type: string
                     type: object
                   type: array
+                instanceNamespace:
+                  description: InstanceNamespace contains the name of the namespace
+                    where the instance resides
+                  type: string
                 localCADebug:
                   items:
                     properties:

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -4,17 +4,17 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '10'
-    metadata.appcat.vshn.io/description: PostgreSQL instances by VSHN
-    metadata.appcat.vshn.io/displayname: VSHN Managed PostgreSQL
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/vshn-dbaas/postgresql/create.html
+    metadata.appcat.vshn.io/description: PostgreSQLRestore instances by VSHN
+    metadata.appcat.vshn.io/displayname: VSHN Managed PostgreSQLRestore
+    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/vshn-dbaas/postgresqlrestore/create.html
     metadata.appcat.vshn.io/flavor: standalone
-    metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/postgresql.html
+    metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/postgresqlrestore.html
     metadata.appcat.vshn.io/zone: rma1
   labels:
-    metadata.appcat.vshn.io/offered: 'true'
-    metadata.appcat.vshn.io/serviceID: vshn-postgresql
-    name: vshnpostgres.vshn.appcat.vshn.io
-  name: vshnpostgres.vshn.appcat.vshn.io
+    metadata.appcat.vshn.io/offered: 'false'
+    metadata.appcat.vshn.io/serviceID: vshn-postgresqlrestore
+    name: vshnpostgresrestore.vshn.appcat.vshn.io
+  name: vshnpostgresrestore.vshn.appcat.vshn.io
 spec:
   compositeTypeRef:
     apiVersion: vshn.appcat.vshn.io/v1
@@ -197,6 +197,106 @@ spec:
         spec:
           forProvider:
             manifest:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                namespace: syn-appcat-control
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - args:
+                          - '#!/bin/sh
+
+
+                            set -e
+
+
+                            xrdname=$(kubectl -n "${CLAIM_NAMESPACE}" get vshnpostgresqls
+                            "${CLAIM_NAME}" -ojson | jq -r ''.spec.resourceRef.name'')
+
+
+                            source_namespace=$(kubectl -n "${CLAIM_NAMESPACE}" get
+                            vshnpostgresqls "${CLAIM_NAME}" -ojson | jq -r ''.status.instanceNamespace'')
+
+
+                            echo "copy secret"
+
+                            kubectl -n "${source_namespace}" get secret "pgbucket-${xrdname}"
+                            -ojson | jq ''del(.metadata.namespace) | del(.metadata.ownerReferences)''
+                            | kubectl -n "${TARGET_NAMESPACE}" apply -f -
+
+                            echo "copy sgObjectStorage"
+
+                            kubectl -n "${source_namespace}" get sgobjectstorages.stackgres.io
+                            "sgbackup-${xrdname}" -ojson | jq ''del(.metadata.namespace)
+                            | del(.metadata.ownerReferences)'' | kubectl -n "$TARGET_NAMESPACE"
+                            apply -f -
+
+                            echo "copy sgBackup"
+
+                            kubectl -n "${source_namespace}" get sgbackups.stackgres.io
+                            "${BACKUP_NAME}" -ojson | jq ''.spec.sgCluster = .metadata.namespace
+                            + "." + .spec.sgCluster | del(.metadata.namespace) | del(.metadata.ownerReferences)''
+                            | kubectl -n "${TARGET_NAMESPACE}" apply -f -
+
+                            '
+                        command:
+                          - sh
+                          - -c
+                        env:
+                          - name: CLAIM_NAMESPACE
+                          - name: CLAIM_NAME
+                          - name: BACKUP_NAME
+                          - name: TARGET_NAMESPACE
+                        image: bitnami/kubectl:latest
+                        name: copyjob
+                    restartPolicy: Never
+                    serviceAccountName: copyserviceaccount
+                    ttlSecondsAfterFinished: 100
+          providerConfigRef:
+            name: kubernetes
+      patches:
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: metadata.name
+          transforms:
+            - string:
+                fmt: '%s-copyjob'
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.manifest.metadata.name
+          transforms:
+            - string:
+                fmt: '%s-copyjob'
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
+          toFieldPath: spec.forProvider.manifest.spec.template.spec.containers[0].env[0].value
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.restore.claimName
+          toFieldPath: spec.forProvider.manifest.spec.template.spec.containers[0].env[1].value
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.restore.backupName
+          toFieldPath: spec.forProvider.manifest.spec.template.spec.containers[0].env[2].value
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.manifest.spec.template.spec.containers[0].env[3].value
+          transforms:
+            - string:
+                fmt: vshn-postgresql-%s
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+    - base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata: {}
+        spec:
+          forProvider:
+            manifest:
               apiVersion: stackgres.io/v1
               kind: SGInstanceProfile
               metadata: {}
@@ -347,6 +447,10 @@ spec:
                 sgInstanceProfile: ''
           providerConfigRef:
             name: kubernetes
+          references:
+            - dependsOn:
+                apiVersion: stackgres.io/v1
+                kind: SGBackup
       patches:
         - fromFieldPath: status.conditions
           toFieldPath: status.pgclusterDebug
@@ -398,6 +502,23 @@ spec:
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.backup.retention
           toFieldPath: spec.forProvider.manifest.spec.configurations.backups[0].retention
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.restore.backupName
+          toFieldPath: spec.forProvider.manifest.spec.initialData.restore.fromBackup.name
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.restore.recoveryTimeStamp
+          toFieldPath: spec.forProvider.manifest.spec.initialData.restore.fromBackup.pointInTimeRecovery.restoreToTimestamp
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.references[0].dependsOn.namespace
+          transforms:
+            - string:
+                fmt: vshn-postgresql-%s
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.restore.backupName
+          toFieldPath: spec.references[0].dependsOn.name
           type: FromCompositeFieldPath
     - base:
         apiVersion: kubernetes.crossplane.io/v1alpha1


### PR DESCRIPTION
This PR adds the ability to do a restore from an existing instance.
To do so it does following actions:

* deploy a clusterRole, namespace (appcat-control) and serviceaccount
* create a new composition for restores, which is 99% the same as the
  normal one
* the composition creates in turn a job to copy over the necessary information from the source
  instance. This happens in the appcat-control namespace.
* a new sgCluster is created that points to the copied objects for the
  restore parameters

The rest is handled by StackGres itself.

## Checklist

- [X] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [X] PR contains a single logical change (to build a better changelog).
- [] Update the documentation.
- [X] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [X] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
