### PR TITLE
Escape tags, so they support valid branch names

### DIFF
--- a/component/appcat_apiserver.jsonnet
+++ b/component/appcat_apiserver.jsonnet
@@ -77,7 +77,7 @@ local apiserver = loadManifest('aggregated-apiserver.yaml') {
         containers: [
           if c.name == 'apiserver' then
             c {
-              image: '%(registry)s/%(repository)s:%(tag)s' % params.images.appcat,
+              image: common.GetAppCatImageString(),
               args: [ super.args[0] ] + common.MergeArgs(common.MergeArgs(super.args[1:], extraDeploymentArgs), apiserverParams.extraArgs),
               env+: com.envList(apiserverParams.extraEnv),
               resources: apiserverParams.resources,

--- a/component/appcat_controller_postgres.jsonnet
+++ b/component/appcat_controller_postgres.jsonnet
@@ -59,7 +59,7 @@ local controller = loadManifest('deployment.yaml') {
         containers: [
           if c.name == 'manager' then
             c {
-              image: '%(registry)s/%(repository)s:%(tag)s' % params.images.appcat,
+              image: common.GetAppCatImageString(),
               args+: postgresControllerParams.extraArgs,
               env+: com.envList(postgresControllerParams.extraEnv),
               resources: postgresControllerParams.resources,

--- a/component/appcat_sli_exporter.jsonnet
+++ b/component/appcat_sli_exporter.jsonnet
@@ -1,7 +1,7 @@
+local common = import 'common.libsonnet';
 local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
-
 
 local inv = kap.inventory();
 // The hiera parameters for the component
@@ -51,7 +51,7 @@ local kustomization =
       image.tag,
       {
         'ghcr.io/vshn/appcat': {
-          newTag: image.tag,
+          newTag: common.GetAppCatImageTag(),
           newName: '%(registry)s/%(repository)s' % image,
         },
       },

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -115,6 +115,10 @@ local openShiftTemplate(name, displayName, description, iconClass, tags, message
   message: message,
 };
 
+local getAppCatImageTag() = std.strReplace(params.images.appcat.tag, '/', '_');
+
+local getAppCatImageString() = params.images.appcat.registry + '/' + params.images.appcat.repository + ':' + getAppCatImageTag();
+
 {
   SyncOptions: syncOptions,
   VshnMetaDBaaSExoscale(dbname):
@@ -129,4 +133,8 @@ local openShiftTemplate(name, displayName, description, iconClass, tags, message
     filterDisabledParams(params),
   OpenShiftTemplate(name, displayName, description, iconClass, tags, message, provider, docs):
     openShiftTemplate(name, displayName, description, iconClass, tags, message, provider, docs),
+  GetAppCatImageString():
+    getAppCatImageString(),
+  GetAppCatImageTag():
+    getAppCatImageTag(),
 }

--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -827,7 +827,7 @@ local composition(restore=false) =
                 name: 'xfn-config',
               },
               data: {
-                imageTag: params.images.appcat.tag,
+                imageTag: common.GetAppCatImageTag(),
                 sgNamespace: pgParams.sgNamespace,
               },
             },


### PR DESCRIPTION
The `tag` field in the `appcat.image` object is used for two things:

1. It points to a git branch/tag
2. It's used for a docker image tag

The problem with this approach is that there are valid branch names that aren't valid docker tags. This commit adds an escape function to build the image that replaces invalid docker tag characters.

For example if `appcat.image.tag` is set to `add/test` it will use `add/test` for the branch to render the manifests and the escaped string `add_test` for the docker image tag.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
