### PR TITLE
Reduce sidecar resource requests

### DIFF
--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -215,24 +215,24 @@ local sgInstanceProfile = {
                       memory: '256Mi',
                     },
                     'cluster-controller': {
-                      cpu: '100m',
-                      memory: '256Mi',
+                      cpu: '32m',
+                      memory: '188Mi',
                     },
                     envoy: {
-                      cpu: '100m',
+                      cpu: '32m',
                       memory: '64Mi',
                     },
                     pgbouncer: {
-                      cpu: '100m',
-                      memory: '64Mi',
+                      cpu: '16m',
+                      memory: '32Mi',
                     },
                     'postgres-util': {
-                      cpu: '100m',
-                      memory: '256Mi',
+                      cpu: '10m',
+                      memory: '4Mi',
                     },
                     'prometheus-postgres-exporter': {
-                      cpu: '100m',
-                      memory: '256Mi',
+                      cpu: '10m',
+                      memory: '32Mi',
                     },
                   },
                   initContainers: {

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -248,20 +248,20 @@ spec:
                     cpu: 250m
                     memory: 256Mi
                   cluster-controller:
-                    cpu: 100m
-                    memory: 256Mi
+                    cpu: 32m
+                    memory: 188Mi
                   envoy:
-                    cpu: 100m
+                    cpu: 32m
                     memory: 64Mi
                   pgbouncer:
-                    cpu: 100m
-                    memory: 64Mi
+                    cpu: 16m
+                    memory: 32Mi
                   postgres-util:
-                    cpu: 100m
-                    memory: 256Mi
+                    cpu: 10m
+                    memory: 4Mi
                   prometheus-postgres-exporter:
-                    cpu: 100m
-                    memory: 256Mi
+                    cpu: 10m
+                    memory: 32Mi
                 cpu: ''
                 initContainers:
                   cluster-reconciliation-cycle:

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -328,20 +328,20 @@ spec:
                     cpu: 250m
                     memory: 256Mi
                   cluster-controller:
-                    cpu: 100m
-                    memory: 256Mi
+                    cpu: 32m
+                    memory: 188Mi
                   envoy:
-                    cpu: 100m
+                    cpu: 32m
                     memory: 64Mi
                   pgbouncer:
-                    cpu: 100m
-                    memory: 64Mi
+                    cpu: 16m
+                    memory: 32Mi
                   postgres-util:
-                    cpu: 100m
-                    memory: 256Mi
+                    cpu: 10m
+                    memory: 4Mi
                   prometheus-postgres-exporter:
-                    cpu: 100m
-                    memory: 256Mi
+                    cpu: 10m
+                    memory: 32Mi
                 cpu: ''
                 initContainers:
                   cluster-reconciliation-cycle:


### PR DESCRIPTION
We significantly reduce the cpu and memory requests of sidcars after observing the actual usage in production

* **envoy**: Uses `30Mi` of RAM and `6m` CPU in prod. The container handles all connections so we should be a bit more consverative with reducing the requests. It should however be safe to reduce the CPU requests to `32m`. The container can still spike to the limit of `600m` if needed.
* **pgBouncer**: Uses less than `1m` of CPU and `3Mi` of memory. The container manages connection pooling so we should again be a bit more conservative. However it seems to be very efficient. It should be fine to reduce memory requests to `32Mi` and CPU requests to `16m`. The limit for CPU is at `600m` and for memory at `768Mi` so it should be able to safely burst.
* **posgtres-exporter**: The exporter uses `10Mi` of memory and about `1m` CPU. It isn't directly critical if the exporter fails. It should be safe to reduce the memory request to `32Mi` and the CPU request to `10m`(the minimum on APPUiO Cloud)
* **cluster-controller**: The controller uses `130Mi` of memory and about `4m` CPU. It has a fairly high memory usage and it's important that it keeps running. We should still be able to reduce the CPU and memory requests to `188Mi` and `32m`.
* **postgres-util**: Uses less than `1Mi`of memory and `1m` CPU. Only does a sleep and AFAICT is only meant to be used to manually run commands on. It should be safe to reduce requests to th minimum of `10m` CPU and `4Mi` of memory.

For the instance sizes we can expect these requests should be more than enough and as we still have very hight limits, the instance should be able to handle bursts without an issue.

I also did some stress test opening up to 400 connections sending a lot of `SELECT 1` queries (i.e. queries that should put load on the proxies but not on the actually DB). The memory usage for envoy and pgBouncer did not change significantly. Envoy used up to `40m` CPU and pgBouncer ~`15m`.

Will update documentation as part of plan introduction.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
