### PR TITLE
Add Namespace field in objectreference

### DIFF
--- a/apis/v1/objectreference.go
+++ b/apis/v1/objectreference.go
@@ -8,5 +8,6 @@ package v1
 type LocalObjectReference struct {
 	// Name of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+	Name      string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
 }

--- a/apis/v1/objectreference.go
+++ b/apis/v1/objectreference.go
@@ -9,5 +9,5 @@ type LocalObjectReference struct {
 	// Name of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	Name      string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
-	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"`
 }

--- a/crds/appcat.vshn.io_objectbuckets.yaml
+++ b/crds/appcat.vshn.io_objectbuckets.yaml
@@ -67,6 +67,8 @@ spec:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
+                  namespace:
+                    type: string
                 type: object
                 x-kubernetes-map-type: atomic
             type: object

--- a/crds/exoscale.appcat.vshn.io_exoscalekafkas.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscalekafkas.yaml
@@ -122,6 +122,8 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                    namespace:
+                      type: string
                   type: object
                   x-kubernetes-map-type: atomic
               type: object

--- a/crds/exoscale.appcat.vshn.io_exoscalemysqls.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscalemysqls.yaml
@@ -129,6 +129,8 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                    namespace:
+                      type: string
                   type: object
                   x-kubernetes-map-type: atomic
               type: object

--- a/crds/exoscale.appcat.vshn.io_exoscaleopensearches.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscaleopensearches.yaml
@@ -130,6 +130,8 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                    namespace:
+                      type: string
                   type: object
                   x-kubernetes-map-type: atomic
               type: object

--- a/crds/exoscale.appcat.vshn.io_exoscalepostgresqls.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscalepostgresqls.yaml
@@ -129,6 +129,8 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                    namespace:
+                      type: string
                   type: object
                   x-kubernetes-map-type: atomic
               type: object

--- a/crds/exoscale.appcat.vshn.io_exoscaleredis.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscaleredis.yaml
@@ -113,6 +113,8 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                    namespace:
+                      type: string
                   type: object
                   x-kubernetes-map-type: atomic
               type: object

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -157,6 +157,8 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                    namespace:
+                      type: string
                   type: object
                   x-kubernetes-map-type: atomic
               type: object

--- a/crds/vshn.appcat.vshn.io_vshnredis.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnredis.yaml
@@ -102,6 +102,8 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                    namespace:
+                      type: string
                   type: object
                   x-kubernetes-map-type: atomic
               type: object


### PR DESCRIPTION

Why this change:
- when I deployed composition functions to openshift I discovered thanks to @glrf that we're missing Namespace field in struct which blocked creation of resurces -> reference to non existing field in composition && can't set it in claim because k8s doesn't know that field
