### PR TITLE
Add SLA reporter cronjob

### DIFF
--- a/class/appcat.yml
+++ b/class/appcat.yml
@@ -70,7 +70,10 @@ parameters:
           INPUT_DIR: ${_base_directory}/.work/appcat_sli_exporter
         args:
           - \${compiled_target_dir}/appcat/sli_exporter
-
+      - input_paths:
+          - ${_base_directory}/component/appcat_sla_reporter.jsonnet
+        input_type: jsonnet
+        output_path: appcat/sla_reporter
 
 
       - input_paths:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -71,7 +71,7 @@ parameters:
       enabled: true
       namespace: appcat-slos
       sla_reporter:
-        enables: false
+        enabled: false
         resources:
           requests:
             cpu: 10m

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -28,7 +28,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: add/slareports
+        tag: v4.5.0
 
     namespace: syn-appcat
 

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -28,7 +28,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.4.0
+        tag: add/slareports
 
     namespace: syn-appcat
 
@@ -70,6 +70,20 @@ parameters:
     slos:
       enabled: true
       namespace: appcat-slos
+      sla_reporter:
+        enables: false
+        resources:
+          requests:
+            cpu: 10m
+            memory: 200Mi
+          limits:
+            cpu: 100m
+            memory: 300Mi
+        # 09:00 on the first of the month
+        schedule: "0 9 1 * *"
+        bucket_region: lpg
+        slo_mimir_endpoint: http://vshn-appuio-mimir-query-frontend.vshn-appuio-mimir.svc.cluster.local:8080/prometheus
+        mimir_organization: appuio-managed-openshift-metrics
       sli_exporter:
         resources:
           requests:

--- a/component/appcat_sla_reporter.jsonnet
+++ b/component/appcat_sla_reporter.jsonnet
@@ -1,0 +1,82 @@
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.appcat;
+local sla_reporter_params = params.slos.sla_reporter;
+local common = import 'common.libsonnet';
+
+local CronJob = kube.CronJob('appcat-sla-reporter') {
+  metadata+: {
+    namespace: params.slos.namespace,
+  },
+  spec+: {
+    schedule: sla_reporter_params.schedule,
+    failedJobsHistoryLimit: 3,
+    successfulJobsHistoryLimit: 0,
+    jobTemplate+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              {
+                name: 'sla-reporter',
+                image: common.GetAppCatImageString(),
+                resources: sla_reporter_params.resources,
+                args: [
+                  'slareport',
+                  '--previousmonth',
+                  '--mimirorg',
+                  sla_reporter_params.mimir_organization,
+                ],
+                envFrom: [
+                  {
+                    secretRef: {
+                      name: 'appcat-sla-reports-creds',
+                    },
+                  },
+                ],
+                env: [
+                  {
+                    name: 'PROM_URL',
+                    value: sla_reporter_params.slo_mimir_endpoint,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+};
+
+local ObjectStorage = kube._Object('appcat.vshn.io/v1', 'ObjectBucket', 'appcat-sla-reports') {
+  metadata: {
+    namespace: params.slos.namespace,
+    name: 'appcat-sla-reports',
+    annotations: {
+      // Our current ArgoCD configuration can't handle the claim -> composite
+      // relationship
+      'argocd.argoproj.io/compare-options': 'IgnoreExtraneous',
+      'argocd.argoproj.io/sync-options': 'Prune=false',
+    },
+  },
+  spec: {
+    parameters: {
+      bucketName: 'appcat-sla-reports',
+      region: sla_reporter_params.bucket_region,
+    },
+    writeConnectionSecretToRef: {
+      name: 'appcat-sla-reports-creds',
+    },
+  },
+};
+
+if params.slos.enabled == true then {
+  '01_cronjob': CronJob,
+  '02_object_bucket': ObjectStorage,
+} else {}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -87,6 +87,6 @@ local secret = kube.Secret(params.services.vshn.emailAlerting.secretName) {
   [if params.services.vshn.enabled then '10_mailgun_secret']: secret,
 
 } + if params.slos.enabled then {
-  [if params.services.vshn.enabled && params.services.vshn.postgres.enabled then '90_slo_vshn_postgresql']: slos.Get('vshn-postgresql'),
+  [if params.services.vshn.enabled && params.services.vshn.postgres.enabled then 'sli_exporter/90_slo_vshn_postgresql']: slos.Get('vshn-postgresql'),
 }
 else {}

--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -64,8 +64,8 @@ local prometheusRule(name) =
         sli: {
           events: {
             // The  0*rate(...) makes sure that the query reports an error rate for all instances, even if that instance has never produced a single error
-            error_query: 'sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[{{.window}}]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[{{.window}}]))  by (service, namespace, name)',
-            total_query: 'sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[{{.window}}])) by (service, namespace, name)',
+            error_query: 'sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[{{.window}}]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[{{.window}}]))  by (service, namespace, name, organization)',
+            total_query: 'sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[{{.window}}])) by (service, namespace, name, organization)',
           },
         },
         alerting+: {

--- a/docs/modules/ROOT/pages/references/slo-parameters.adoc
+++ b/docs/modules/ROOT/pages/references/slo-parameters.adoc
@@ -96,3 +96,48 @@ vshn:
 <2> Adds the label `foo: bar` to all page alerts
 <3> Only fires page alerts if they are pending for 13 minutes
 <4> Adds annotation `please: ignore` to all ticket alerts
+
+== `sla_reporter`
+
+Configuration options for the monthly SLA report generator.
+
+=== `sla_reporter.enabled`
+[horizontal]
+type:: boolean
+default:: false
+
+Enables or disables the monthly reporter cronjob.
+
+=== `sla_reporter.resources`
+[horizontal]
+type:: dict
+
+The resource requests and limits for the SLA Reporter.
+
+=== `sla_reporter.schedule`
+[horizontal]
+type:: string
+default:: "0 9 1 * *"
+
+Cron schedule when the SLA Reporter should run.
+
+=== `sla_reporter.bucket_region`
+[horizontal]
+type:: dict
+default:: lpg
+
+The region in which the bucket that stores the reports should be provisioned.
+
+=== `sla_reporter.slo_mimir_endpoint`
+[horizontal]
+type:: dict
+default:: http://vshn-appuio-mimir-query-frontend.vshn-appuio-mimir.svc.cluster.local:8080/prometheus
+
+Endpoint for the Prometheus compatible data source.
+
+=== `sla_reporter.mimir_organization`
+[horizontal]
+type:: dict
+default:: appuio-managed-openshift-metrics
+
+Organization header needed to query Mimir data sources.

--- a/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
@@ -32,7 +32,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: apiserver-envs
-          image: ghcr.io/vshn/appcat:v4.4.0
+          image: ghcr.io/vshn/appcat:add_slareports
           name: apiserver
           resources:
             limits:

--- a/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
@@ -32,7 +32,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: apiserver-envs
-          image: ghcr.io/vshn/appcat:add_slareports
+          image: ghcr.io/vshn/appcat:v4.5.0
           name: apiserver
           resources:
             limits:

--- a/tests/golden/controllers/appcat/appcat/controllers/postgres/30_deployment.yaml
+++ b/tests/golden/controllers/appcat/appcat/controllers/postgres/30_deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - controller
             - --leader-elect
           env: []
-          image: ghcr.io/vshn/appcat:v4.4.0
+          image: ghcr.io/vshn/appcat:add_slareports
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/controllers/appcat/appcat/controllers/postgres/30_deployment.yaml
+++ b/tests/golden/controllers/appcat/appcat/controllers/postgres/30_deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - controller
             - --leader-elect
           env: []
-          image: ghcr.io/vshn/appcat:add_slareports
+          image: ghcr.io/vshn/appcat:v4.5.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/defaults/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/defaults/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:add_slareports
+              image: ghcr.io/vshn/appcat:v4.5.0
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/defaults/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/defaults/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-sla-reporter
+  name: appcat-sla-reporter
+  namespace: appcat-slos
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appcat-sla-reporter
+        spec:
+          containers:
+            - args:
+                - slareport
+                - --previousmonth
+                - --mimirorg
+                - appuio-managed-openshift-metrics
+              env:
+                - name: PROM_URL
+                  value: http://vshn-appuio-mimir-query-frontend.vshn-appuio-mimir.svc.cluster.local:8080/prometheus
+              envFrom:
+                - secretRef:
+                    name: appcat-sla-reports-creds
+              image: ghcr.io/vshn/appcat:add_slareports
+              name: sla-reporter
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 300Mi
+                requests:
+                  cpu: 10m
+                  memory: 200Mi
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          terminationGracePeriodSeconds: 30
+          volumes: []
+  schedule: 0 9 1 * *
+  successfulJobsHistoryLimit: 0

--- a/tests/golden/defaults/appcat/appcat/sla_reporter/02_object_bucket.yaml
+++ b/tests/golden/defaults/appcat/appcat/sla_reporter/02_object_bucket.yaml
@@ -1,0 +1,14 @@
+apiVersion: appcat.vshn.io/v1
+kind: ObjectBucket
+metadata:
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
+  name: appcat-sla-reports
+  namespace: appcat-slos
+spec:
+  parameters:
+    bucketName: appcat-sla-reports
+    region: lpg
+  writeConnectionSecretToRef:
+    name: appcat-sla-reports-creds

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.4.0
+        image: ghcr.io/vshn/appcat:add_slareports
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "false"
-        image: ghcr.io/vshn/appcat:add_slareports
+        image: ghcr.io/vshn/appcat:v4.5.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -18,8 +18,6 @@ rules:
   - vshnpostgresqls/status
   verbs:
   - get
-<<<<<<< HEAD
-=======
 - apiGroups:
   - ""
   resources:
@@ -28,4 +26,4 @@ rules:
   verbs:
   - get
   - list
->>>>>>> 1d232be (Fix sli exporter)
+  - watch

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -18,3 +18,14 @@ rules:
   - vshnpostgresqls/status
   verbs:
   - get
+<<<<<<< HEAD
+=======
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - secrets
+  verbs:
+  - get
+  - list
+>>>>>>> 1d232be (Fix sli exporter)

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: appcat-sliexporter-glrf-test-appcat-sli-probe
+  name: appcat-sliexporter-appcat-sli-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: appcat-sliexporter-appcat-sli-exporter
 subjects:
 - kind: ServiceAccount
   name: appcat-sliexporter-controller-manager

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-proxy-rolebinding.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-proxy-rolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: appcat-sliexporter-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: appcat-sliexporter-controller-manager
+  namespace: appcat-slos

--- a/tests/golden/openshift/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/openshift/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:add_slareports
+              image: ghcr.io/vshn/appcat:v4.5.0
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/openshift/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/openshift/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-sla-reporter
+  name: appcat-sla-reporter
+  namespace: appcat-slos
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appcat-sla-reporter
+        spec:
+          containers:
+            - args:
+                - slareport
+                - --previousmonth
+                - --mimirorg
+                - appuio-managed-openshift-metrics
+              env:
+                - name: PROM_URL
+                  value: http://vshn-appuio-mimir-query-frontend.vshn-appuio-mimir.svc.cluster.local:8080/prometheus
+              envFrom:
+                - secretRef:
+                    name: appcat-sla-reports-creds
+              image: ghcr.io/vshn/appcat:add_slareports
+              name: sla-reporter
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 300Mi
+                requests:
+                  cpu: 10m
+                  memory: 200Mi
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          terminationGracePeriodSeconds: 30
+          volumes: []
+  schedule: 0 9 1 * *
+  successfulJobsHistoryLimit: 0

--- a/tests/golden/openshift/appcat/appcat/sla_reporter/02_object_bucket.yaml
+++ b/tests/golden/openshift/appcat/appcat/sla_reporter/02_object_bucket.yaml
@@ -1,0 +1,14 @@
+apiVersion: appcat.vshn.io/v1
+kind: ObjectBucket
+metadata:
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
+  name: appcat-sla-reports
+  namespace: appcat-slos
+spec:
+  parameters:
+    bucketName: appcat-sla-reports
+    region: lpg
+  writeConnectionSecretToRef:
+    name: appcat-sla-reports-creds

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.4.0
+        image: ghcr.io/vshn/appcat:add_slareports
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "false"
-        image: ghcr.io/vshn/appcat:add_slareports
+        image: ghcr.io/vshn/appcat:v4.5.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -18,8 +18,6 @@ rules:
   - vshnpostgresqls/status
   verbs:
   - get
-<<<<<<< HEAD
-=======
 - apiGroups:
   - ""
   resources:
@@ -28,4 +26,4 @@ rules:
   verbs:
   - get
   - list
->>>>>>> 1d232be (Fix sli exporter)
+  - watch

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -18,3 +18,14 @@ rules:
   - vshnpostgresqls/status
   verbs:
   - get
+<<<<<<< HEAD
+=======
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - secrets
+  verbs:
+  - get
+  - list
+>>>>>>> 1d232be (Fix sli exporter)

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: appcat-sliexporter-glrf-test-appcat-sli-probe
+  name: appcat-sliexporter-appcat-sli-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: appcat-sliexporter-appcat-sli-exporter
 subjects:
 - kind: ServiceAccount
   name: appcat-sliexporter-controller-manager

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-proxy-rolebinding.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-proxy-rolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: appcat-sliexporter-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: appcat-sliexporter-controller-manager
+  namespace: appcat-slos

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -31,7 +31,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.4.0
+          imageTag: add_slareports
           sgNamespace: stackgres
         kind: ConfigMap
         metadata:

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -31,7 +31,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: add_slareports
+          imageTag: v4.5.0
           sgNamespace: stackgres
         kind: ConfigMap
         metadata:

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -31,7 +31,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.4.0
+          imageTag: add_slareports
           sgNamespace: stackgres
         kind: ConfigMap
         metadata:

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -31,7 +31,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: add_slareports
+          imageTag: v4.5.0
           sgNamespace: stackgres
         kind: ConfigMap
         metadata:

--- a/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
@@ -32,7 +32,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: apiserver-envs
-          image: ghcr.io/vshn/appcat:v4.4.0
+          image: ghcr.io/vshn/appcat:add_slareports
           name: apiserver
           resources:
             limits:

--- a/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
@@ -32,7 +32,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: apiserver-envs
-          image: ghcr.io/vshn/appcat:add_slareports
+          image: ghcr.io/vshn/appcat:v4.5.0
           name: apiserver
           resources:
             limits:

--- a/tests/golden/vshn/appcat/appcat/controllers/postgres/30_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/controllers/postgres/30_deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - controller
             - --leader-elect
           env: []
-          image: ghcr.io/vshn/appcat:v4.4.0
+          image: ghcr.io/vshn/appcat:add_slareports
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn/appcat/appcat/controllers/postgres/30_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/controllers/postgres/30_deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - controller
             - --leader-elect
           env: []
-          image: ghcr.io/vshn/appcat:add_slareports
+          image: ghcr.io/vshn/appcat:v4.5.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:add_slareports
+              image: ghcr.io/vshn/appcat:v4.5.0
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-sla-reporter
+  name: appcat-sla-reporter
+  namespace: appcat-slos
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: appcat-sla-reporter
+        spec:
+          containers:
+            - args:
+                - slareport
+                - --previousmonth
+                - --mimirorg
+                - appuio-managed-openshift-metrics
+              env:
+                - name: PROM_URL
+                  value: http://kube-prometheus-kube-prome-prometheus.prometheus-system.svc:9090/prometheus
+              envFrom:
+                - secretRef:
+                    name: appcat-sla-reports-creds
+              image: ghcr.io/vshn/appcat:add_slareports
+              name: sla-reporter
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 300Mi
+                requests:
+                  cpu: 10m
+                  memory: 200Mi
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          terminationGracePeriodSeconds: 30
+          volumes: []
+  schedule: 0 9 1 * *
+  successfulJobsHistoryLimit: 0

--- a/tests/golden/vshn/appcat/appcat/sla_reporter/02_object_bucket.yaml
+++ b/tests/golden/vshn/appcat/appcat/sla_reporter/02_object_bucket.yaml
@@ -1,0 +1,14 @@
+apiVersion: appcat.vshn.io/v1
+kind: ObjectBucket
+metadata:
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
+  name: appcat-sla-reports
+  namespace: appcat-slos
+spec:
+  parameters:
+    bucketName: appcat-sla-reports
+    region: lpg
+  writeConnectionSecretToRef:
+    name: appcat-sla-reports-creds

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
@@ -11,9 +11,9 @@ spec:
     - name: sloth-slo-sli-recordings-appcat-vshn-postgresql-uptime
       rules:
         - expr: |
-            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[5m]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[5m]))  by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[5m]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[5m]))  by (service, namespace, name, organization))
             /
-            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[5m])) by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[5m])) by (service, namespace, name, organization))
           labels:
             sloth_id: appcat-vshn-postgresql-uptime
             sloth_service: appcat-vshn-postgresql
@@ -21,9 +21,9 @@ spec:
             sloth_window: 5m
           record: slo:sli_error:ratio_rate5m
         - expr: |
-            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[30m]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[30m]))  by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[30m]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[30m]))  by (service, namespace, name, organization))
             /
-            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[30m])) by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[30m])) by (service, namespace, name, organization))
           labels:
             sloth_id: appcat-vshn-postgresql-uptime
             sloth_service: appcat-vshn-postgresql
@@ -31,9 +31,9 @@ spec:
             sloth_window: 30m
           record: slo:sli_error:ratio_rate30m
         - expr: |
-            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[1h]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1h]))  by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[1h]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1h]))  by (service, namespace, name, organization))
             /
-            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1h])) by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1h])) by (service, namespace, name, organization))
           labels:
             sloth_id: appcat-vshn-postgresql-uptime
             sloth_service: appcat-vshn-postgresql
@@ -41,9 +41,9 @@ spec:
             sloth_window: 1h
           record: slo:sli_error:ratio_rate1h
         - expr: |
-            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[2h]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[2h]))  by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[2h]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[2h]))  by (service, namespace, name, organization))
             /
-            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[2h])) by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[2h])) by (service, namespace, name, organization))
           labels:
             sloth_id: appcat-vshn-postgresql-uptime
             sloth_service: appcat-vshn-postgresql
@@ -51,9 +51,9 @@ spec:
             sloth_window: 2h
           record: slo:sli_error:ratio_rate2h
         - expr: |
-            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[6h]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[6h]))  by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[6h]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[6h]))  by (service, namespace, name, organization))
             /
-            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[6h])) by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[6h])) by (service, namespace, name, organization))
           labels:
             sloth_id: appcat-vshn-postgresql-uptime
             sloth_service: appcat-vshn-postgresql
@@ -61,9 +61,9 @@ spec:
             sloth_window: 6h
           record: slo:sli_error:ratio_rate6h
         - expr: |
-            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[1d]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1d]))  by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[1d]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1d]))  by (service, namespace, name, organization))
             /
-            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1d])) by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[1d])) by (service, namespace, name, organization))
           labels:
             sloth_id: appcat-vshn-postgresql-uptime
             sloth_service: appcat-vshn-postgresql
@@ -71,9 +71,9 @@ spec:
             sloth_window: 1d
           record: slo:sli_error:ratio_rate1d
         - expr: |
-            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[3d]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[3d]))  by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL"}[3d]) or 0*rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[3d]))  by (service, namespace, name, organization))
             /
-            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[3d])) by (service, namespace, name))
+            (sum(rate(appcat_probes_seconds_count{service="VSHNPostgreSQL"}[3d])) by (service, namespace, name, organization))
           labels:
             sloth_id: appcat-vshn-postgresql-uptime
             sloth_service: appcat-vshn-postgresql

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "true"
-        image: ghcr.io/vshn/appcat:add_slareports
+        image: ghcr.io/vshn/appcat:v4.5.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "true"
-        image: ghcr.io/vshn/appcat:v4.4.0
+        image: ghcr.io/vshn/appcat:add_slareports
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -18,8 +18,6 @@ rules:
   - vshnpostgresqls/status
   verbs:
   - get
-<<<<<<< HEAD
-=======
 - apiGroups:
   - ""
   resources:
@@ -28,4 +26,4 @@ rules:
   verbs:
   - get
   - list
->>>>>>> 1d232be (Fix sli exporter)
+  - watch

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -18,3 +18,14 @@ rules:
   - vshnpostgresqls/status
   verbs:
   - get
+<<<<<<< HEAD
+=======
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - secrets
+  verbs:
+  - get
+  - list
+>>>>>>> 1d232be (Fix sli exporter)

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: appcat-sliexporter-glrf-test-appcat-sli-probe
+  name: appcat-sliexporter-appcat-sli-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: appcat-sliexporter-appcat-sli-exporter
 subjects:
 - kind: ServiceAccount
   name: appcat-sliexporter-controller-manager

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-proxy-rolebinding.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrolebinding_appcat-sliexporter-proxy-rolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: appcat-sliexporter-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: appcat-sliexporter-controller-manager
+  namespace: appcat-slos

--- a/tests/vshn.yml
+++ b/tests/vshn.yml
@@ -19,6 +19,9 @@ parameters:
   appcat:
     slos:
       enabled: true
+      sla_reporter:
+        enabled: true
+        slo_mimir_endpoint: http://kube-prometheus-kube-prome-prometheus.prometheus-system.svc:9090/prometheus
     controller:
       enabled: true
       postgres:


### PR DESCRIPTION
This adds a cronjob that runs on the first of each month at 09:00 and
generates the SLA information for the previous month.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
