### PR TITLE
Add plans for redis by VSHN

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_redis.go
+++ b/apis/vshn/v1/dbaas_vshn_redis.go
@@ -62,30 +62,24 @@ type VSHNRedisServiceSpec struct {
 
 // VSHNRedisSizeSpec contains settings to control the sizing of a service.
 type VSHNRedisSizeSpec struct {
-	// +kubebuilder:default="500m"
 
 	// CPURequests defines the requests amount of Kubernetes CPUs for an instance.
 	CPURequests string `json:"cpuRequests,omitempty"`
 
-	// +kubebuilder:default="500m"
-
 	// CPULimits defines the limits amount of Kubernetes CPUs for an instance.
 	CPULimits string `json:"cpuLimits,omitempty"`
-
-	// +kubebuilder:default="2048Mi"
 
 	// MemoryRequests defines the requests amount of memory in units of bytes for an instance.
 	MemoryRequests string `json:"memoryRequests,omitempty"`
 
-	// +kubebuilder:default="2048Mi"
-
 	// MemoryLimits defines the limits amount of memory in units of bytes for an instance.
 	MemoryLimits string `json:"memoryLimits,omitempty"`
 
-	// +kubebuilder:default="5Gi"
-
 	// Disk defines the amount of disk space for an instance.
 	Disk string `json:"disk,omitempty"`
+
+	// Plan is the name of the resource plan that defines the compute resources.
+	Plan string `json:"plan,omitempty"`
 }
 
 // VSHNRedisTLSSpec contains settings to control tls traffic of a service.

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -133,6 +133,39 @@ parameters:
           helmChartVersion: ${appcat:charts:redis:version}
           imageRegistry: ""
 
+          defaultPlan: standard-1
+          plans:
+            standard-512m:
+              size:
+                enabled: true
+                cpu: "125m"
+                memory: "512Mi"
+                disk: 16Gi
+            standard-1:
+              size:
+                enabled: true
+                cpu: "250m"
+                memory: "1Gi"
+                disk: 16Gi
+            standard-2:
+              size:
+                enabled: true
+                cpu: "500m"
+                memory: "2Gi"
+                disk: 16Gi
+            standard-4:
+              size:
+                enabled: true
+                cpu: "1"
+                memory: "4Gi"
+                disk: 16Gi
+            standard-8:
+              size:
+                enabled: true
+                cpu: "2"
+                memory: "8Gi"
+                disk: 16Gi
+
       # Config for exoscale composites
       exoscale:
         enabled: false

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -86,6 +86,18 @@ local mergeArgs(args, additional) =
   [ '%s=%s' % [ k, final[k] ] for k in std.objectFields(final) ];
 
 
+local filterDisabledParams(params) = std.foldl(
+  function(ps, key)
+    local p = params[key];
+    local enabled = p != null && p != {} && std.get(p, 'enabled', true);
+    ps {
+      [if enabled then key]: p,
+    },
+  std.objectFields(params),
+  {}
+);
+
+
 {
   SyncOptions: syncOptions,
   VshnMetaDBaaSExoscale(dbname):
@@ -96,4 +108,6 @@ local mergeArgs(args, additional) =
     mergeArgs(args, additional),
   VshnMetaVshn(dbname, flavor, offered='true'):
     vshnMetaVshn(dbname, flavor, offered),
+  FilterDisabledParams(params):
+    filterDisabledParams(params),
 }

--- a/crds/vshn.appcat.vshn.io_vshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnredis.yaml
@@ -62,24 +62,22 @@ spec:
                       description: Size contains settings to control the sizing of a service.
                       properties:
                         cpuLimits:
-                          default: 500m
                           description: CPULimits defines the limits amount of Kubernetes CPUs for an instance.
                           type: string
                         cpuRequests:
-                          default: 500m
                           description: CPURequests defines the requests amount of Kubernetes CPUs for an instance.
                           type: string
                         disk:
-                          default: 5Gi
                           description: Disk defines the amount of disk space for an instance.
                           type: string
                         memoryLimits:
-                          default: 2048Mi
                           description: MemoryLimits defines the limits amount of memory in units of bytes for an instance.
                           type: string
                         memoryRequests:
-                          default: 2048Mi
                           description: MemoryRequests defines the requests amount of memory in units of bytes for an instance.
+                          type: string
+                        plan:
+                          description: Plan is the name of the resource plan that defines the compute resources.
                           type: string
                       type: object
                       default: {}

--- a/docs/modules/ROOT/pages/references/services-vshn.adoc
+++ b/docs/modules/ROOT/pages/references/services-vshn.adoc
@@ -73,7 +73,7 @@ Bucket endpoint, required for xObjectBucket and PostreSQL managed by VSHN backup
 * Exoscale
 ** 'https://sos-ch-gva-2.exo.io'
 
-=== `postgres.plan`
+=== `postgres.plans`
 type:: dict
 
 A dict of plans for PostgreSQL by VSHN.
@@ -104,9 +104,10 @@ plans:
     size: ${appcat:services:vshn:postgres:plans:standard-4:size}
     scheduling:
       nodeSelector:
-        appuio.io/node-class: "plus"
+        appuio.io/node-class: "plus" <1>
     note: "Will be scheduled on APPUiO Cloud plus nodes"
 ----
+<1> See  https://docs.appuio.cloud/user/references/node-classes.html[Node Classes]
 
 === `postgres.defaultPlan`
 type:: string
@@ -129,3 +130,45 @@ type:: bool
 default:: `true`
 
 Whether to enable NetworkPolicy in the Redis instance namespace. This allows to establish connections from claim's namespace to the Redis instance.
+
+=== `redis.plans`
+type:: dict
+
+A dict of plans for Redis by VSHN.
+
+The key is the name of the plan.
+You can configure the CPU request through `size.cpu`, memory through `size.memory`, and disk size through `size.disk`.
+You can also set a node selector through `scheduling.nodeSelector`.
+
+There is also the option to specify a note in `note`, which will be added to the description of the field in the CRD.
+
+.Examples
+[source,yaml]
+----
+plans:
+  standard-2:
+    size:
+      cpu: "500m"
+      memory: "2Gi"
+      disk: 16Gi
+  standard-4:
+    size:
+      cpu: "1"
+      memory: "4Gi"
+      disk: 16Gi
+  standard-8:
+    enabled: false
+  plus-4:
+    size: ${appcat:services:vshn:redis:plans:standard-4:size}
+    scheduling:
+      nodeSelector:
+        appuio.io/node-class: "plus" <1>
+    note: "Will be scheduled on APPUiO Cloud plus nodes"
+----
+<1> See  https://docs.appuio.cloud/user/references/node-classes.html[Node Classes]
+
+=== `redis.defaultPlan`
+type:: string
+default:: `standard-1`
+
+The default plan used for Redis by VSHN, if the service user doesn't specify a plan.

--- a/tests/golden/vshn/appcat/appcat/20_xrd_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_xrd_vshn_redis.yaml
@@ -75,29 +75,56 @@ spec:
                         a service.
                       properties:
                         cpuLimits:
-                          default: 500m
                           description: CPULimits defines the limits amount of Kubernetes
                             CPUs for an instance.
                           type: string
                         cpuRequests:
-                          default: 500m
                           description: CPURequests defines the requests amount of
                             Kubernetes CPUs for an instance.
                           type: string
                         disk:
-                          default: 5Gi
                           description: Disk defines the amount of disk space for an
                             instance.
                           type: string
                         memoryLimits:
-                          default: 2048Mi
                           description: MemoryLimits defines the limits amount of memory
                             in units of bytes for an instance.
                           type: string
                         memoryRequests:
-                          default: 2048Mi
                           description: MemoryRequests defines the requests amount
                             of memory in units of bytes for an instance.
+                          type: string
+                        plan:
+                          default: standard-1
+                          description: |
+                            Plan is the name of the resource plan that defines the compute resources.
+
+                            The following plans are available:
+
+                              plus-1 - CPU: 250m; Memory: 1Gi; Disk: 16Gi - Will be scheduled on APPUiO Cloud plus nodes
+
+                              plus-2 - CPU: 500m; Memory: 2Gi; Disk: 16Gi - Will be scheduled on APPUiO Cloud plus nodes
+
+                              plus-4 - CPU: 1; Memory: 4Gi; Disk: 16Gi - Will be scheduled on APPUiO Cloud plus nodes
+
+                              plus-512m - CPU: 125m; Memory: 512Mi; Disk: 16Gi - Will be scheduled on APPUiO Cloud plus nodes
+
+                              standard-1 - CPU: 250m; Memory: 1Gi; Disk: 16Gi
+
+                              standard-2 - CPU: 500m; Memory: 2Gi; Disk: 16Gi
+
+                              standard-4 - CPU: 1; Memory: 4Gi; Disk: 16Gi
+
+                              standard-512m - CPU: 125m; Memory: 512Mi; Disk: 16Gi
+                          enum:
+                            - plus-1
+                            - plus-2
+                            - plus-4
+                            - plus-512m
+                            - standard-1
+                            - standard-2
+                            - standard-4
+                            - standard-512m
                           type: string
                       type: object
                     tls:

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -657,17 +657,87 @@ spec:
         - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
           toFieldPath: spec.forProvider.values.networkPolicy.ingressNSMatchLabels[kubernetes.io/metadata.name]
           type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.values.master.resources.requests.memory
+          transforms:
+            - map:
+                plus-1: 1Gi
+                plus-2: 2Gi
+                plus-4: 4Gi
+                plus-512m: 512Mi
+                standard-1: 1Gi
+                standard-2: 2Gi
+                standard-4: 4Gi
+                standard-512m: 512Mi
+              type: map
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.values.master.resources.limits.memory
+          transforms:
+            - map:
+                plus-1: 1Gi
+                plus-2: 2Gi
+                plus-4: 4Gi
+                plus-512m: 512Mi
+                standard-1: 1Gi
+                standard-2: 2Gi
+                standard-4: 4Gi
+                standard-512m: 512Mi
+              type: map
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.size.memoryRequests
           toFieldPath: spec.forProvider.values.master.resources.requests.memory
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.size.memoryLimits
           toFieldPath: spec.forProvider.values.master.resources.limits.memory
           type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.values.master.resources.requests.cpu
+          transforms:
+            - map:
+                plus-1: 250m
+                plus-2: 500m
+                plus-4: '1'
+                plus-512m: 125m
+                standard-1: 250m
+                standard-2: 500m
+                standard-4: '1'
+                standard-512m: 125m
+              type: map
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.values.master.resources.limits.cpu
+          transforms:
+            - map:
+                plus-1: 250m
+                plus-2: 500m
+                plus-4: '1'
+                plus-512m: 125m
+                standard-1: 250m
+                standard-2: 500m
+                standard-4: '1'
+                standard-512m: 125m
+              type: map
+          type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.size.cpuRequests
           toFieldPath: spec.forProvider.values.master.resources.requests.cpu
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.size.cpuLimits
           toFieldPath: spec.forProvider.values.master.resources.limits.cpu
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.values.master.persistence.size
+          transforms:
+            - map:
+                plus-1: 16Gi
+                plus-2: 16Gi
+                plus-4: 16Gi
+                plus-512m: 16Gi
+                standard-1: 16Gi
+                standard-2: 16Gi
+                standard-4: 16Gi
+                standard-512m: 16Gi
+              type: map
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.size.disk
           toFieldPath: spec.forProvider.values.master.persistence.size
@@ -677,6 +747,24 @@ spec:
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.tls.authClients
           toFieldPath: spec.forProvider.values.tls.authClients
+          type: FromCompositeFieldPath
+        - fromFieldPath: spec.parameters.size.plan
+          toFieldPath: spec.forProvider.values.master.nodeSelector
+          transforms:
+            - map:
+                plus-1:
+                  appuio.io/node-class: plus
+                plus-2:
+                  appuio.io/node-class: plus
+                plus-4:
+                  appuio.io/node-class: plus
+                plus-512m:
+                  appuio.io/node-class: plus
+                standard-1: {}
+                standard-2: {}
+                standard-4: {}
+                standard-512m: {}
+              type: map
           type: FromCompositeFieldPath
         - fromFieldPath: spec.parameters.scheduling.nodeSelector
           toFieldPath: spec.forProvider.values.master.nodeSelector

--- a/tests/vshn.yml
+++ b/tests/vshn.yml
@@ -138,6 +138,40 @@ parameters:
                 nodeSelector:
                   appuio.io/node-class: "plus"
               note: "Will be scheduled on APPUiO Cloud plus nodes"
+        redis:
+          plans:
+            standard-8:
+              enabled: false
+            plus-512m:
+              size: ${appcat:services:vshn:redis:plans:standard-512m:size}
+              scheduling:
+                nodeSelector:
+                  appuio.io/node-class: "plus"
+              note: "Will be scheduled on APPUiO Cloud plus nodes"
+            plus-1:
+              size: ${appcat:services:vshn:redis:plans:standard-1:size}
+              scheduling:
+                nodeSelector:
+                  appuio.io/node-class: "plus"
+              note: "Will be scheduled on APPUiO Cloud plus nodes"
+            plus-4:
+              size: ${appcat:services:vshn:redis:plans:standard-4:size}
+              scheduling:
+                nodeSelector:
+                  appuio.io/node-class: "plus"
+              note: "Will be scheduled on APPUiO Cloud plus nodes"
+            plus-2:
+              size: ${appcat:services:vshn:redis:plans:standard-2:size}
+              scheduling:
+                nodeSelector:
+                  appuio.io/node-class: "plus"
+              note: "Will be scheduled on APPUiO Cloud plus nodes"
+            plus-4:
+              size: ${appcat:services:vshn:redis:plans:standard-4:size}
+              scheduling:
+                nodeSelector:
+                  appuio.io/node-class: "plus"
+              note: "Will be scheduled on APPUiO Cloud plus nodes"
       generic:
           objectstorage:
             enabled: true


### PR DESCRIPTION
This PR adds plans for Redis by VSHN. It's very similar to https://github.com/vshn/component-appcat/pull/114 

PR for end-user documentation: https://github.com/appuio/appcat-docs/pull/45

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation. *Don't forget to generate the CRD API!*
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
