### PR TITLE
Add randomized default maintenance and backup schedules for PostgreSQL by VSHN

### DIFF
--- a/apis/vshn/v1/dbaas_vshn_postgresql.go
+++ b/apis/vshn/v1/dbaas_vshn_postgresql.go
@@ -90,14 +90,12 @@ type VSHNDBaaSSchedulingSpec struct {
 // VSHNDBaaSMaintenanceScheduleSpec contains settings to control the maintenance of an instance.
 type VSHNDBaaSMaintenanceScheduleSpec struct {
 	// +kubebuilder:validation:Enum=monday;tuesday;wednesday;thursday;friday;saturday;sunday
-	// +kubebuilder:default="tuesday"
 
 	// DayOfWeek specifies at which weekday the maintenance is held place.
 	// Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
 	DayOfWeek string `json:"dayOfWeek,omitempty"`
 
 	// +kubebuilder:validation:Pattern="^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$"
-	// +kubebuilder:default="22:30:00"
 
 	// TimeOfDay for installing updates in UTC.
 	// Format: "hh:mm:ss".
@@ -143,7 +141,6 @@ type VSHNDBaaSNetworkSpec struct {
 
 type VSHNPostgreSQLBackup struct {
 	// +kubebuilder:validation:Pattern=^(\*|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])|\*\/([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])) (\*|([0-9]|1[0-9]|2[0-3])|\*\/([0-9]|1[0-9]|2[0-3])) (\*|([1-9]|1[0-9]|2[0-9]|3[0-1])|\*\/([1-9]|1[0-9]|2[0-9]|3[0-1])) (\*|([1-9]|1[0-2])|\*\/([1-9]|1[0-2])) (\*|([0-6])|\*\/([0-6]))$
-	// +kubebuilder:default="0 22 * * *"
 	Schedule string `json:"schedule,omitempty"`
 
 	// +kubebuilder:validation:Pattern="^[1-9][0-9]*$"

--- a/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
+++ b/crds/vshn.appcat.vshn.io_vshnpostgresqls.yaml
@@ -43,7 +43,6 @@ spec:
                           type: integer
                           x-kubernetes-int-or-string: true
                         schedule:
-                          default: 0 22 * * *
                           pattern: ^(\*|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])|\*\/([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])) (\*|([0-9]|1[0-9]|2[0-3])|\*\/([0-9]|1[0-9]|2[0-3])) (\*|([1-9]|1[0-9]|2[0-9]|3[0-1])|\*\/([1-9]|1[0-9]|2[0-9]|3[0-1])) (\*|([1-9]|1[0-2])|\*\/([1-9]|1[0-2])) (\*|([0-6])|\*\/([0-6]))$
                           type: string
                       type: object
@@ -59,7 +58,6 @@ spec:
                       description: Maintenance contains settings to control the maintenance of an instance.
                       properties:
                         dayOfWeek:
-                          default: tuesday
                           description: DayOfWeek specifies at which weekday the maintenance is held place. Allowed values are [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
                           enum:
                             - monday
@@ -71,7 +69,6 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          default: "22:30:00"
                           description: 'TimeOfDay for installing updates in UTC. Format: "hh:mm:ss".'
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
                           type: string

--- a/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -52,7 +52,6 @@ spec:
                           type: integer
                           x-kubernetes-int-or-string: true
                         schedule:
-                          default: 0 22 * * *
                           pattern: ^(\*|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])|\*\/([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]))
                             (\*|([0-9]|1[0-9]|2[0-3])|\*\/([0-9]|1[0-9]|2[0-3])) (\*|([1-9]|1[0-9]|2[0-9]|3[0-1])|\*\/([1-9]|1[0-9]|2[0-9]|3[0-1]))
                             (\*|([1-9]|1[0-2])|\*\/([1-9]|1[0-2])) (\*|([0-6])|\*\/([0-6]))$
@@ -73,7 +72,6 @@ spec:
                         of an instance.
                       properties:
                         dayOfWeek:
-                          default: tuesday
                           description: DayOfWeek specifies at which weekday the maintenance
                             is held place. Allowed values are [monday, tuesday, wednesday,
                             thursday, friday, saturday, sunday]
@@ -87,7 +85,6 @@ spec:
                             - sunday
                           type: string
                         timeOfDay:
-                          default: '22:30:00'
                           description: 'TimeOfDay for installing updates in UTC. Format:
                             "hh:mm:ss".'
                           pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$


### PR DESCRIPTION
Enables the feature implemented in https://github.com/vshn/appcat-comp-functions/pull/20 by removing the defaults for the maintenance and backup schedule.

Slight documentation change in: https://github.com/vshn/appcat-user-docs/pull/54

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation. *Don't forget to generate the CRD API!*
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
