### PR TITLE
Fix defaults to remove ArgoCD diff

### DIFF
--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -333,9 +333,7 @@ local composition =
     {
       apiVersion: 'appcat.vshn.io/v1',
       kind: 'XObjectBucket',
-      metadata: {
-        name: '',
-      },
+      metadata: {},
       spec: {
         parameters: {
           bucketName: '',

--- a/lib/appcat-compositions.libsonnet
+++ b/lib/appcat-compositions.libsonnet
@@ -14,6 +14,7 @@ local fromCompositeFieldPathWithTransform(from, to, prefix, suffix) = fromCompos
       type: 'string',
       string: {
         fmt: prefix + '%s' + suffix,
+        type: 'Format',
       },
     },
   ],
@@ -26,6 +27,7 @@ local fromCompositeFieldPathWithTransformSuffix(from, to, suffix) = fromComposit
       type: 'string',
       string: {
         fmt: '%s-' + suffix,
+        type: 'Format',
       },
     },
   ],
@@ -38,6 +40,7 @@ local fromCompositeFieldPathWithTransformPrefix(from, to, prefix) = fromComposit
       type: 'string',
       string: {
         fmt: prefix + '-%s',
+        type: 'Format',
       },
     },
   ],

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -43,6 +43,7 @@ spec:
           transforms:
             - string:
                 fmt: ns-observer-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
@@ -76,6 +77,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
@@ -110,6 +112,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-localca'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -120,6 +123,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
     - base:
@@ -166,6 +170,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-certificate'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -179,6 +184,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
     - base:
@@ -237,6 +243,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-profile'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -244,6 +251,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -279,6 +287,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-pgconf'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -286,6 +295,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -340,6 +350,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-cluster'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -347,6 +358,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -372,6 +384,7 @@ spec:
           transforms:
             - string:
                 fmt: sgbackup-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.backup.schedule
@@ -466,6 +479,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-connection'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -473,6 +487,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/claim-name]
@@ -480,6 +495,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-connection'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - combine:
@@ -496,6 +512,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -506,6 +523,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/claim-name]
@@ -513,6 +531,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-connection'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -520,6 +539,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -527,6 +547,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -534,13 +555,13 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
     - base:
         apiVersion: appcat.vshn.io/v1
         kind: XObjectBucket
-        metadata:
-          name: ''
+        metadata: {}
         spec:
           parameters:
             bucketName: ''
@@ -563,6 +584,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -570,6 +592,7 @@ spec:
           transforms:
             - string:
                 fmt: pgbucket-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
     - base:
@@ -610,6 +633,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-object-storage'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -617,6 +641,7 @@ spec:
           transforms:
             - string:
                 fmt: sgbackup-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -624,6 +649,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -637,6 +663,7 @@ spec:
           transforms:
             - string:
                 fmt: pgbucket-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -644,6 +671,7 @@ spec:
           transforms:
             - string:
                 fmt: pgbucket-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
     - base:
@@ -676,6 +704,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-network-policy'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -683,6 +712,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-postgresql-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -690,6 +720,7 @@ spec:
           transforms:
             - string:
                 fmt: allow-from-claim-namespace-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -43,6 +43,7 @@ spec:
           transforms:
             - string:
                 fmt: ns-observer-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
@@ -73,6 +74,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-redis-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
@@ -130,6 +132,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-connection'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -137,6 +140,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-redis-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -144,6 +148,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-connection'
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - combine:
@@ -159,6 +164,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-redis-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -166,6 +172,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-redis-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -173,6 +180,7 @@ spec:
           transforms:
             - string:
                 fmt: '%s-connection'
+                type: Format
               type: string
           type: FromCompositeFieldPath
     - base:
@@ -223,6 +231,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-redis-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]
@@ -230,6 +239,7 @@ spec:
           transforms:
             - string:
                 fmt: vshn-redis-%s
+                type: Format
               type: string
           type: FromCompositeFieldPath
         - fromFieldPath: metadata.labels[crossplane.io/composite]


### PR DESCRIPTION
Crossplane is a bit special with when it adds defaults to fields and when it doesn't.  This change should fix the ArgoCD sees because of set defaults.
## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
