### PR TITLE
Adding possibility to send some alerts to customers via mailgun

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -28,7 +28,9 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.2.0
+        tag: v4.4.0
+
+    namespace: syn-appcat
 
     controller:
       enabled: false
@@ -36,7 +38,7 @@ parameters:
       postgres:
         enabled: false
         extraArgs: []
-        extraEnv: { }
+        extraEnv: {}
         resources:
           requests:
             cpu: 100m
@@ -100,7 +102,6 @@ parameters:
                 for: 6m
               ticket_alert: {}
 
-
     providers:
       cloudscale:
         enabled: false
@@ -151,6 +152,13 @@ parameters:
       vshn:
         enabled: false
         secretNamespace: ${crossplane:namespace}
+        emailAlerting:
+          smtpHost: "smtp.eu.mailgun.org:465"
+          smtpUsername: myuser@example.com
+          smtpPassword: "?{vaultkv:__shared__/__shared__/mailgun/smtp_password}"
+          smtpFromAddress: myuser@example.com
+          secretNamespace: syn-appcat
+          secretName: mailgun-smtp-credentials
         postgres:
           # bucket_region: 'lpg' || 'ch-gva-2'
           bucket_region: ""
@@ -160,7 +168,7 @@ parameters:
           enableNetworkPolicy: true
           secretNamespace: ${appcat:services:vshn:secretNamespace}
           # Used for deploying jobs during restores
-          controlNamespace: 'syn-appcat-control'
+          controlNamespace: "syn-appcat-control"
           sgNamespace: syn-stackgres-operator
 
           defaultPlan: standard-2

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -3,8 +3,10 @@ local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local slos = import 'slos.libsonnet';
 
+
 local inv = kap.inventory();
 local params = inv.parameters.appcat;
+local pgParams = params.services.vshn.postgres;
 
 local xrdBrowseRole = kube.ClusterRole('appcat:browse') + {
   metadata+: {
@@ -66,10 +68,23 @@ local readServices = kube.ClusterRole('appcat:services:read') + {
   ],
 };
 
+// adding namespace for syn-appcat
+local ns = kube.Namespace(params.namespace);
+
+local secret = kube.Secret(params.services.vshn.emailAlerting.secretName) {
+  metadata+: {
+    namespace: params.services.vshn.emailAlerting.secretNamespace,
+  },
+  stringData: {
+    password: params.services.vshn.emailAlerting.smtpPassword,
+  },
+};
 {
   '10_clusterrole_view': xrdBrowseRole,
   [if isOpenshift then '10_clusterrole_finalizer']: finalizerRole,
   '10_clusterrole_services_read': readServices,
+  '10_appcat_namespace': ns,
+  [if params.services.vshn.enabled then '10_mailgun_secret']: secret,
 
 } + if params.slos.enabled then {
   [if params.services.vshn.enabled && params.services.vshn.postgres.enabled then '90_slo_vshn_postgresql']: slos.Get('vshn-postgresql'),

--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -829,6 +829,11 @@ local composition(restore=false) =
               data: {
                 imageTag: common.GetAppCatImageTag(),
                 sgNamespace: pgParams.sgNamespace,
+                emailAlertingSecretNamespace: params.services.vshn.emailAlerting.secretNamespace,
+                emailAlertingSecretName: params.services.vshn.emailAlerting.secretName,
+                emailAlertingSmtpFromAddress: params.services.vshn.emailAlerting.smtpFromAddress,
+                emailAlertingSmtpUsername: params.services.vshn.emailAlerting.smtpUsername,
+                emailAlertingSmtpHost: params.services.vshn.emailAlerting.smtpHost,
               },
             },
             container: {

--- a/docs/modules/ROOT/pages/references/services-vshn.adoc
+++ b/docs/modules/ROOT/pages/references/services-vshn.adoc
@@ -26,6 +26,48 @@ In which namespace an XR's connection secret is written to.
 
 Defaults to the crossplane namespace.
 
+== `emailAlerting`
+[horizontal]
+type:: dict
+
+Configuration options for email alerting trough an SMTP service.
+Here you can configure the smtp host as well as the credentails required to send out alerts via any SMTP mail relay.
+
+=== `emailAlerting.smtpHost`
+type:: string
+default:: `'smtp.eu.mailgun.org:465'`
+
+Hostname to be used for sending out email alerts
+
+=== `emailAlerting.smtpUsername`
+type:: string
+default:: `'myuser@example.com'`
+
+The Username for the mail relay server
+
+=== `emailAlerting.smtpPassword`
+type:: string
+default:: `?{vaultkv:__shared__/__shared__/mailgun/smtp_password}`
+
+The Password for the mail relay server.
+
+=== `emailAlerting.smtpFromAddress`
+type:: string
+default:: `'myuser@example.com'`
+
+The email address used in the FROM header for sending out the alerts.
+
+=== `emailAlerting.secretNamespace`
+type:: string
+default:: `'syn-appcat'`
+
+The namespace where the secret that contains the password for the smtp relay server will be placed in
+
+=== `emailAlerting.secretName`
+type:: string
+default:: `'mailgun-smtp-secret'`
+
+The name of the secret that contains the password for the smtp relay server.
 
 == `postgres`
 [horizontal]

--- a/tests/golden/apiserver/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/apiserver/appcat/appcat/10_appcat_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-appcat
+  name: syn-appcat

--- a/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
@@ -32,7 +32,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: apiserver-envs
-          image: ghcr.io/vshn/appcat:v4.2.0
+          image: ghcr.io/vshn/appcat:v4.4.0
           name: apiserver
           resources:
             limits:

--- a/tests/golden/cloudscale/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_appcat_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-appcat
+  name: syn-appcat

--- a/tests/golden/controllers/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/controllers/appcat/appcat/10_appcat_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-appcat
+  name: syn-appcat

--- a/tests/golden/controllers/appcat/appcat/controllers/postgres/30_deployment.yaml
+++ b/tests/golden/controllers/appcat/appcat/controllers/postgres/30_deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - controller
             - --leader-elect
           env: []
-          image: ghcr.io/vshn/appcat:v4.2.0
+          image: ghcr.io/vshn/appcat:v4.4.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/defaults/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_appcat_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-appcat
+  name: syn-appcat

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.2.0
+        image: ghcr.io/vshn/appcat:v4.4.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/exoscale/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_appcat_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-appcat
+  name: syn-appcat

--- a/tests/golden/openshift/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_appcat_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-appcat
+  name: syn-appcat

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.2.0
+        image: ghcr.io/vshn/appcat:v4.4.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/vshn/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_appcat_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-appcat
+  name: syn-appcat

--- a/tests/golden/vshn/appcat/appcat/10_mailgun_secret.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_mailgun_secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: mailgun-smtp-credentials
+  name: mailgun-smtp-credentials
+  namespace: syn-appcat
+stringData:
+  password: whatever
+type: Opaque

--- a/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -5018,6 +5018,9 @@ spec:
                                   type: array
                               type: object
                           type: object
+                        email:
+                          description: Email necessary to send alerts via email
+                          type: string
                       type: object
                     network:
                       description: Network contains any network related settings.

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -26,7 +26,12 @@ spec:
     - config:
         apiVersion: v1
         data:
-          imageTag: v4.2.0
+          emailAlertingSecretName: mailgun-smtp-credentials
+          emailAlertingSecretNamespace: syn-appcat
+          emailAlertingSmtpFromAddress: myuser@example.com
+          emailAlertingSmtpHost: smtp.eu.mailgun.org:465
+          emailAlertingSmtpUsername: myuser@example.com
+          imageTag: v4.4.0
           sgNamespace: stackgres
         kind: ConfigMap
         metadata:

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -26,7 +26,12 @@ spec:
     - config:
         apiVersion: v1
         data:
-          imageTag: v4.2.0
+          emailAlertingSecretName: mailgun-smtp-credentials
+          emailAlertingSecretNamespace: syn-appcat
+          emailAlertingSmtpFromAddress: myuser@example.com
+          emailAlertingSmtpHost: smtp.eu.mailgun.org:465
+          emailAlertingSmtpUsername: myuser@example.com
+          imageTag: v4.4.0
           sgNamespace: stackgres
         kind: ConfigMap
         metadata:

--- a/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
@@ -32,7 +32,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: apiserver-envs
-          image: ghcr.io/vshn/appcat:v4.2.0
+          image: ghcr.io/vshn/appcat:v4.4.0
           name: apiserver
           resources:
             limits:

--- a/tests/golden/vshn/appcat/appcat/controllers/postgres/30_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/controllers/postgres/30_deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - controller
             - --leader-elect
           env: []
-          image: ghcr.io/vshn/appcat:v4.2.0
+          image: ghcr.io/vshn/appcat:v4.4.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "true"
-        image: ghcr.io/vshn/appcat:v4.2.0
+        image: ghcr.io/vshn/appcat:v4.4.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/vshn.yml
+++ b/tests/vshn.yml
@@ -35,6 +35,8 @@ parameters:
     services:
       vshn:
         enabled: true
+        emailAlerting:
+          smtpPassword: "whatever"
         postgres:
           sgNamespace: stackgres
           bucket_region: 'us-east-1'


### PR DESCRIPTION
## Summary

This adds the possibility to send alerts triggered by the created instance to the customer via mailgun.
This PR will add the required smtp secret for mailgun to the cluster, which is then used by the alertmanager config of that instance to send alerts to the configured e-mail address in the claim.
The alertmanager config itself is created using composition functions and is implemented here: https://github.com/vshn/appcat/pull/21

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
