### PR TITLE
Add instance namespace permissions

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -50,7 +50,23 @@ local finalizerRole = kube.ClusterRole('crossplane:appcat:finalizer') {
 
 };
 
+local readServices = kube.ClusterRole('appcat:services:read') + {
+  rules+: [
+    {
+      apiGroups: [ '' ],
+      resources: [ 'pods', 'pods/log', 'pods/status', 'events', 'services' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
+    {
+      apiGroups: [ '' ],
+      resources: [ 'pods/portforward' ],
+      verbs: [ 'get', 'list', 'create' ],
+    },
+  ],
+};
+
 {
   '10_clusterrole_view': xrdBrowseRole,
   [if isOpenshift then '10_clusterrole_finalizer']: finalizerRole,
+  '10_clusterrole_services_read': readServices,
 }

--- a/component/provider.jsonnet
+++ b/component/provider.jsonnet
@@ -130,7 +130,7 @@ local controllerConfigRef(config) =
         },
         {
           apiGroups: [ '' ],
-          resources: [ 'namespaces', 'serviceaccounts', 'secrets' ],
+          resources: [ 'namespaces', 'serviceaccounts', 'secrets', 'pods', 'pods/log', 'pods/portforward', 'pods/status' ],
           verbs: [ 'get', 'list', 'watch', 'create', 'watch', 'patch', 'update', 'delete' ],
         },
         {

--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -857,6 +857,7 @@ local composition(restore=false) =
       resources: [
                    namespaceObserve,
                    namespaceConditions,
+                   comp.NamespacePermissions('vshn-postgresql'),
                    localca,
                    certificate,
                  ] +

--- a/component/vshn_redis.jsonnet
+++ b/component/vshn_redis.jsonnet
@@ -372,6 +372,7 @@ local composition =
             comp.FromCompositeFieldPath('metadata.labels[appuio.io/organization]', 'spec.forProvider.manifest.metadata.labels[appuio.io/organization]'),
           ],
         },
+        comp.NamespacePermissions('vshn-redis'),
         {
           base: selfSignedIssuer,
           patches: [

--- a/tests/golden/apiserver/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/apiserver/appcat/appcat/10_clusterrole_services_read.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-services-read
+  name: appcat:services:read
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/log
+      - pods/status
+      - events
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/portforward
+    verbs:
+      - get
+      - list
+      - create

--- a/tests/golden/cloudscale/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_clusterrole_services_read.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-services-read
+  name: appcat:services:read
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/log
+      - pods/status
+      - events
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/portforward
+    verbs:
+      - get
+      - list
+      - create

--- a/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -82,6 +82,10 @@ rules:
       - namespaces
       - serviceaccounts
       - secrets
+      - pods
+      - pods/log
+      - pods/portforward
+      - pods/status
     verbs:
       - get
       - list

--- a/tests/golden/defaults/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_clusterrole_services_read.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-services-read
+  name: appcat:services:read
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/log
+      - pods/status
+      - events
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/portforward
+    verbs:
+      - get
+      - list
+      - create

--- a/tests/golden/exoscale/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_clusterrole_services_read.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-services-read
+  name: appcat:services:read
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/log
+      - pods/status
+      - events
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/portforward
+    verbs:
+      - get
+      - list
+      - create

--- a/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -82,6 +82,10 @@ rules:
       - namespaces
       - serviceaccounts
       - secrets
+      - pods
+      - pods/log
+      - pods/portforward
+      - pods/status
     verbs:
       - get
       - list

--- a/tests/golden/openshift/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_clusterrole_services_read.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-services-read
+  name: appcat:services:read
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/log
+      - pods/status
+      - events
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/portforward
+    verbs:
+      - get
+      - list
+      - create

--- a/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
@@ -84,6 +84,10 @@ rules:
       - namespaces
       - serviceaccounts
       - secrets
+      - pods
+      - pods/log
+      - pods/portforward
+      - pods/status
     verbs:
       - get
       - list

--- a/tests/golden/vshn/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_clusterrole_services_read.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-services-read
+  name: appcat:services:read
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/log
+      - pods/status
+      - events
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/portforward
+    verbs:
+      - get
+      - list
+      - create

--- a/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
@@ -82,6 +82,10 @@ rules:
       - namespaces
       - serviceaccounts
       - secrets
+      - pods
+      - pods/log
+      - pods/portforward
+      - pods/status
     verbs:
       - get
       - list

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -92,6 +92,46 @@ spec:
     - base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
         kind: Object
+        spec:
+          forProvider:
+            manifest:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: RoleBinding
+              metadata:
+                name: appcat:services:read
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: appcat:services:read
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: Group
+                  name: organization
+          providerConfigRef:
+            name: kubernetes
+      patches:
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: metadata.name
+          transforms:
+            - string:
+                fmt: '%s-service-rolebinding'
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[appuio.io/organization]
+          toFieldPath: spec.forProvider.manifest.subjects[0].name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.manifest.metadata.namespace
+          transforms:
+            - string:
+                fmt: vshn-postgresql-%s
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+    - base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
         metadata: {}
         spec:
           forProvider:

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -92,6 +92,46 @@ spec:
     - base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
         kind: Object
+        spec:
+          forProvider:
+            manifest:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: RoleBinding
+              metadata:
+                name: appcat:services:read
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: appcat:services:read
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: Group
+                  name: organization
+          providerConfigRef:
+            name: kubernetes
+      patches:
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: metadata.name
+          transforms:
+            - string:
+                fmt: '%s-service-rolebinding'
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[appuio.io/organization]
+          toFieldPath: spec.forProvider.manifest.subjects[0].name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.manifest.metadata.namespace
+          transforms:
+            - string:
+                fmt: vshn-postgresql-%s
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+    - base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
         metadata: {}
         spec:
           forProvider:

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -89,6 +89,46 @@ spec:
     - base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
         kind: Object
+        spec:
+          forProvider:
+            manifest:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: RoleBinding
+              metadata:
+                name: appcat:services:read
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: appcat:services:read
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: Group
+                  name: organization
+          providerConfigRef:
+            name: kubernetes
+      patches:
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: metadata.name
+          transforms:
+            - string:
+                fmt: '%s-service-rolebinding'
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[appuio.io/organization]
+          toFieldPath: spec.forProvider.manifest.subjects[0].name
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.manifest.metadata.namespace
+          transforms:
+            - string:
+                fmt: vshn-redis-%s
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+    - base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
         metadata: {}
         spec:
           forProvider:


### PR DESCRIPTION
Adds permissions for the enduser to the instance namespaces.

With this the user can:

- view events
- do portforwardings to pods
- read pod logs

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation. *Don't forget to generate the CRD API!*
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
