### PR TITLE
Fix invalid composition naming

### DIFF
--- a/component/vshn_redis.jsonnet
+++ b/component/vshn_redis.jsonnet
@@ -357,6 +357,7 @@ local composition =
       writeConnectionSecretsToNamespace: redisParams.secretNamespace,
       resources: [
         {
+          name: 'ns-observer',
           base: namespace {
             spec+: {
               managementPolicy: 'Observe',
@@ -369,6 +370,7 @@ local composition =
           ],
         },
         {
+          name: 'namespace-conditions',
           base: namespace,
           patches: [
             comp.ToCompositeFieldPath('status.conditions', 'status.namespaceConditions'),
@@ -380,6 +382,7 @@ local composition =
         },
         comp.NamespacePermissions('vshn-redis'),
         {
+          name: 'self-signed-issuer',
           base: selfSignedIssuer,
           patches: [
             comp.ToCompositeFieldPath('status.conditions', 'status.selfSignedIssuerConditions'),
@@ -389,6 +392,7 @@ local composition =
           ],
         },
         {
+          name: 'local-ca',
           base: caIssuer,
           patches: [
             comp.ToCompositeFieldPath('status.conditions', 'status.localCAConditions'),
@@ -398,6 +402,7 @@ local composition =
           ],
         },
         {
+          name: 'certificate',
           base: caCertificate,
           patches: [
             comp.ToCompositeFieldPath('status.conditions', 'status.caCertificateConditions'),
@@ -408,6 +413,7 @@ local composition =
           ],
         },
         {
+          name: 'server-certificate',
           base: serverCertificate,
           patches: [
             comp.ToCompositeFieldPath('status.conditions', 'status.serverCertificateConditions'),
@@ -418,6 +424,7 @@ local composition =
           ],
         },
         {
+          name: 'client-certificate',
           base: clientCertificate,
           patches: [
             comp.ToCompositeFieldPath('status.conditions', 'status.clientCertificateConditions'),
@@ -428,6 +435,7 @@ local composition =
           ],
         },
         {
+          name: 'connection',
           base: secret,
           connectionDetails: comp.conn.AllFromSecretKeys(connectionSecretKeys),
           patches: [
@@ -445,6 +453,7 @@ local composition =
           ],
         },
         {
+          name: 'release',
           base: redisHelmChart,
           patches: [
             comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -38,6 +38,7 @@ spec:
           managementPolicy: Observe
           providerConfigRef:
             name: kubernetes
+      name: ns-observer
       patches:
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
@@ -70,6 +71,7 @@ spec:
                 name: ''
           providerConfigRef:
             name: kubernetes
+      name: namespace-conditions
       patches:
         - fromFieldPath: status.conditions
           toFieldPath: status.namespaceConditions
@@ -149,6 +151,7 @@ spec:
                   crlDistributionPoints: []
           providerConfigRef:
             name: kubernetes
+      name: self-signed-issuer
       patches:
         - fromFieldPath: status.conditions
           toFieldPath: status.selfSignedIssuerConditions
@@ -194,6 +197,7 @@ spec:
                   secretName: tls-ca-certificate
           providerConfigRef:
             name: kubernetes
+      name: local-ca
       patches:
         - fromFieldPath: status.conditions
           toFieldPath: status.localCAConditions
@@ -254,6 +258,7 @@ spec:
                     - vshn-appcat-ca
           providerConfigRef:
             name: kubernetes
+      name: certificate
       patches:
         - fromFieldPath: status.conditions
           toFieldPath: status.caCertificateConditions
@@ -325,6 +330,7 @@ spec:
                   - client auth
           providerConfigRef:
             name: kubernetes
+      name: server-certificate
       patches:
         - fromFieldPath: status.conditions
           toFieldPath: status.serverCertificateConditions
@@ -395,6 +401,7 @@ spec:
                   - client auth
           providerConfigRef:
             name: kubernetes
+      name: client-certificate
       patches:
         - fromFieldPath: status.conditions
           toFieldPath: status.clientCertificateConditions
@@ -504,6 +511,7 @@ spec:
         - fromConnectionSecretKey: REDIS_URL
           name: REDIS_URL
           type: FromConnectionSecretKey
+      name: connection
       patches:
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name
@@ -632,6 +640,7 @@ spec:
                 existingSecret: tls-server-certificate
           providerConfigRef:
             name: helm
+      name: release
       patches:
         - fromFieldPath: metadata.labels[crossplane.io/composite]
           toFieldPath: metadata.name


### PR DESCRIPTION
Crossplane does not allow to have some ressources named and some without names in the same composition.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation. *Don't forget to generate the CRD API!*
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
