### PR TITLE
Add Prometheus rule for storage

### DIFF
--- a/component/provider.jsonnet
+++ b/component/provider.jsonnet
@@ -168,6 +168,11 @@ local controllerConfigRef(config) =
           resources: [ 'vshnpostgresqls' ],
           verbs: [ 'get' ],
         },
+        {
+          apiGroups: [ 'monitoring.coreos.com' ],
+          resources: [ 'prometheusrules' ],
+          verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
+        },
       ],
     };
     local rolebinding = kube.ClusterRoleBinding('crossplane:provider:provider-kubernetes:system:custom') {

--- a/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -183,6 +183,18 @@ rules:
       - vshnpostgresqls
     verbs:
       - get
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -183,6 +183,18 @@ rules:
       - vshnpostgresqls
     verbs:
       - get
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
@@ -185,6 +185,18 @@ rules:
       - vshnpostgresqls
     verbs:
       - get
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
@@ -183,6 +183,18 @@ rules:
       - vshnpostgresqls
     verbs:
       - get
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -991,6 +991,89 @@ spec:
         spec:
           forProvider:
             manifest:
+              apiVersion: monitoring.coreos.com/v1
+              kind: PrometheusRule
+              metadata:
+                name: postgresql-storage-rules
+              spec:
+                groups:
+                  - name: postgresql-storage
+                    rules:
+                      - alert: PostgreSQLPersistentVolumeFillingUp
+                        annotations:
+                          description: |-
+                            The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
+                                          }} in Namespace {{ $labels.namespace }} is only {{ $value |
+                                          humanizePercentage }} free.
+                          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumefillingup
+                          summary: PersistentVolume is filling up.
+                        expr: |-
+                          (
+                                      kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}
+                                        /
+                                      kubelet_volume_stats_capacity_bytes{job="kubelet", metrics_path="/metrics"}
+                                    ) < 0.03
+                                    and
+                                    kubelet_volume_stats_used_bytes{job="kubelet", metrics_path="/metrics"} > 0
+                                    unless on(namespace, persistentvolumeclaim)
+                                    kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+                                    unless on(namespace, persistentvolumeclaim)
+                                    kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+                        for: 1m
+                        labels:
+                          severity: critical
+                      - alert: PostgreSQLPersistentVolumeFillingUp
+                        annotations:
+                          description: |-
+                            Based on recent sampling, the PersistentVolume claimed by {{
+                                          $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace
+                                          }} is expected to fill up within four days. Currently {{ $value |
+                                          humanizePercentage }} is available.
+                          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumefillingup
+                          summary: PersistentVolume is filling up.
+                        expr: |-
+                          (
+                                      kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}
+                                        /
+                                      kubelet_volume_stats_capacity_bytes{job="kubelet", metrics_path="/metrics"}
+                                    ) < 0.15
+                                    and
+                                    kubelet_volume_stats_used_bytes{job="kubelet", metrics_path="/metrics"} > 0
+                                    and
+                                    predict_linear(kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+                                    unless on(namespace, persistentvolumeclaim)
+                                    kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+                                    unless on(namespace, persistentvolumeclaim)
+                                    kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+                        for: 1h
+                        labels:
+                          severity: warning
+          providerConfigRef:
+            name: kubernetes
+      patches:
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: metadata.name
+          transforms:
+            - string:
+                fmt: '%s-prometheusrule'
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.manifest.metadata.namespace
+          transforms:
+            - string:
+                fmt: vshn-postgresql-%s
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+    - base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata: {}
+        spec:
+          forProvider:
+            manifest:
               apiVersion: networking.k8s.io/v1
               kind: NetworkPolicy
               metadata: {}

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -1092,6 +1092,89 @@ spec:
         spec:
           forProvider:
             manifest:
+              apiVersion: monitoring.coreos.com/v1
+              kind: PrometheusRule
+              metadata:
+                name: postgresql-storage-rules
+              spec:
+                groups:
+                  - name: postgresql-storage
+                    rules:
+                      - alert: PostgreSQLPersistentVolumeFillingUp
+                        annotations:
+                          description: |-
+                            The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
+                                          }} in Namespace {{ $labels.namespace }} is only {{ $value |
+                                          humanizePercentage }} free.
+                          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumefillingup
+                          summary: PersistentVolume is filling up.
+                        expr: |-
+                          (
+                                      kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}
+                                        /
+                                      kubelet_volume_stats_capacity_bytes{job="kubelet", metrics_path="/metrics"}
+                                    ) < 0.03
+                                    and
+                                    kubelet_volume_stats_used_bytes{job="kubelet", metrics_path="/metrics"} > 0
+                                    unless on(namespace, persistentvolumeclaim)
+                                    kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+                                    unless on(namespace, persistentvolumeclaim)
+                                    kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+                        for: 1m
+                        labels:
+                          severity: critical
+                      - alert: PostgreSQLPersistentVolumeFillingUp
+                        annotations:
+                          description: |-
+                            Based on recent sampling, the PersistentVolume claimed by {{
+                                          $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace
+                                          }} is expected to fill up within four days. Currently {{ $value |
+                                          humanizePercentage }} is available.
+                          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumefillingup
+                          summary: PersistentVolume is filling up.
+                        expr: |-
+                          (
+                                      kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}
+                                        /
+                                      kubelet_volume_stats_capacity_bytes{job="kubelet", metrics_path="/metrics"}
+                                    ) < 0.15
+                                    and
+                                    kubelet_volume_stats_used_bytes{job="kubelet", metrics_path="/metrics"} > 0
+                                    and
+                                    predict_linear(kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+                                    unless on(namespace, persistentvolumeclaim)
+                                    kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+                                    unless on(namespace, persistentvolumeclaim)
+                                    kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+                        for: 1h
+                        labels:
+                          severity: warning
+          providerConfigRef:
+            name: kubernetes
+      patches:
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: metadata.name
+          transforms:
+            - string:
+                fmt: '%s-prometheusrule'
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.manifest.metadata.namespace
+          transforms:
+            - string:
+                fmt: vshn-postgresql-%s
+                type: Format
+              type: string
+          type: FromCompositeFieldPath
+    - base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        metadata: {}
+        spec:
+          forProvider:
+            manifest:
               apiVersion: networking.k8s.io/v1
               kind: NetworkPolicy
               metadata: {}


### PR DESCRIPTION
This will alert on PostgreSQL storage filling up.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation. *Don't forget to generate the CRD API!*
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
