### PR TITLE
Allow setting resource requests and limits separately for VshnPostgreSQL

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -105,10 +105,22 @@ type VSHNDBaaSSizeSpec struct {
 	// Memory defines the amount of memory in units of bytes for an instance.
 	Memory string `json:"memory,omitempty"`
 
+	// Requests defines CPU and memory requests for an instance
+	Requests VSHNDBaaSSizeRequestsSpec `json:"requests,omitempty"`
+
 	// +kubebuilder:default="5Gi"
 
 	// Disk defines the amount of disk space for an instance.
 	Disk string `json:"disk,omitempty"`
+}
+
+// VSHNDBaaSSizeRequestsSpec contains settings to control the resoure requests of a service.
+type VSHNDBaaSSizeRequestsSpec struct {
+	// CPU defines the amount of Kubernetes CPUs for an instance.
+	CPU string `json:"cpu,omitempty"`
+
+	// Memory defines the amount of memory in units of bytes for an instance.
+	Memory string `json:"memory,omitempty"`
 }
 
 // VSHNDBaaSNetworkSpec contains any network related settings.

--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -204,6 +204,10 @@ local sgInstanceProfile = {
                 spec: {
                   cpu: '',
                   memory: '',
+                  requests: {
+                    cpu: null,
+                    memory: null,
+                  },
                   containers: {
                     'backup.create-backup': {
                       cpu: '250m',
@@ -265,6 +269,8 @@ local sgInstanceProfile = {
 
     comp.FromCompositeFieldPath('spec.parameters.size.memory', 'spec.forProvider.manifest.spec.memory'),
     comp.FromCompositeFieldPath('spec.parameters.size.cpu', 'spec.forProvider.manifest.spec.cpu'),
+    comp.FromCompositeFieldPath('spec.parameters.size.requests.memory', 'spec.forProvider.manifest.spec.requests.memory'),
+    comp.FromCompositeFieldPath('spec.parameters.size.requests.cpu', 'spec.forProvider.manifest.spec.requests.cpu'),
   ],
 };
 
@@ -333,6 +339,10 @@ local sgCluster = {
                     persistentVolume: {
                       size: '',
                     },
+                  },
+                  nonProductionOptions: {
+                    enableSetPatroniCpuRequests: true,
+                    enableSetPatroniMemoryRequests: true,
                   },
                 },
               },

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -137,6 +137,16 @@ spec:
                           default: 3500Mi
                           description: Memory defines the amount of memory in units of bytes for an instance.
                           type: string
+                        requests:
+                          description: Requests defines CPU and memory requests for an instance
+                          properties:
+                            cpu:
+                              description: CPU defines the amount of Kubernetes CPUs for an instance.
+                              type: string
+                            memory:
+                              description: Memory defines the amount of memory in units of bytes for an instance.
+                              type: string
+                          type: object
                       type: object
                       default: {}
                   type: object

--- a/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -171,6 +171,19 @@ spec:
                           description: Memory defines the amount of memory in units
                             of bytes for an instance.
                           type: string
+                        requests:
+                          description: Requests defines CPU and memory requests for
+                            an instance
+                          properties:
+                            cpu:
+                              description: CPU defines the amount of Kubernetes CPUs
+                                for an instance.
+                              type: string
+                            memory:
+                              description: Memory defines the amount of memory in
+                                units of bytes for an instance.
+                              type: string
+                          type: object
                       type: object
                   type: object
               type: object

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -238,6 +238,9 @@ spec:
                     cpu: 100m
                     memory: 100Mi
                 memory: ''
+                requests:
+                  cpu: null
+                  memory: null
           providerConfigRef:
             name: kubernetes
       patches:
@@ -268,6 +271,12 @@ spec:
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.size.cpu
           toFieldPath: spec.forProvider.manifest.spec.cpu
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.requests.memory
+          toFieldPath: spec.forProvider.manifest.spec.requests.memory
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.requests.cpu
+          toFieldPath: spec.forProvider.manifest.spec.requests.cpu
           type: FromCompositeFieldPath
     - base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
@@ -331,6 +340,9 @@ spec:
                       sgObjectStorage: ''
                   sgPostgresConfig: ''
                 instances: 1
+                nonProductionOptions:
+                  enableSetPatroniCpuRequests: true
+                  enableSetPatroniMemoryRequests: true
                 pods:
                   persistentVolume:
                     size: ''

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -338,6 +338,9 @@ spec:
                     cpu: 100m
                     memory: 100Mi
                 memory: ''
+                requests:
+                  cpu: null
+                  memory: null
           providerConfigRef:
             name: kubernetes
       patches:
@@ -368,6 +371,12 @@ spec:
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.size.cpu
           toFieldPath: spec.forProvider.manifest.spec.cpu
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.requests.memory
+          toFieldPath: spec.forProvider.manifest.spec.requests.memory
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.requests.cpu
+          toFieldPath: spec.forProvider.manifest.spec.requests.cpu
           type: FromCompositeFieldPath
     - base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
@@ -431,6 +440,9 @@ spec:
                       sgObjectStorage: ''
                   sgPostgresConfig: ''
                 instances: 1
+                nonProductionOptions:
+                  enableSetPatroniCpuRequests: true
+                  enableSetPatroniMemoryRequests: true
                 pods:
                   persistentVolume:
                     size: ''


### PR DESCRIPTION
Currently, it's not possible to set resource requests to different values then the request limits.

This PR adds new parameters to be able to set the resource requests explicitly.

This resolves #87 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation. *Don't forget to generate the CRD API!*
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
