### PR TITLE
Fix wrong type for nodeSelector field

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -70,7 +70,7 @@ type VSHNPostgreSQLServiceSpec struct {
 // VSHNDBaaSSchedulingSpec contains settings to control the scheduling of an instance.
 type VSHNDBaaSSchedulingSpec struct {
 	// NodeSelector is a selector which must match a node’s labels for the pod to be scheduled on that node
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector string `json:"nodeSelector,omitempty"`
 }
 
 // VSHNDBaaSMaintenanceScheduleSpec contains settings to control the maintenance of an instance.

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -85,10 +85,8 @@ spec:
                       description: Scheduling contains settings to control the scheduling of an instance.
                       properties:
                         nodeSelector:
-                          additionalProperties:
-                            type: string
                           description: NodeSelector is a selector which must match a node’s labels for the pod to be scheduled on that node
-                          type: object
+                          type: string
                       type: object
                     service:
                       description: Service contains PostgreSQL DBaaS specific properties

--- a/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -103,12 +103,10 @@ spec:
                         of an instance.
                       properties:
                         nodeSelector:
-                          additionalProperties:
-                            type: string
                           description: "NodeSelector is a selector which must match\
                             \ a node\u2019s labels for the pod to be scheduled on\
                             \ that node"
-                          type: object
+                          type: string
                       type: object
                     service:
                       default: {}


### PR DESCRIPTION
The nodeSelector field is actually a string and not a map




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
