### PR TITLE
Fix outdated user docs url

### DIFF
--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -31,7 +31,7 @@ local vshnMetaDBaaSExoscale(dbname) = {
     annotations+: {
       'metadata.appcat.vshn.io/displayname': 'Exoscale ' + dbname,
       'metadata.appcat.vshn.io/description': dbname + ' DBaaS instances by Exoscale',
-      'metadata.appcat.vshn.io/end-user-docs-url': 'https://docs.appuio.cloud/appcat/exoscale-dbaas/' + std.asciiLower(dbname) + '/create.html',
+      'metadata.appcat.vshn.io/end-user-docs-url': 'https://vs.hn/exo-' + std.asciiLower(dbname),
       'metadata.appcat.vshn.io/zone': 'Exoscale zones: ' + strExoscaleZones,
       'metadata.appcat.vshn.io/product-description': 'https://products.docs.vshn.ch/products/appcat/exoscale_dbaas.html',
     },
@@ -47,7 +47,7 @@ local vshnMetaVshn(dbname, flavor, offered) = {
     annotations+: {
       'metadata.appcat.vshn.io/displayname': 'VSHN Managed ' + dbname,
       'metadata.appcat.vshn.io/description': dbname + ' instances by VSHN',
-      'metadata.appcat.vshn.io/end-user-docs-url': 'https://docs.appuio.cloud/appcat/vshn-dbaas/' + std.asciiLower(dbname) + '/create.html',
+      'metadata.appcat.vshn.io/end-user-docs-url': 'https://vs.hn/vshn-' + std.asciiLower(dbname),
       'metadata.appcat.vshn.io/zone': facts.region,
       'metadata.appcat.vshn.io/flavor': flavor,
       'metadata.appcat.vshn.io/product-description': 'https://products.docs.vshn.ch/products/appcat/' + std.asciiLower(dbname) + '.html',
@@ -64,7 +64,7 @@ local vshnMetaObjectStorage(provider) = {
     annotations+: {
       'metadata.appcat.vshn.io/displayname': provider + ' Object Storage',
       'metadata.appcat.vshn.io/description': 'S3 compatible object storage hosted by ' + provider,
-      'metadata.appcat.vshn.io/end-user-docs-url': 'https://docs.appuio.cloud/appcat/object-storage/create.html',
+      'metadata.appcat.vshn.io/end-user-docs-url': 'https://vs.hn/objstor',
       'metadata.appcat.vshn.io/zone': provider + ' zones: ' +
                                       if provider == 'Exoscale' then strExoscaleZones else strCloudscaleZones,
       'metadata.appcat.vshn.io/product-description': 'https://products.docs.vshn.ch/products/appcat/objectstorage.html',

--- a/tests/golden/cloudscale/appcat/appcat/21_composition_objectstorage_cloudscale.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/21_composition_objectstorage_cloudscale.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: S3 compatible object storage hosted by cloudscale.ch
     metadata.appcat.vshn.io/displayname: cloudscale.ch Object Storage
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/object-storage/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/objstor
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/objectstorage.html
     metadata.appcat.vshn.io/zone: 'cloudscale.ch zones: lpgandrma'
   labels:

--- a/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_kafka.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_kafka.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: Kafka DBaaS instances by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale Kafka
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/exoscale-dbaas/kafka/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/exo-kafka
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/exoscale_dbaas.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_mysql.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_mysql.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: MySQL DBaaS instances by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale MySQL
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/exoscale-dbaas/mysql/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/exo-mysql
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/exoscale_dbaas.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_opensearch.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_opensearch.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: OpenSearch DBaaS instances by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale OpenSearch
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/exoscale-dbaas/opensearch/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/exo-opensearch
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/exoscale_dbaas.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_postgres.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_postgres.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: PostgreSQL DBaaS instances by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale PostgreSQL
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/exoscale-dbaas/postgresql/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/exo-postgresql
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/exoscale_dbaas.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_redis.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_redis.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: Redis DBaaS instances by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale Redis
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/exoscale-dbaas/redis/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/exo-redis
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/exoscale_dbaas.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/exoscale/appcat/appcat/21_composition_objectstorage_exoscale.yaml
+++ b/tests/golden/exoscale/appcat/appcat/21_composition_objectstorage_exoscale.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: S3 compatible object storage hosted by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale Object Storage
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/object-storage/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/objstor
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/objectstorage.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/openshift/appcat/appcat/21_composition_exoscale_kafka.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_exoscale_kafka.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: Kafka DBaaS instances by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale Kafka
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/exoscale-dbaas/kafka/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/exo-kafka
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/exoscale_dbaas.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/openshift/appcat/appcat/21_composition_exoscale_mysql.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_exoscale_mysql.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: MySQL DBaaS instances by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale MySQL
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/exoscale-dbaas/mysql/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/exo-mysql
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/exoscale_dbaas.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/openshift/appcat/appcat/21_composition_exoscale_opensearch.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_exoscale_opensearch.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: OpenSearch DBaaS instances by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale OpenSearch
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/exoscale-dbaas/opensearch/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/exo-opensearch
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/exoscale_dbaas.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/openshift/appcat/appcat/21_composition_exoscale_postgres.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_exoscale_postgres.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: PostgreSQL DBaaS instances by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale PostgreSQL
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/exoscale-dbaas/postgresql/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/exo-postgresql
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/exoscale_dbaas.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/openshift/appcat/appcat/21_composition_exoscale_redis.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_exoscale_redis.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: Redis DBaaS instances by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale Redis
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/exoscale-dbaas/redis/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/exo-redis
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/exoscale_dbaas.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/openshift/appcat/appcat/21_composition_objectstorage_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_objectstorage_exoscale.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: S3 compatible object storage hosted by Exoscale
     metadata.appcat.vshn.io/displayname: Exoscale Object Storage
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/object-storage/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/objstor
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/objectstorage.html
     metadata.appcat.vshn.io/zone: 'Exoscale zones: de-fra-1, de-muc-1, at-vie-1, ch-gva-2,
       ch-dk-2, bg-sof-1'

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: PostgreSQL instances by VSHN
     metadata.appcat.vshn.io/displayname: VSHN Managed PostgreSQL
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/vshn-dbaas/postgresql/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/vshn-postgresql
     metadata.appcat.vshn.io/flavor: standalone
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/postgresql.html
     metadata.appcat.vshn.io/zone: rma1

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: PostgreSQLRestore instances by VSHN
     metadata.appcat.vshn.io/displayname: VSHN Managed PostgreSQLRestore
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/vshn-dbaas/postgresqlrestore/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/vshn-postgresqlrestore
     metadata.appcat.vshn.io/flavor: standalone
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/postgresqlrestore.html
     metadata.appcat.vshn.io/zone: rma1

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '10'
     metadata.appcat.vshn.io/description: Redis instances by VSHN
     metadata.appcat.vshn.io/displayname: VSHN Managed Redis
-    metadata.appcat.vshn.io/end-user-docs-url: https://docs.appuio.cloud/appcat/vshn-dbaas/redis/create.html
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/vshn-redis
     metadata.appcat.vshn.io/flavor: standalone
     metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/redis.html
     metadata.appcat.vshn.io/zone: rma1


### PR DESCRIPTION
The end user documentation has been moved to a new URL. We use this oportunity to switch the links to the docs to our short URLs on the `vs.hn domain.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation. *Don't forget to generate the CRD API!*
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
