### PR TITLE
Add OpenShift templates to AppCat

### DIFF
--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -32,7 +32,7 @@ JSONNET_DOCKER  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=json
 VALE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --volume "$${PWD}"/docs/modules:/pages docker.io/vshn/vale:2.1.1
 VALE_ARGS ?= --minAlertLevel=error --config=/pages/ROOT/pages/.vale.ini /pages
 
-ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 2020:2020 $(antora_git_volume) --volume "${PWD}/docs":/preview/antora/docs docker.io/vshn/antora-preview:3.0.1.1 --style=syn --antora=docs
+ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 2020:2020 $(antora_git_volume) --volume "${PWD}/docs":/preview/antora/docs ghcr.io/vshn/antora-preview:3.1.2.3 --style=syn --antora=docs
 
 COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projectsyn/commodore:latest
 COMPILE_CMD    ?= $(COMMODORE_CMD) component compile . $(commodore_args)

--- a/apis/exoscale/v1/dbaas_exoscale_kafka.go
+++ b/apis/exoscale/v1/dbaas_exoscale_kafka.go
@@ -67,7 +67,7 @@ type ExoscaleKafkaServiceSpec struct {
 	// KafkaSettings contains additional Kafka settings.
 	KafkaSettings runtime.RawExtension `json:"kafkaSettings,omitempty"`
 
-	// +kubebuilder:validation:Enum="3.3";"3.4"
+	// +kubebuilder:validation:Enum="3.4"
 	// +kubebuilder:default="3.4"
 
 	// Version contains the minor version for Kafka.

--- a/apis/exoscale/v1/dbaas_exoscale_kafka.go
+++ b/apis/exoscale/v1/dbaas_exoscale_kafka.go
@@ -67,11 +67,11 @@ type ExoscaleKafkaServiceSpec struct {
 	// KafkaSettings contains additional Kafka settings.
 	KafkaSettings runtime.RawExtension `json:"kafkaSettings,omitempty"`
 
-	// +kubebuilder:validation:Enum="3.2"
-	// +kubebuilder:default="3.2"
+	// +kubebuilder:validation:Enum="3.3";"3.4"
+	// +kubebuilder:default="3.4"
 
 	// Version contains the minor version for Kafka.
-	// Currently only "3.2" is supported. Leave it empty to always get the latest supported version.
+	// Currently only "3.4" is supported. Leave it empty to always get the latest supported version.
 	Version string `json:"version,omitempty"`
 }
 

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -97,6 +97,21 @@ local filterDisabledParams(params) = std.foldl(
   {}
 );
 
+local openShiftTemplate(name, displayName, description, iconClass, tags, message, provider, docs)
+      = kube._Object('template.openshift.io/v1', 'Template', name) + {
+  metadata+: {
+    annotations: {
+      'openshift.io/display-name': displayName,
+      description: description,
+      iconClass: iconClass,
+      tags: tags,
+      'openshift.io/provider-display-name': provider,
+      'openshift.io/documentation-url': docs,
+    },
+    namespace: 'openshift',
+  },
+  message: message,
+};
 
 {
   SyncOptions: syncOptions,
@@ -110,4 +125,6 @@ local filterDisabledParams(params) = std.foldl(
     vshnMetaVshn(dbname, flavor, offered),
   FilterDisabledParams(params):
     filterDisabledParams(params),
+  OpenShiftTemplate(name, displayName, description, iconClass, tags, message, provider, docs):
+    openShiftTemplate(name, displayName, description, iconClass, tags, message, provider, docs),
 }

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -107,6 +107,7 @@ local openShiftTemplate(name, displayName, description, iconClass, tags, message
       tags: tags,
       'openshift.io/provider-display-name': provider,
       'openshift.io/documentation-url': docs,
+      'openshift.io/support-url': 'https://www.vshn.ch/en/contact/',
     },
     namespace: 'openshift',
   },

--- a/component/exoscale_kafka.jsonnet
+++ b/component/exoscale_kafka.jsonnet
@@ -113,10 +113,10 @@ local templateMessage = 'Your Kafka by Exoscale instance is being provisioned, p
 
 local osTemplate =
   common.OpenShiftTemplate('kafkabyexoscale',
-                           'Kafka by Exoscale',
+                           'Kafka',
                            templateDescription,
-                           'icon-kafka',
-                           'database,nosql',
+                           'icon-other-unknown',
+                           'database,nosql,kafka',
                            templateMessage,
                            'Exoscale',
                            'https://vs.hn/exo-kafka') + {
@@ -126,7 +126,7 @@ local osTemplate =
     parameters: [
       {
         name: 'PLAN',
-        value: 'startup-4',
+        value: 'startup-2',
       },
       {
         name: 'SECRET_NAME',

--- a/component/exoscale_kafka.jsonnet
+++ b/component/exoscale_kafka.jsonnet
@@ -12,6 +12,8 @@ local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local kafkaParams = params.services.exoscale.kafka;
 
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+
 local connectionSecretKeys = [
   'KAFKA_URI',
   'KAFKA_HOST',
@@ -89,9 +91,60 @@ local composition =
     },
   };
 
+// OpenShift template configuration
+local templateObject = kube._Object('exoscale.appcat.vshn.io/v1', 'ExoscaleKafka', '${INSTANCE_NAME}') + {
+  spec: {
+    parameters: {
+      service: {
+        zone: '${ZONE}',
+      },
+      size: {
+        plan: '${PLAN}',
+      },
+    },
+    writeConnectionSecretToRef: {
+      name: '${SECRET_NAME}',
+    },
+  },
+};
+
+local templateDescription = 'Apache Kafka is an open-source distributed event streaming platform used by thousands of companies for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications.';
+local templateMessage = 'Your Kafka by Exoscale instance is being provisioned, please see ${SECRET_NAME} for access.';
+
+local osTemplate =
+  common.OpenShiftTemplate('kafkabyexoscale',
+                           'Kafka by Exoscale',
+                           templateDescription,
+                           'icon-kafka',
+                           'database,nosql',
+                           templateMessage,
+                           'Exoscale',
+                           'https://vs.hn/exo-kafka') + {
+    objects: [
+      templateObject,
+    ],
+    parameters: [
+      {
+        name: 'PLAN',
+        value: 'startup-4',
+      },
+      {
+        name: 'SECRET_NAME',
+        value: 'kafka-credentials',
+      },
+      {
+        name: 'INSTANCE_NAME',
+      },
+      {
+        name: 'ZONE',
+        value: 'ch-dk-2',
+      },
+    ],
+  };
 
 if params.services.exoscale.enabled && kafkaParams.enabled then {
   '20_xrd_exoscale_kafka': xrd,
   '20_rbac_exoscale_kafka': xrds.CompositeClusterRoles(xrd),
   '21_composition_exoscale_kafka': composition,
+  [if isOpenshift then '21_openshift_template_kafka_exoscale']: osTemplate,
 } else {}

--- a/component/exoscale_mysql.jsonnet
+++ b/component/exoscale_mysql.jsonnet
@@ -118,10 +118,10 @@ local templateMessage = 'Your MySQL by Exoscale instance is being provisioned, p
 
 local osTemplate =
   common.OpenShiftTemplate('mysqlbyexoscale',
-                           'MySQL by Exoscale',
+                           'MySQL',
                            templateDescription,
-                           'icon-mysql',
-                           'database,sql',
+                           'icon-mysql-database',
+                           'database,sql,mysql',
                            templateMessage,
                            'Exoscale',
                            'https://vs.hn/exo-mysql') + {

--- a/component/exoscale_opensearch.jsonnet
+++ b/component/exoscale_opensearch.jsonnet
@@ -117,10 +117,10 @@ local templateMessage = 'Your OpenSearch by Exoscale instance is being provision
 
 local osTemplate =
   common.OpenShiftTemplate('opensearchbyexoscale',
-                           'OpenSearch by Exoscale',
+                           'OpenSearch',
                            templateDescription,
-                           'icon-opensearch',
-                           'database,nosql',
+                           'icon-elastic',
+                           'database,nosql,opensearch,search',
                            templateMessage,
                            'Exoscale',
                            'https://vs.hn/exo-opensearch') + {

--- a/component/exoscale_postgres.jsonnet
+++ b/component/exoscale_postgres.jsonnet
@@ -12,6 +12,8 @@ local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local pgParams = params.services.exoscale.postgres;
 
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+
 local connectionSecretKeys = [
   'POSTGRESQL_URL',
   'POSTGRESQL_DB',
@@ -93,9 +95,65 @@ local composition =
     },
   };
 
+// OpenShift template configuration
+local templateObject = kube._Object('exoscale.appcat.vshn.io/v1', 'ExoscalePostgreSQL', '${INSTANCE_NAME}') + {
+  spec: {
+    parameters: {
+      service: {
+        majorVersion: '${MAJOR_VERSION}',
+        zone: '${ZONE}',
+      },
+      size: {
+        plan: '${PLAN}',
+      },
+    },
+    writeConnectionSecretToRef: {
+      name: '${SECRET_NAME}',
+    },
+  },
+};
+
+local templateDescription = 'PostgreSQL is a powerful, open source object-relational database system that uses and extends the SQL language combined with many features that safely store and scale the most complicated data workloads. The origins of PostgreSQL date back to 1986 as part of the POSTGRES project at the University of California at Berkeley and has more than 30 years of active development on the core platform.';
+local templateMessage = 'Your PostgreSQL by Exoscale instance is being provisioned, please see ${SECRET_NAME} for access.';
+
+local osTemplate =
+  common.OpenShiftTemplate('postgresqlbyexoscale',
+                           'PostgreSQL by Exoscale',
+                           templateDescription,
+                           'icon-postgresql',
+                           'database,sql',
+                           templateMessage,
+                           'Exoscale',
+                           'https://vs.hn/exo-postgresql') + {
+    objects: [
+      templateObject,
+    ],
+    parameters: [
+      {
+        name: 'PLAN',
+        value: 'startup-4',
+      },
+      {
+        name: 'SECRET_NAME',
+        value: 'postgresql-credentials',
+      },
+      {
+        name: 'INSTANCE_NAME',
+      },
+      {
+        name: 'MAJOR_VERSION',
+        value: '14',
+      },
+      {
+        name: 'ZONE',
+        value: 'ch-dk-2',
+      },
+    ],
+  };
 
 if params.services.exoscale.enabled && pgParams.enabled then {
   '20_xrd_exoscale_postgres': xrd,
   '20_rbac_exoscale_postgres': xrds.CompositeClusterRoles(xrd),
   '21_composition_exoscale_postgres': composition,
+  [if isOpenshift then '21_openshift_template_postgresql_exoscale']: osTemplate,
 } else {}

--- a/component/exoscale_postgres.jsonnet
+++ b/component/exoscale_postgres.jsonnet
@@ -118,10 +118,10 @@ local templateMessage = 'Your PostgreSQL by Exoscale instance is being provision
 
 local osTemplate =
   common.OpenShiftTemplate('postgresqlbyexoscale',
-                           'PostgreSQL by Exoscale',
+                           'PostgreSQL',
                            templateDescription,
                            'icon-postgresql',
-                           'database,sql',
+                           'database,sql,postgresql',
                            templateMessage,
                            'Exoscale',
                            'https://vs.hn/exo-postgresql') + {

--- a/component/exoscale_redis.jsonnet
+++ b/component/exoscale_redis.jsonnet
@@ -109,7 +109,7 @@ local templateMessage = 'Your Redis by Exoscale instance is being provisioned, p
 
 local osTemplate =
   common.OpenShiftTemplate('redisbyexoscale',
-                           'Redis by Exoscale',
+                           'Redis',
                            templateDescription,
                            'icon-redis',
                            'database,nosql',

--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -1087,10 +1087,10 @@ local templateMessage = 'Your PostgreSQL by VSHN instance is being provisioned, 
 
 local osTemplate =
   common.OpenShiftTemplate('postgresqlbyvshn',
-                           'PostgreSQL by VSHN',
+                           'PostgreSQL',
                            templateDescription,
                            'icon-postgresql',
-                           'database,sql',
+                           'database,sql,postgresql',
                            templateMessage,
                            'VSHN',
                            'https://vs.hn/vshn-postgresql') + {

--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -21,6 +21,8 @@ local certificateSecretName = 'tls-certificate';
 local serviceNameLabelKey = 'appcat.vshn.io/servicename';
 local serviceNamespaceLabelKey = 'appcat.vshn.io/claim-namespace';
 
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+
 // Filter out disabled plans
 local pgPlans = common.FilterDisabledParams(pgParams.plans);
 
@@ -1063,6 +1065,57 @@ local composition(restore=false) =
 local defaultComp = composition();
 local restoreComp = composition(true);
 
+// OpenShift template configuration
+local templateObject = kube._Object('vshn.appcat.vshn.io/v1', 'VSHNPostgreSQL', '${INSTANCE_NAME}') + {
+  spec: {
+    parameters: {
+      service: {
+        majorVersion: '${MAJOR_VERSION}',
+      },
+      size: {
+        plan: '${PLAN}',
+      },
+    },
+    writeConnectionSecretToRef: {
+      name: '${SECRET_NAME}',
+    },
+  },
+};
+
+local templateDescription = 'PostgreSQL is a powerful, open source object-relational database system that uses and extends the SQL language combined with many features that safely store and scale the most complicated data workloads. The origins of PostgreSQL date back to 1986 as part of the POSTGRES project at the University of California at Berkeley and has more than 30 years of active development on the core platform.';
+local templateMessage = 'Your PostgreSQL by VSHN instance is being provisioned, please see ${SECRET_NAME} for access.';
+
+local osTemplate =
+  common.OpenShiftTemplate('postgresqlbyvshn',
+                           'PostgreSQL by VSHN',
+                           templateDescription,
+                           'icon-postgresql',
+                           'database,sql',
+                           templateMessage,
+                           'VSHN',
+                           'https://vs.hn/vshn-postgresql') + {
+    objects: [
+      templateObject,
+    ],
+    parameters: [
+      {
+        name: 'PLAN',
+        value: 'standard-4',
+      },
+      {
+        name: 'SECRET_NAME',
+        value: 'postgresql-credentials',
+      },
+      {
+        name: 'INSTANCE_NAME',
+      },
+      {
+        name: 'MAJOR_VERSION',
+        value: '15',
+      },
+    ],
+  };
+
 if params.services.vshn.enabled && pgParams.enabled then
   assert std.length(pgParams.bucket_region) != 0 : 'appcat.services.vshn.postgres.bucket_region is empty';
   assert std.length(pgParams.bucket_endpoint) != 0 : 'appcat.services.vshn.postgres.bucket_endpoint is empty';
@@ -1073,4 +1126,5 @@ if params.services.vshn.enabled && pgParams.enabled then
     '20_namespace_vshn_control': controlNamespace,
     '21_composition_vshn_postgres': defaultComp,
     '21_composition_vshn_postgresrestore': restoreComp,
+    [if isOpenshift then '21_openshift_template_postgresql_vshn']: osTemplate,
   } else {}

--- a/component/vshn_redis.jsonnet
+++ b/component/vshn_redis.jsonnet
@@ -515,7 +515,7 @@ local templateMessage = 'Your Redis by VSHN instance is being provisioned, pleas
 
 local osTemplate =
   common.OpenShiftTemplate('redisbyvshn',
-                           'Redis by VSHN',
+                           'Redis',
                            templateDescription,
                            'icon-redis',
                            'database,nosql',

--- a/crds/exoscale.appcat.vshn.io_exoscalekafkas.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscalekafkas.yaml
@@ -90,7 +90,6 @@ spec:
                           default: "3.4"
                           description: Version contains the minor version for Kafka. Currently only "3.4" is supported. Leave it empty to always get the latest supported version.
                           enum:
-                            - "3.3"
                             - "3.4"
                           type: string
                         zone:

--- a/crds/exoscale.appcat.vshn.io_exoscalekafkas.yaml
+++ b/crds/exoscale.appcat.vshn.io_exoscalekafkas.yaml
@@ -87,10 +87,11 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         version:
-                          default: "3.2"
-                          description: Version contains the minor version for Kafka. Currently only "3.2" is supported. Leave it empty to always get the latest supported version.
+                          default: "3.4"
+                          description: Version contains the minor version for Kafka. Currently only "3.4" is supported. Leave it empty to always get the latest supported version.
                           enum:
-                            - "3.2"
+                            - "3.3"
+                            - "3.4"
                           type: string
                         zone:
                           default: ch-gva-2

--- a/docs/modules/ROOT/pages/explanations/add-to-openshift-catalog.adoc
+++ b/docs/modules/ROOT/pages/explanations/add-to-openshift-catalog.adoc
@@ -1,0 +1,98 @@
+= Add a service to the OpenShift catalog
+
+There's a function in the common library that helps to create an OpenShift template.
+The function will ensure that all necessary metadata is set for the template.
+
+== Set the template metadata
+
+[source,jsonnet]
+----
+local osTemplate =
+  common.OpenShiftTemplate('postgresqlbyvshn', <1>
+                           'PostgreSQL', <2>
+                           templateDescription, <3>
+                           'icon-postgresql', <4>
+                           'database,sql,postgresql', <5>
+                           templateMessage, <6>
+                           'VSHN', <7>
+                           'https://vs.hn/vshn-postgresql') <8>
+----
+<1> Objectname of the tempalte. All these objects are deployed to the `openshift` namespace. So make sure this name doesn't collide with any other template. Use the `$servicenameby$provider` naming scheme to avoid collisons.
+<2> DisplayName of the template. This is the name shown in the OpenShift console.
+<3> Description of the service, a description what this service is. Can usually be copied from https://products.vshn.ch/appcat/services_index.html[the product docs].
+<4> Icon class, the icon can be chosen from predefined ones. See this list https://docs.openshift.com/container-platform/4.11/openshift_images/using-templates.html#templates-writing-description_using-templates[here].
+<5> Tags, various tags that can be set. For some of the tags there are predefined filters in the OpenShift console.
+<6> Template message, a message that is shown after the template is applied. It's only shown if the template is applied via the CLI.
+<7> Provider name, this can be set to the name of the provider that provides this service. For example VSHN or Exoscale.
+<8> Docs link, this should point to the docs of this specific service.
+
+== Add the actual template
+
+To add the actual template part, you need to add fields to the template
+
+[source,jsonnet]
+----
+local templateObject = kube._Object('vshn.appcat.vshn.io/v1', 'VSHNPostgreSQL', '${INSTANCE_NAME}') + { <1>
+  spec: {
+    parameters: {
+      service: {
+        majorVersion: '${MAJOR_VERSION}',
+      },
+      size: {
+        plan: '${PLAN}',
+      },
+    },
+    writeConnectionSecretToRef: {
+      name: '${SECRET_NAME}',
+    },
+  },
+};
+
+local osTemplate =
+  common.OpenShiftTemplate(...)  + {
+    objects: [
+      templateObject, <1>
+    ],
+    parameters: [ <2>
+      {
+        name: 'PLAN',
+        value: 'standard-4',
+      },
+      {
+        name: 'SECRET_NAME',
+        value: 'postgresql-credentials',
+      },
+      {
+        name: 'INSTANCE_NAME',
+      },
+      {
+        name: 'MAJOR_VERSION',
+        value: '15',
+      },
+    ],
+  }
+----
+<1> The actual template, this is just a normal claim with some variable placeholders. Each tempalte could hold multiple objects to template.
+<2> Parameters define the user input and will be placed in the variable placeholders specified in the object. If the `value` field is provided then it's set a default and can be overwriten by the user.
+
+Currently we expose these parameters for each service:
+
+* PLAN: with the same default as in the CRD
+* SECRET_NAME: Crossplane's `writeConnectionSecretToRef` field
+* INSTANCE_NAME: name of the claim. It should not have a default.
+* MAJOR_VERSION or VERSION: depending on the service we expose only the major version or a specific version.
+
+== Render it
+
+Finally, we need to render it, but only on OpenShift.
+
+[source,jsonnet]
+----
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+
+{
+  '20_xrd_vshn_postgres': xrd,
+  ...
+  [if isOpenshift then '21_openshift_template_postgresql_vshn']: osTemplate,
+}
+----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -3,6 +3,7 @@
 .Explanations
 * xref:explanations/crossplane-secrets-non-provider.adoc[Manage secrets not coming from a provider]
 * xref:explanations/restore.adoc[]
+* xref:explanations/add-to-openshift-catalog.adoc[]
 
 .Tutorials
 * xref:tutorials/install-cloudscale.adoc[Install Cloudscale Stack]

--- a/tests/golden/exoscale/appcat/appcat/20_xrd_exoscale_kafka.yaml
+++ b/tests/golden/exoscale/appcat/appcat/20_xrd_exoscale_kafka.yaml
@@ -104,7 +104,6 @@ spec:
                             Currently only "3.4" is supported. Leave it empty to always
                             get the latest supported version.
                           enum:
-                            - '3.3'
                             - '3.4'
                           type: string
                         zone:

--- a/tests/golden/exoscale/appcat/appcat/20_xrd_exoscale_kafka.yaml
+++ b/tests/golden/exoscale/appcat/appcat/20_xrd_exoscale_kafka.yaml
@@ -99,12 +99,13 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         version:
-                          default: '3.2'
+                          default: '3.4'
                           description: Version contains the minor version for Kafka.
-                            Currently only "3.2" is supported. Leave it empty to always
+                            Currently only "3.4" is supported. Leave it empty to always
                             get the latest supported version.
                           enum:
-                            - '3.2'
+                            - '3.3'
+                            - '3.4'
                           type: string
                         zone:
                           default: ch-gva-2

--- a/tests/golden/openshift/appcat/appcat/20_xrd_exoscale_kafka.yaml
+++ b/tests/golden/openshift/appcat/appcat/20_xrd_exoscale_kafka.yaml
@@ -104,7 +104,6 @@ spec:
                             Currently only "3.4" is supported. Leave it empty to always
                             get the latest supported version.
                           enum:
-                            - '3.3'
                             - '3.4'
                           type: string
                         zone:

--- a/tests/golden/openshift/appcat/appcat/20_xrd_exoscale_kafka.yaml
+++ b/tests/golden/openshift/appcat/appcat/20_xrd_exoscale_kafka.yaml
@@ -99,12 +99,13 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         version:
-                          default: '3.2'
+                          default: '3.4'
                           description: Version contains the minor version for Kafka.
-                            Currently only "3.2" is supported. Leave it empty to always
+                            Currently only "3.4" is supported. Leave it empty to always
                             get the latest supported version.
                           enum:
-                            - '3.2'
+                            - '3.3'
+                            - '3.4'
                           type: string
                         zone:
                           default: ch-gva-2

--- a/tests/golden/openshift/appcat/appcat/21_openshift_template_kafka_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_openshift_template_kafka_exoscale.yaml
@@ -7,11 +7,12 @@ metadata:
     description: Apache Kafka is an open-source distributed event streaming platform
       used by thousands of companies for high-performance data pipelines, streaming
       analytics, data integration, and mission-critical applications.
-    iconClass: icon-kafka
-    openshift.io/display-name: Kafka by Exoscale
+    iconClass: icon-amq
+    openshift.io/display-name: Kafka
     openshift.io/documentation-url: https://vs.hn/exo-kafka
     openshift.io/provider-display-name: Exoscale
-    tags: database,nosql
+    openshift.io/support-url: https://www.vshn.ch/en/contact/
+    tags: database,nosql,kafka
   labels:
     name: kafkabyexoscale
   name: kafkabyexoscale

--- a/tests/golden/openshift/appcat/appcat/21_openshift_template_kafka_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_openshift_template_kafka_exoscale.yaml
@@ -7,7 +7,7 @@ metadata:
     description: Apache Kafka is an open-source distributed event streaming platform
       used by thousands of companies for high-performance data pipelines, streaming
       analytics, data integration, and mission-critical applications.
-    iconClass: icon-amq
+    iconClass: icon-other-unknown
     openshift.io/display-name: Kafka
     openshift.io/documentation-url: https://vs.hn/exo-kafka
     openshift.io/provider-display-name: Exoscale
@@ -35,7 +35,7 @@ objects:
         name: ${SECRET_NAME}
 parameters:
   - name: PLAN
-    value: startup-4
+    value: startup-2
   - name: SECRET_NAME
     value: kafka-credentials
   - name: INSTANCE_NAME

--- a/tests/golden/openshift/appcat/appcat/21_openshift_template_kafka_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_openshift_template_kafka_exoscale.yaml
@@ -1,0 +1,42 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+message: Your Kafka by Exoscale instance is being provisioned, please see ${SECRET_NAME}
+  for access.
+metadata:
+  annotations:
+    description: Apache Kafka is an open-source distributed event streaming platform
+      used by thousands of companies for high-performance data pipelines, streaming
+      analytics, data integration, and mission-critical applications.
+    iconClass: icon-kafka
+    openshift.io/display-name: Kafka by Exoscale
+    openshift.io/documentation-url: https://vs.hn/exo-kafka
+    openshift.io/provider-display-name: Exoscale
+    tags: database,nosql
+  labels:
+    name: kafkabyexoscale
+  name: kafkabyexoscale
+  namespace: openshift
+objects:
+  - apiVersion: exoscale.appcat.vshn.io/v1
+    kind: ExoscaleKafka
+    metadata:
+      annotations: {}
+      labels:
+        name: ${INSTANCE_NAME}
+      name: ${INSTANCE_NAME}
+    spec:
+      parameters:
+        service:
+          zone: ${ZONE}
+        size:
+          plan: ${PLAN}
+      writeConnectionSecretToRef:
+        name: ${SECRET_NAME}
+parameters:
+  - name: PLAN
+    value: startup-4
+  - name: SECRET_NAME
+    value: kafka-credentials
+  - name: INSTANCE_NAME
+  - name: ZONE
+    value: ch-dk-2

--- a/tests/golden/openshift/appcat/appcat/21_openshift_template_mysql_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_openshift_template_mysql_exoscale.yaml
@@ -1,0 +1,43 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+message: Your MySQL by Exoscale instance is being provisioned, please see ${SECRET_NAME}
+  for access.
+metadata:
+  annotations:
+    description: "The world\u2019s most popular open-source database."
+    iconClass: icon-mysql
+    openshift.io/display-name: MySQL by Exoscale
+    openshift.io/documentation-url: https://vs.hn/exo-mysql
+    openshift.io/provider-display-name: Exoscale
+    tags: database,sql
+  labels:
+    name: mysqlbyexoscale
+  name: mysqlbyexoscale
+  namespace: openshift
+objects:
+  - apiVersion: exoscale.appcat.vshn.io/v1
+    kind: ExoscaleMySQL
+    metadata:
+      annotations: {}
+      labels:
+        name: ${INSTANCE_NAME}
+      name: ${INSTANCE_NAME}
+    spec:
+      parameters:
+        service:
+          majorVersion: ${MAJOR_VERSION}
+          zone: ${ZONE}
+        size:
+          plan: ${PLAN}
+      writeConnectionSecretToRef:
+        name: ${SECRET_NAME}
+parameters:
+  - name: PLAN
+    value: startup-4
+  - name: SECRET_NAME
+    value: mysql-credentials
+  - name: INSTANCE_NAME
+  - name: ZONE
+    value: ch-dk-2
+  - name: MAJOR_VERSION
+    value: '8'

--- a/tests/golden/openshift/appcat/appcat/21_openshift_template_mysql_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_openshift_template_mysql_exoscale.yaml
@@ -5,11 +5,12 @@ message: Your MySQL by Exoscale instance is being provisioned, please see ${SECR
 metadata:
   annotations:
     description: "The world\u2019s most popular open-source database."
-    iconClass: icon-mysql
-    openshift.io/display-name: MySQL by Exoscale
+    iconClass: icon-mysql-database
+    openshift.io/display-name: MySQL
     openshift.io/documentation-url: https://vs.hn/exo-mysql
     openshift.io/provider-display-name: Exoscale
-    tags: database,sql
+    openshift.io/support-url: https://www.vshn.ch/en/contact/
+    tags: database,sql,mysql
   labels:
     name: mysqlbyexoscale
   name: mysqlbyexoscale

--- a/tests/golden/openshift/appcat/appcat/21_openshift_template_opensearch_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_openshift_template_opensearch_exoscale.yaml
@@ -6,11 +6,12 @@ metadata:
   annotations:
     description: OpenSearch is a community-driven, open-source search and analytics
       suite used by developers to ingest, search, visualize, and analyze data.
-    iconClass: icon-opensearch
-    openshift.io/display-name: OpenSearch by Exoscale
+    iconClass: icon-elastic
+    openshift.io/display-name: OpenSearch
     openshift.io/documentation-url: https://vs.hn/exo-opensearch
     openshift.io/provider-display-name: Exoscale
-    tags: database,nosql
+    openshift.io/support-url: https://www.vshn.ch/en/contact/
+    tags: database,nosql,opensearch,search
   labels:
     name: opensearchbyexoscale
   name: opensearchbyexoscale

--- a/tests/golden/openshift/appcat/appcat/21_openshift_template_opensearch_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_openshift_template_opensearch_exoscale.yaml
@@ -1,0 +1,44 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+message: Your OpenSearch by Exoscale instance is being provisioned, please see ${SECRET_NAME}
+  for access.
+metadata:
+  annotations:
+    description: OpenSearch is a community-driven, open-source search and analytics
+      suite used by developers to ingest, search, visualize, and analyze data.
+    iconClass: icon-opensearch
+    openshift.io/display-name: OpenSearch by Exoscale
+    openshift.io/documentation-url: https://vs.hn/exo-opensearch
+    openshift.io/provider-display-name: Exoscale
+    tags: database,nosql
+  labels:
+    name: opensearchbyexoscale
+  name: opensearchbyexoscale
+  namespace: openshift
+objects:
+  - apiVersion: exoscale.appcat.vshn.io/v1
+    kind: ExoscaleOpenSearch
+    metadata:
+      annotations: {}
+      labels:
+        name: ${INSTANCE_NAME}
+      name: ${INSTANCE_NAME}
+    spec:
+      parameters:
+        service:
+          majorVersion: ${MAJOR_VERSION}
+          zone: ${ZONE}
+        size:
+          plan: ${PLAN}
+      writeConnectionSecretToRef:
+        name: ${SECRET_NAME}
+parameters:
+  - name: PLAN
+    value: startup-4
+  - name: SECRET_NAME
+    value: opensearch-credentials
+  - name: INSTANCE_NAME
+  - name: ZONE
+    value: ch-dk-2
+  - name: MAJOR_VERSION
+    value: '2'

--- a/tests/golden/openshift/appcat/appcat/21_openshift_template_postgresql_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_openshift_template_postgresql_exoscale.yaml
@@ -10,10 +10,11 @@ metadata:
       date back to 1986 as part of the POSTGRES project at the University of California
       at Berkeley and has more than 30 years of active development on the core platform.
     iconClass: icon-postgresql
-    openshift.io/display-name: PostgreSQL by Exoscale
+    openshift.io/display-name: PostgreSQL
     openshift.io/documentation-url: https://vs.hn/exo-postgresql
     openshift.io/provider-display-name: Exoscale
-    tags: database,sql
+    openshift.io/support-url: https://www.vshn.ch/en/contact/
+    tags: database,sql,postgresql
   labels:
     name: postgresqlbyexoscale
   name: postgresqlbyexoscale

--- a/tests/golden/openshift/appcat/appcat/21_openshift_template_postgresql_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_openshift_template_postgresql_exoscale.yaml
@@ -1,0 +1,47 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+message: Your PostgreSQL by Exoscale instance is being provisioned, please see ${SECRET_NAME}
+  for access.
+metadata:
+  annotations:
+    description: PostgreSQL is a powerful, open source object-relational database
+      system that uses and extends the SQL language combined with many features that
+      safely store and scale the most complicated data workloads. The origins of PostgreSQL
+      date back to 1986 as part of the POSTGRES project at the University of California
+      at Berkeley and has more than 30 years of active development on the core platform.
+    iconClass: icon-postgresql
+    openshift.io/display-name: PostgreSQL by Exoscale
+    openshift.io/documentation-url: https://vs.hn/exo-postgresql
+    openshift.io/provider-display-name: Exoscale
+    tags: database,sql
+  labels:
+    name: postgresqlbyexoscale
+  name: postgresqlbyexoscale
+  namespace: openshift
+objects:
+  - apiVersion: exoscale.appcat.vshn.io/v1
+    kind: ExoscalePostgreSQL
+    metadata:
+      annotations: {}
+      labels:
+        name: ${INSTANCE_NAME}
+      name: ${INSTANCE_NAME}
+    spec:
+      parameters:
+        service:
+          majorVersion: ${MAJOR_VERSION}
+          zone: ${ZONE}
+        size:
+          plan: ${PLAN}
+      writeConnectionSecretToRef:
+        name: ${SECRET_NAME}
+parameters:
+  - name: PLAN
+    value: startup-4
+  - name: SECRET_NAME
+    value: postgresql-credentials
+  - name: INSTANCE_NAME
+  - name: MAJOR_VERSION
+    value: '14'
+  - name: ZONE
+    value: ch-dk-2

--- a/tests/golden/openshift/appcat/appcat/21_openshift_template_redis_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_openshift_template_redis_exoscale.yaml
@@ -1,0 +1,41 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+message: Your Redis by Exoscale instance is being provisioned, please see ${SECRET_NAME}
+  for access.
+metadata:
+  annotations:
+    description: The open source, in-memory data store used by millions of developers
+      as a database, cache, streaming engine, and message broker.
+    iconClass: icon-redis
+    openshift.io/display-name: Redis by Exoscale
+    openshift.io/documentation-url: https://vs.hn/exo-redis
+    openshift.io/provider-display-name: Exoscale
+    tags: database,nosql
+  labels:
+    name: redisbyexoscale
+  name: redisbyexoscale
+  namespace: openshift
+objects:
+  - apiVersion: exoscale.appcat.vshn.io/v1
+    kind: ExoscaleRedis
+    metadata:
+      annotations: {}
+      labels:
+        name: ${INSTANCE_NAME}
+      name: ${INSTANCE_NAME}
+    spec:
+      parameters:
+        service:
+          zone: ${ZONE}
+        size:
+          plan: ${PLAN}
+      writeConnectionSecretToRef:
+        name: ${SECRET_NAME}
+parameters:
+  - name: PLAN
+    value: startup-4
+  - name: SECRET_NAME
+    value: redis-credentials
+  - name: INSTANCE_NAME
+  - name: ZONE
+    value: ch-dk-2

--- a/tests/golden/openshift/appcat/appcat/21_openshift_template_redis_exoscale.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_openshift_template_redis_exoscale.yaml
@@ -7,9 +7,10 @@ metadata:
     description: The open source, in-memory data store used by millions of developers
       as a database, cache, streaming engine, and message broker.
     iconClass: icon-redis
-    openshift.io/display-name: Redis by Exoscale
+    openshift.io/display-name: Redis
     openshift.io/documentation-url: https://vs.hn/exo-redis
     openshift.io/provider-display-name: Exoscale
+    openshift.io/support-url: https://www.vshn.ch/en/contact/
     tags: database,nosql
   labels:
     name: redisbyexoscale


### PR DESCRIPTION
## Summary

These OpenShift templates add integration into OpenShifts catalog. With this it's possible to provision simple AppCat instances right from the OpenShift console.

While testing this I also found, that Exoscale bumped their Kafka version and `3.2` isn't supported anymore.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation. *Don't forget to generate the CRD API!*
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
