### PR TITLE
Fix stackgres namespace name

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -161,7 +161,7 @@ parameters:
           secretNamespace: ${appcat:services:vshn:secretNamespace}
           # Used for deploying jobs during restores
           controlNamespace: 'syn-appcat-control'
-          sgNamespace: syn-stackgres
+          sgNamespace: syn-stackgres-operator
 
           defaultPlan: standard-2
           plans:


### PR DESCRIPTION
## Summary

The default namespace for stackgres is `syn-stackgres-operator`

## Checklist

- [ ] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
