### PR TITLE
Add SLO for PostgreSQL by VSHN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ vendor/
 dependencies/
 hack/
 
+# sloth artifacts
+sloth-*-*-*
+sloth-input/
+sloth-output/

--- a/class/appcat.yml
+++ b/class/appcat.yml
@@ -11,6 +11,33 @@ parameters:
           - ${_base_directory}/component/app.jsonnet
         input_type: jsonnet
         output_path: apps/
+
+      - input_paths:
+          - ${_base_directory}/component/sloth-input.jsonnet
+        input_type: jsonnet
+        output_path: ${_base_directory}/sloth-input
+        output_type: yaml
+      - input_type: external
+        input_paths:
+          - /bin/mkdir
+        args:
+          - -p
+          - ${_base_directory}/sloth-output
+        output_path: .
+      - input_type: external
+        input_paths:
+          - appcat/run-sloth
+        output_path: .
+        env_vars:
+          SLOTH_VERSION: ${appcat:images:sloth:tag}
+        args:
+          - generate
+          - -i
+          - ${_base_directory}/sloth-input
+          - -o
+          - ${_base_directory}/sloth-output
+
+
       - input_paths:
           - ${_base_directory}/component/main.jsonnet
         input_type: jsonnet
@@ -43,3 +70,11 @@ parameters:
           INPUT_DIR: ${_base_directory}/.work/appcat_sli_exporter
         args:
           - \${compiled_target_dir}/appcat/sli_exporter
+
+
+
+      - input_paths:
+          - ${_base_directory}/sloth-input
+          - ${_base_directory}/sloth-output
+        input_type: remove
+        output_path: .

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -84,7 +84,9 @@ parameters:
           namespace: ${appcat:slos:namespace}
       alerting:
         labels:
-          syn_component: "appcat"
+          syn: "true"
+          syn_team: schedar
+          syn_component: appcat
           slo: "true"
         page_labels:
           severity: "critical"

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -29,6 +29,10 @@ parameters:
         registry: ghcr.io
         repository: vshn/appcat-sli-exporter
         tag: v0.1.1
+      sloth:
+        registry: ghcr.io
+        image: slok/sloth
+        tag: v0.11.0
 
     controller:
       enabled: false
@@ -78,6 +82,26 @@ parameters:
             memory: 300Mi
         kustomize_input:
           namespace: ${appcat:slos:namespace}
+      alerting:
+        labels:
+          syn_component: "appcat"
+          slo: "true"
+        page_labels:
+          severity: "critical"
+        ticket_labels:
+          severity: "warning"
+      vshn:
+        postgres:
+          uptime:
+            objective: 99.9
+            alerting:
+              page_alert:
+                # This should reduce non actionable alerts because of single instance restarts.
+                # The page alert looks (ammong other things) at the burn rate over the last 5min.
+                # If the alert is pending for more than 5m this indicates a real problem.
+                for: 6m
+              ticket_alert: {}
+
 
     providers:
       cloudscale:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,6 +1,7 @@
 local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+local slos = import 'slos.libsonnet';
 
 local inv = kap.inventory();
 local params = inv.parameters.appcat;
@@ -69,4 +70,8 @@ local readServices = kube.ClusterRole('appcat:services:read') + {
   '10_clusterrole_view': xrdBrowseRole,
   [if isOpenshift then '10_clusterrole_finalizer']: finalizerRole,
   '10_clusterrole_services_read': readServices,
+
+} + if params.slos.enabled then {
+  [if params.services.vshn.enabled && params.services.vshn.postgres.enabled then '90_slo_vshn_postgresql']: slos.Get('vshn-postgresql'),
 }
+else {}

--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -1,0 +1,84 @@
+// main template for openshift4-slos
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.appcat;
+
+
+local newSLO(name, group, sloParams) =
+  {
+    local slo = self,
+
+    name: name,
+    objective: sloParams.objective,
+    alerting: {
+      labels: params.slos.alerting.labels,
+      page_alert: {
+        labels: params.slos.alerting.page_labels,
+        annotations: {
+          [if std.objectHas(slo.alerting.page_alert, 'for') then 'for']: std.get(slo.alerting.page_alert, 'for'),
+        },
+      },
+      ticket_alert: {
+        labels: params.slos.alerting.ticket_labels,
+        annotations: {
+          [if std.objectHas(slo.alerting.ticket_alert, 'for') then 'for']: std.get(slo.alerting.ticket_alert, 'for'),
+          runbook_url: 'https://hub.syn.tools/appcat/runbooks/%s.html#%s' % [ group, name ],
+        },
+      },
+    } + com.makeMergeable(sloParams.alerting),
+  } + com.makeMergeable(
+    std.get(sloParams, 'sloth', default={})
+  );
+
+local prometheusRule(name) =
+  local slothRendered = std.parseJson(kap.yaml_load('%s/sloth-output/%s.yaml' % [ inv.parameters._base_directory, name ]));
+
+  local patchedRules = slothRendered {
+    groups: [
+      g {
+        rules: [ r {
+          [if std.objectHas(r, 'annotations') && std.objectHas(r.annotations, 'for') then 'for']: std.get(super.annotations, 'for'),
+        } for r in g.rules ],
+      }
+      for g in super.groups
+    ],
+  };
+
+  kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', kube.hyphenate(name)) {
+    metadata+: {
+      namespace: params.slos.namespace,
+    },
+    spec: patchedRules,
+  };
+
+{
+  slothInput: {
+    'vshn-postgresql': [
+      newSLO('uptime', 'vshn-postgresql', params.slos.vshn.postgres.uptime) {
+        description: 'Uptime SLO for PostgreSQL by VSHN',
+        sli: {
+          events: {
+            // The  0*rate(...) makes sure that the query reports an error rate for all instances, even if that instance has never produced a single error
+            error_query: 'sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[{{.window}}]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[{{.window}}]))  by (service, namespace, name)',
+            total_query: 'sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[{{.window}}])) by (service, namespace, name)',
+          },
+        },
+        alerting+: {
+          name: 'SLO_AppCat_VSHNPosgtreSQLUptime',
+          annotations+: {
+            summary: 'Probes to PostgreSQL by VSHN instance fail',
+          },
+          labels+: {
+            service: 'VSHNPostgreSQL',
+          },
+        },
+      },
+    ],
+  },
+  Get(name): prometheusRule(name),
+}

--- a/component/sloth-input.jsonnet
+++ b/component/sloth-input.jsonnet
@@ -1,0 +1,17 @@
+// main template for openshift4-slos
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local slos = import 'slos.libsonnet';
+
+
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.appcat;
+
+
+std.mapWithKey(function(name, obj) {
+  version: 'prometheus/v1',
+  service: 'appcat-' + name,
+  slos: obj,
+}, slos.slothInput)

--- a/docs/modules/ROOT/pages/references/slo-parameters.adoc
+++ b/docs/modules/ROOT/pages/references/slo-parameters.adoc
@@ -29,3 +29,71 @@ type:: dict
 
 The input passed to the Kustomize renderer.
 See https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/[the Kustomization File] for all available options.
+
+== `alerting.labels`
+[horizontal]
+type:: dict
+
+Labels that will be added to any SLO alerts.
+
+== `alerting.page_labels`
+[horizontal]
+type:: dict
+
+Labels that will be added to any critical SLO alerts.
+`page_alerts` are alerts are critical alerts for a high burn rate that require immediate attention.
+
+== `alerting.tickt_labels`
+[horizontal]
+type:: dict
+
+Labels that will be added to any non-crtiical SLO alerts.
+`ticket_alerts` are alerts are alerts for an elevated burn rate that might require attention, but aren’t urg
+
+== `vshn.postgres.uptime`
+
+Configuration of the PostgreSQL by VSHN uptime SLO.
+
+=== `vshn.postgres.uptime.objective`
+[horizontal]
+type:: float
+default:: 99.9
+
+The SLO objective in percentage between 0-100.
+
+=== `vshn.postgres.uptime.alerting.page_alert`
+[horizontal]
+type:: dict
+
+The alert configuration for `page_alerts`.
+Can be used add additional lables or annotations throght the `labels` or `annotations` key, disable the alert through the `disable` key, or delay emitting the alert throug the `for` key.
+
+=== `vshn.postgres.uptime.alerting.ticket_alert`
+[horizontal]
+type:: dict
+
+The alert configuration for `page_alerts`.
+Can be used add additional lables or annotations throght the `labels` or `annotations` key, disable the alert through the `disable` key, or delay emitting the alert throug the `for` key.
+
+
+.Example
+
+[source,yaml]
+----
+vshn:
+  postgres:
+    uptime:
+      objective: 81.9 <1>
+      alerting:
+        page_alert:
+          labels: <2>
+            foo: bar
+          for: 13m <3>
+        ticket_alert:
+          annotations: <4>
+            please: ignore
+----
+<1> Reduces the objective to 81.9%
+<2> Adds the label `foo: bar` to all page alerts
+<3> Only fires page alerts if they are pending for 13 minutes
+<4> Adds annotation `please: ignore` to all ticket alerts

--- a/docs/modules/ROOT/pages/references/slo-parameters.adoc
+++ b/docs/modules/ROOT/pages/references/slo-parameters.adoc
@@ -48,7 +48,7 @@ Labels that will be added to any critical SLO alerts.
 type:: dict
 
 Labels that will be added to any non-crtiical SLO alerts.
-`ticket_alerts` are alerts are alerts for an elevated burn rate that might require attention, but aren’t urg
+`ticket_alerts` are alerts for an elevated burn rate that might require attention, but aren’t urgent.
 
 == `vshn.postgres.uptime`
 
@@ -66,15 +66,14 @@ The SLO objective in percentage between 0-100.
 type:: dict
 
 The alert configuration for `page_alerts`.
-Can be used add additional lables or annotations throght the `labels` or `annotations` key, disable the alert through the `disable` key, or delay emitting the alert throug the `for` key.
+Can be used to add additional labels or annotations through `labels` or `annotations` key, disable the alert through the `disable` key, or delay emitting the alert through the `for` key.
 
 === `vshn.postgres.uptime.alerting.ticket_alert`
 [horizontal]
 type:: dict
 
-The alert configuration for `page_alerts`.
-Can be used add additional lables or annotations throght the `labels` or `annotations` key, disable the alert through the `disable` key, or delay emitting the alert throug the `for` key.
-
+The alert configuration for `ticket_alert`.
+Can be used to add additional labels or annotations through `labels` or `annotations` key, disable the alert through the `disable` key, or delay emitting the alert through the `for` key.
 
 .Example
 

--- a/docs/modules/ROOT/pages/runbooks/vshn-postgresql.adoc
+++ b/docs/modules/ROOT/pages/runbooks/vshn-postgresql.adoc
@@ -84,7 +84,7 @@ If they're running, check the logs if there are any obvious error messages
 
 [source,shell]
 ----
-kubectl --as cluster-admin -n $INSTANCE_NAMESPACE logs ${COMPOSITE}-0
+kubectl --as cluster-admin -n $INSTANCE_NAMESPACE sts/${COMPOSITE}
 ----
 
 If you can't see any pods at all, this might be a Stackgres operator issue.

--- a/docs/modules/ROOT/pages/runbooks/vshn-postgresql.adoc
+++ b/docs/modules/ROOT/pages/runbooks/vshn-postgresql.adoc
@@ -66,7 +66,7 @@ kubectl --as cluster-admin get object -l crossplane.io/composite=$COMPOSITE
 
 If any of them are not synced, describing them should point you in the right direction.
 
-Finally, it might also be helpful to look at the logs of various crossplane components in namespace `sny-crossplane`.
+Finally, it might also be helpful to look at the logs of various crossplane components in namespace `syn-crossplane`.
 
 ==== Debugging PostgreSQL Instance
 

--- a/docs/modules/ROOT/pages/runbooks/vshn-postgresql.adoc
+++ b/docs/modules/ROOT/pages/runbooks/vshn-postgresql.adoc
@@ -1,0 +1,125 @@
+= PostgreSQL by VSHN
+
+
+[[uptime]]
+== Uptime
+
+[IMPORTANT]
+We don't yet have a lot of operational experience with this service.
+If you received this alert, please add any insights you gained to improve this runbook.
+
+=== icon:glasses[] Overview
+
+The SLI measures the uptime of each PostgreSQL by VSHN instance.
+This SLI is measured by a prober that executes a SQL query every second.
+
+If this SLI results in an alert, it means that a significant number of SQL queries failed and that we risk missing the SLO.
+
+There are two types of alerts that fire if we expect to miss the configured objective.
+
+* A ticket alert means that the error rate is slightly higher than the objective.
+If we don't intervene at some point after receiving this alert, we can expect to miss the objective.
+However, no immediate, urgent action is necessary.
+A ticket alert should have a label `severity: warning`.
+* A page alert means that the error rate is significantly higher than the objective.
+Immediate action is necessary to not miss the objective.
+
+=== icon:bug[] Steps for debugging
+
+Failed probes can have a multitude of reasons, but in general there are two different kinds of issue clases.
+Either the instance itself is failing or provisioning or updating the instance failed.
+
+In any case, you should first figure out where the effected instance runs.
+The alert will provide you with three labels: `cluster_id`, `namespace`, and `name`.
+
+Connect to the Kubernetes cluster with the provided `cluster_id` and get the effected claim.
+
+[source,shell]
+----
+export NAMESPACE={{ namespace }}
+export NAME={{ name }}
+
+export COMPOSITE=$(kubectl -n $NAMESPACE get vshnpostgresql $NAME -o jsonpath="{.spec.resourceRef.name}")
+kubectl -n $NAMESPACE get vshnpostgresql $NAME
+----
+
+If the claim is not `SYNCED` this might indicate that there is an issue with provisioning.
+If it is synced there is most likely an issue with the instance itself, you can skip to the next subsection.
+
+==== Debugging Provisioning
+
+To figure out what went wrong with provisioning it usually helps to take a closer look at the composite.
+
+[source,shell]
+----
+kubectl --as cluster-admin describe xvshnpostgresql $COMPOSITE
+----
+
+If there are sync issues there usually are events that point to the root cause of the issue.
+
+Further it can help to look at the `Object` resources that are created for this instance.
+
+[source,shell]
+----
+kubectl --as cluster-admin get object -l crossplane.io/composite=$COMPOSITE
+----
+
+If any of them are not synced, describing them should point you in the right direction.
+
+Finally, it might also be helpful to look at the logs of various crossplane components in namespace `sny-crossplane`.
+
+==== Debugging PostgreSQL Instance
+
+If the instance is synced, but still not running, we'll need to look at the database pods themselves.
+
+First see if the pods are running.
+
+[source,shell]
+----
+export INSTANCE_NAMESPACE=$(kubectl -n $NAMESPACE get vshnpostgresql $NAME -o jsonpath="{.status.instanceNamespace}")
+kubectl --as cluster-admin -n $INSTANCE_NAMESPACE get pod
+----
+
+If they're running, check the logs if there are any obvious error messages
+
+[source,shell]
+----
+kubectl --as cluster-admin -n $INSTANCE_NAMESPACE logs ${COMPOSITE}-0
+----
+
+If you can't see any pods at all, this might be a Stackgres operator issue.
+Check the corresponding SGCluster resource.
+
+[source,shell]
+----
+kubectl --as cluster-admin -n $INSTANCE_NAMESPACE describe sgcluster ${COMPOSITE}
+----
+
+If there are no obvious errors, it might help to also look at the Stackgres operator logs.
+
+[source,shell]
+----
+kubectl -n syn-stackgres-operator logs deployments/stackgres-operator
+----
+
+=== icon:wrench[] Tune
+
+If this alert isn't actionable, noisy, or was raised too late you may want to tune the SLO.
+
+You have the option tune the SLO through the component parameters.
+You can modify the objective, disable the page or ticket alert, or completely disable the SLO.
+
+The example below will set the SLO set the objective to 99.25% and disable the page alert.
+
+[source,yaml]
+----
+appcat:
+  slos:
+    vshn:
+      postgresql:
+        uptime:
+          objective: 99.25
+          alerting:
+            page_alert:
+              enabled: false
+----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -23,3 +23,7 @@
 ** xref:references/services-exoscale.adoc[Exoscale Services]
 ** xref:references/services-vshn.adoc[VSHN Services]
 ** xref:references/service-objectstorage.adoc[Objectstorage Service]
+
+.Runbooks
+* xref:runbooks/vshn-postgresql.adoc[]
+

--- a/run-sloth
+++ b/run-sloth
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -eu
+
+basedir=$(dirname "$0")
+version="${SLOTH_VERSION:-v0.10.0}"
+
+ensure_sloth () {
+  set -eu
+
+  local dir="$1"
+  # Version with leading `v`.
+  local version="$2"
+
+  local arch
+  arch=$(uname -m)
+  case $arch in
+    aarch64|arm64) arch="arm64";;
+    x86_64|amd64) arch="amd64";;
+    *)
+      >&2 echo "Unsupported arch: $arch"
+      exit 5
+    ::
+  esac
+
+  local os
+  os=$(uname -s)
+  case $os in
+    Linux) os="linux";;
+    Darwin) os="darwin";;
+    *)
+      >&2 echo "Unsupported os: $os"
+      exit 5
+    ::
+  esac
+
+  if [ ! -x "${dir}/sloth-${version}-${os}-${arch}" ]; then
+    download_sloth "${dir}" "${version}" "${os}" "${arch}"
+  else
+    >&2 echo "sloth-${version}-${os}-${arch} already installed"
+  fi
+
+  echo "${dir}/sloth-${version}-${os}-${arch}"
+}
+
+download_sloth () {
+  set -eu
+
+  local dir="$1"
+  local version="$2"
+  local os="$3"
+  local arch="$4"
+
+  local url="https://github.com/slok/sloth/releases/download/${version}/sloth-${os}-${arch}"
+
+  >&2 echo "Downloading sloth-${version}-${os}-${arch} from ${url}"
+
+  curl -fsSLo "${dir}/sloth-${version}-${os}-${arch}" "${url}"
+  chmod +x "${dir}/sloth-${version}-${os}-${arch}"
+
+  >&2 echo "sloth-${version}-${os}-${arch} successfully installed"
+}
+
+sloth=$(ensure_sloth "$basedir" "$version")
+
+"$sloth" "$@"

--- a/run-sloth
+++ b/run-sloth
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# This script is used to download and run the Sloth tooling as part of the catalog compile step
+# Sloth (sloth.dev) is used to generate prometheus alerts and recording rules based on the SLO alerting standards defined in Google's SRE book
+
 set -eu
 
 basedir=$(dirname "$0")

--- a/tests/golden/vshn/appcat/appcat/90_slo_vshn_postgresql.yaml
+++ b/tests/golden/vshn/appcat/appcat/90_slo_vshn_postgresql.yaml
@@ -171,7 +171,9 @@ spec:
             severity: critical
             slo: 'true'
             sloth_severity: page
+            syn: 'true'
             syn_component: appcat
+            syn_team: schedar
         - alert: SLO_AppCat_VSHNPosgtreSQLUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-postgresql.html#uptime
@@ -195,4 +197,6 @@ spec:
             severity: warning
             slo: 'true'
             sloth_severity: ticket
+            syn: 'true'
             syn_component: appcat
+            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/90_slo_vshn_postgresql.yaml
+++ b/tests/golden/vshn/appcat/appcat/90_slo_vshn_postgresql.yaml
@@ -1,0 +1,198 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: vshn-postgresql
+  name: vshn-postgresql
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: sloth-slo-sli-recordings-appcat-vshn-postgresql-uptime
+      rules:
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[5m]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[5m]))  by (service, namespace, name))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[5m])) by (service, namespace, name))
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+            sloth_window: 5m
+          record: slo:sli_error:ratio_rate5m
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[30m]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[30m]))  by (service, namespace, name))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[30m])) by (service, namespace, name))
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+            sloth_window: 30m
+          record: slo:sli_error:ratio_rate30m
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[1h]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1h]))  by (service, namespace, name))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1h])) by (service, namespace, name))
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+            sloth_window: 1h
+          record: slo:sli_error:ratio_rate1h
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[2h]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[2h]))  by (service, namespace, name))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[2h])) by (service, namespace, name))
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+            sloth_window: 2h
+          record: slo:sli_error:ratio_rate2h
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[6h]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[6h]))  by (service, namespace, name))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[6h])) by (service, namespace, name))
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+            sloth_window: 6h
+          record: slo:sli_error:ratio_rate6h
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[1d]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1d]))  by (service, namespace, name))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1d])) by (service, namespace, name))
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+            sloth_window: 1d
+          record: slo:sli_error:ratio_rate1d
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[3d]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[3d]))  by (service, namespace, name))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[3d])) by (service, namespace, name))
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+            sloth_window: 3d
+          record: slo:sli_error:ratio_rate3d
+        - expr: |
+            sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"}[30d])
+            / ignoring (sloth_window)
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"}[30d])
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+            sloth_window: 30d
+          record: slo:sli_error:ratio_rate30d
+    - name: sloth-slo-meta-recordings-appcat-vshn-postgresql-uptime
+      rules:
+        - expr: vector(0.9990000000000001)
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+          record: slo:objective:ratio
+        - expr: vector(1-0.9990000000000001)
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+          record: slo:error_budget:ratio
+        - expr: vector(30)
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+          record: slo:time_period:days
+        - expr: |
+            slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"}
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+            slo:error_budget:ratio{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"}
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+          record: slo:current_burn_rate:ratio
+        - expr: |
+            slo:sli_error:ratio_rate30d{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"}
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+            slo:error_budget:ratio{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"}
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+          record: slo:period_burn_rate:ratio
+        - expr: 1 - slo:period_burn_rate:ratio{sloth_id="appcat-vshn-postgresql-uptime",
+            sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"}
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+          record: slo:period_error_budget_remaining:ratio
+        - expr: vector(1)
+          labels:
+            sloth_id: appcat-vshn-postgresql-uptime
+            sloth_mode: cli-gen-prom
+            sloth_objective: '99.9'
+            sloth_service: appcat-vshn-postgresql
+            sloth_slo: uptime
+            sloth_spec: prometheus/v1
+            sloth_version: v0.11.0
+          record: sloth_slo_info
+    - name: sloth-slo-alerts-appcat-vshn-postgresql-uptime
+      rules:
+        - alert: SLO_AppCat_VSHNPosgtreSQLUptime
+          annotations:
+            for: 6m
+            summary: Probes to PostgreSQL by VSHN instance fail
+            title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1h{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate30m{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (6 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate6h{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (6 * 0.0009999999999999432)) without (sloth_window)
+            )
+          for: 6m
+          labels:
+            service: VSHNPostgreSQL
+            severity: critical
+            slo: 'true'
+            sloth_severity: page
+            syn_component: appcat
+        - alert: SLO_AppCat_VSHNPosgtreSQLUptime
+          annotations:
+            runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-postgresql.html#uptime
+            summary: Probes to PostgreSQL by VSHN instance fail
+            title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate2h{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (3 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1d{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (3 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate6h{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
+            )
+          labels:
+            service: VSHNPostgreSQL
+            severity: warning
+            slo: 'true'
+            sloth_severity: ticket
+            syn_component: appcat


### PR DESCRIPTION
This PR adds the uptime SLO for VSHNPostgreSQL as well as base boilerplate to generate.

In detail this PR:

* Adds [Sloth](https://sloth.dev) as a dependency that is run as a compile step
* Uses metrics exposed by [the SLI Exporter](https://github.com/vshn/appcat-sli-exporter)
* Uses the added sloth to generate recording rules and alerts for PostgreSQL by VSHN based on Google's SLO implementation and [multi window multi burn alerts framework](https://landing.google.com/sre/workbook/chapters/alerting-on-slos/#6-multiwindow-multi-burn-rate-alerts).
* Adds a first iteration of a runbook that should help an engineer if he receives the alert.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation. *Don't forget to generate the CRD API!*
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
