### PR TITLE
Add plans for PostgreSQL by VSHN

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -96,12 +96,8 @@ type VSHNDBaaSMaintenanceScheduleSpec struct {
 
 // VSHNDBaaSSizeSpec contains settings to control the sizing of a service.
 type VSHNDBaaSSizeSpec struct {
-	// +kubebuilder:default="600m"
-
 	// CPU defines the amount of Kubernetes CPUs for an instance.
 	CPU string `json:"cpu,omitempty"`
-
-	// +kubebuilder:default="3500Mi"
 
 	// Memory defines the amount of memory in units of bytes for an instance.
 	Memory string `json:"memory,omitempty"`
@@ -109,10 +105,11 @@ type VSHNDBaaSSizeSpec struct {
 	// Requests defines CPU and memory requests for an instance
 	Requests VSHNDBaaSSizeRequestsSpec `json:"requests,omitempty"`
 
-	// +kubebuilder:default="5Gi"
-
 	// Disk defines the amount of disk space for an instance.
 	Disk string `json:"disk,omitempty"`
+
+	// Plan is the name of the resource plan that defines the compute resources.
+	Plan string `json:"plan,omitempty"`
 }
 
 // VSHNDBaaSSizeRequestsSpec contains settings to control the resoure requests of a service.

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -105,6 +105,27 @@ parameters:
           secretNamespace: ${appcat:services:vshn:secretNamespace}
           # Used for deploying jobs during restores
           controlNamespace: 'syn-appcat-control'
+
+          defaultPlan: standard-2
+          plans:
+            standard-2:
+              size:
+                enabled: true
+                cpu: "400m"
+                memory: "1728Mi"
+                disk: 20Gi
+            standard-4:
+              size:
+                enabled: true
+                cpu: "900m"
+                memory: "3776Mi"
+                disk: 40Gi
+            standard-8:
+              size:
+                enabled: true
+                cpu: "1900m"
+                memory: "7872Mi"
+                disk: 80Gi
         redis:
           enabled: true
           enableNetworkPolicy: true

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -126,16 +126,16 @@ spec:
                       description: Size contains settings to control the sizing of a service.
                       properties:
                         cpu:
-                          default: 600m
                           description: CPU defines the amount of Kubernetes CPUs for an instance.
                           type: string
                         disk:
-                          default: 5Gi
                           description: Disk defines the amount of disk space for an instance.
                           type: string
                         memory:
-                          default: 3500Mi
                           description: Memory defines the amount of memory in units of bytes for an instance.
+                          type: string
+                        plan:
+                          description: Plan is the name of the resource plan that defines the compute resources.
                           type: string
                         requests:
                           description: Requests defines CPU and memory requests for an instance

--- a/docs/modules/ROOT/pages/references/services-vshn.adoc
+++ b/docs/modules/ROOT/pages/references/services-vshn.adoc
@@ -73,6 +73,46 @@ Bucket endpoint, required for xObjectBucket and PostreSQL managed by VSHN backup
 * Exoscale
 ** 'https://sos-ch-gva-2.exo.io'
 
+=== `postgres.plan`
+type:: dict
+
+A dict of plans for PostgreSQL by VSHN.
+
+The key is the name of the plan.
+You can configure the CPU request through `size.cpu`, memory through `size.memory`, and disk size through `size.disk`.
+You can also set a node selector through `scheduling.nodeSelector`.
+
+There is also the option to specify a note in `note`, which will be added to the description of the field in the CRD.
+
+.Examples
+[source,yaml]
+----
+plans:
+  standard-2:
+    size:
+      cpu: "400m"
+      memory: "1728Mi"
+      disk: 20Gi
+  standard-4:
+    size:
+      cpu: "900m"
+      memory: "3776Mi"
+      disk: 40Gi
+  standard-8:
+    enabled: false
+  plus-4:
+    size: ${appcat:services:vshn:postgres:plans:standard-4:size}
+    scheduling:
+      nodeSelector:
+        appuio.io/node-class: "plus"
+    note: "Will be scheduled on APPUiO Cloud plus nodes"
+----
+
+=== `postgres.defaultPlan`
+type:: string
+default:: `standard-2`
+
+The default plan used for PostgreSQL by VSHN, if the service user doesn't specify a plan.
 
 == `redis`
 [horizontal]

--- a/lib/appcat-compositions.libsonnet
+++ b/lib/appcat-compositions.libsonnet
@@ -7,6 +7,7 @@ local fromCompositeFieldPath(from, to) = {
   toFieldPath: to,
 };
 
+
 local fromCompositeFieldPathWithTransform(from, to, prefix, suffix) = fromCompositeFieldPath(from, to) + {
   // this is an enhanced patch type with a transform function that adds the 3rd argument as a suffix
   transforms: [
@@ -42,6 +43,16 @@ local fromCompositeFieldPathWithTransformPrefix(from, to, prefix) = fromComposit
         fmt: prefix + '-%s',
         type: 'Format',
       },
+    },
+  ],
+};
+
+local fromCompositeFieldPathWithTransformMap(from, to, map) = fromCompositeFieldPath(from, to) + {
+  // this is an enhanced patch type with a transform function that maps values given the provided object
+  transforms: [
+    {
+      type: 'map',
+      map: map,
     },
   ],
 };
@@ -214,6 +225,8 @@ local namespacePermissions(namespacePrefix) = {
     commonResources[name],
   FromCompositeFieldPath(from, to):
     fromCompositeFieldPath(from, to),
+  FromCompositeFieldPathWithTransformMap(from, to, map):
+    fromCompositeFieldPathWithTransformMap(from, to, map),
   FromCompositeFieldPathWithTransformSuffix(from, to, suffix):
     fromCompositeFieldPathWithTransformSuffix(from, to, suffix),
   FromCompositeFieldPathWithTransformPrefix(from, to, prefix):

--- a/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -157,19 +157,36 @@ spec:
                         a service.
                       properties:
                         cpu:
-                          default: 600m
                           description: CPU defines the amount of Kubernetes CPUs for
                             an instance.
                           type: string
                         disk:
-                          default: 5Gi
                           description: Disk defines the amount of disk space for an
                             instance.
                           type: string
                         memory:
-                          default: 3500Mi
                           description: Memory defines the amount of memory in units
                             of bytes for an instance.
+                          type: string
+                        plan:
+                          default: standard-2
+                          description: |
+                            Plan is the name of the resource plan that defines the compute resources.
+
+                            The following plans are available:
+
+                              plus-2 - CPU: 400m; Memory: 1728Mi; Disk: 20Gi - Will be scheduled on APPUiO Cloud plus nodes
+
+                              plus-4 - CPU: 900m; Memory: 3776Mi; Disk: 40Gi - Will be scheduled on APPUiO Cloud plus nodes
+
+                              standard-2 - CPU: 400m; Memory: 1728Mi; Disk: 20Gi
+
+                              standard-4 - CPU: 900m; Memory: 3776Mi; Disk: 40Gi
+                          enum:
+                            - plus-2
+                            - plus-4
+                            - standard-2
+                            - standard-4
                           type: string
                         requests:
                           description: Requests defines CPU and memory requests for

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -308,6 +308,26 @@ spec:
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: spec.forProvider.manifest.metadata.name
           type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.manifest.spec.cpu
+          transforms:
+            - map:
+                plus-2: 400m
+                plus-4: 900m
+                standard-2: 400m
+                standard-4: 900m
+              type: map
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.manifest.spec.memory
+          transforms:
+            - map:
+                plus-2: 1728Mi
+                plus-4: 3776Mi
+                standard-2: 1728Mi
+                standard-4: 3776Mi
+              type: map
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.size.memory
           toFieldPath: spec.forProvider.manifest.spec.memory
           type: FromCompositeFieldPath
@@ -424,8 +444,30 @@ spec:
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: spec.forProvider.manifest.metadata.name
           type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.manifest.spec.pods.persistentVolume.size
+          transforms:
+            - map:
+                plus-2: 20Gi
+                plus-4: 40Gi
+                standard-2: 20Gi
+                standard-4: 40Gi
+              type: map
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.size.disk
           toFieldPath: spec.forProvider.manifest.spec.pods.persistentVolume.size
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.manifest.spec.pods.scheduling.nodeSelector
+          transforms:
+            - map:
+                plus-2:
+                  appuio.io/node-class: plus
+                plus-4:
+                  appuio.io/node-class: plus
+                standard-2: {}
+                standard-4: {}
+              type: map
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.scheduling.nodeSelector
           toFieldPath: spec.forProvider.manifest.spec.pods.scheduling.nodeSelector

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -388,6 +388,26 @@ spec:
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: spec.forProvider.manifest.metadata.name
           type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.manifest.spec.cpu
+          transforms:
+            - map:
+                plus-2: 400m
+                plus-4: 900m
+                standard-2: 400m
+                standard-4: 900m
+              type: map
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.manifest.spec.memory
+          transforms:
+            - map:
+                plus-2: 1728Mi
+                plus-4: 3776Mi
+                standard-2: 1728Mi
+                standard-4: 3776Mi
+              type: map
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.size.memory
           toFieldPath: spec.forProvider.manifest.spec.memory
           type: FromCompositeFieldPath
@@ -508,8 +528,30 @@ spec:
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: spec.forProvider.manifest.metadata.name
           type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.manifest.spec.pods.persistentVolume.size
+          transforms:
+            - map:
+                plus-2: 20Gi
+                plus-4: 40Gi
+                standard-2: 20Gi
+                standard-4: 40Gi
+              type: map
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.size.disk
           toFieldPath: spec.forProvider.manifest.spec.pods.persistentVolume.size
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.manifest.spec.pods.scheduling.nodeSelector
+          transforms:
+            - map:
+                plus-2:
+                  appuio.io/node-class: plus
+                plus-4:
+                  appuio.io/node-class: plus
+                standard-2: {}
+                standard-4: {}
+              type: map
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.scheduling.nodeSelector
           toFieldPath: spec.forProvider.manifest.spec.pods.scheduling.nodeSelector

--- a/tests/vshn.yml
+++ b/tests/vshn.yml
@@ -123,6 +123,21 @@ parameters:
         postgres:
           bucket_region: 'us-east-1'
           bucket_endpoint: 'http://minio-server.minio:9000'
+          plans:
+            standard-8:
+              enabled: false
+            plus-2:
+              size: ${appcat:services:vshn:postgres:plans:standard-2:size}
+              scheduling:
+                nodeSelector:
+                  appuio.io/node-class: "plus"
+              note: "Will be scheduled on APPUiO Cloud plus nodes"
+            plus-4:
+              size: ${appcat:services:vshn:postgres:plans:standard-4:size}
+              scheduling:
+                nodeSelector:
+                  appuio.io/node-class: "plus"
+              note: "Will be scheduled on APPUiO Cloud plus nodes"
       generic:
           objectstorage:
             enabled: true


### PR DESCRIPTION
This PR adds plans for PostgreSQL. See user documentation here: https://github.com/appuio/appcat-docs/pull/44

We don't add `plus-X` plans to the component default as it is specific to APPUiO Cloud. I'll add it in the cluster catalog.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation. *Don't forget to generate the CRD API!*
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
