### PR TITLE
Fix RBAC not being applied properly

### DIFF
--- a/component/provider.jsonnet
+++ b/component/provider.jsonnet
@@ -130,7 +130,7 @@ local controllerConfigRef(config) =
         },
         {
           apiGroups: [ '' ],
-          resources: [ 'namespaces', 'serviceaccounts', 'secrets', 'pods', 'pods/log', 'pods/portforward', 'pods/status' ],
+          resources: [ 'namespaces', 'serviceaccounts', 'secrets', 'pods', 'pods/log', 'pods/portforward', 'pods/status', 'services' ],
           verbs: [ 'get', 'list', 'watch', 'create', 'watch', 'patch', 'update', 'delete' ],
         },
         {

--- a/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -86,6 +86,7 @@ rules:
       - pods/log
       - pods/portforward
       - pods/status
+      - services
     verbs:
       - get
       - list

--- a/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -86,6 +86,7 @@ rules:
       - pods/log
       - pods/portforward
       - pods/status
+      - services
     verbs:
       - get
       - list

--- a/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
@@ -88,6 +88,7 @@ rules:
       - pods/log
       - pods/portforward
       - pods/status
+      - services
     verbs:
       - get
       - list

--- a/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
@@ -86,6 +86,7 @@ rules:
       - pods/log
       - pods/portforward
       - pods/status
+      - services
     verbs:
       - get
       - list


### PR DESCRIPTION
Provider-kubernetes can't apply the `services` permissions without holding it.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation. *Don't forget to generate the CRD API!*
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
