### PR TITLE
Give option to disable e-mail alerting

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -28,7 +28,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.7.0
+        tag: v4.8.0
 
     namespace: syn-appcat
 
@@ -168,6 +168,7 @@ parameters:
         enabled: false
         secretNamespace: ${crossplane:namespace}
         emailAlerting:
+          enabled: false
           smtpHost: "smtp.eu.mailgun.org:465"
           smtpUsername: myuser@example.com
           smtpPassword: "?{vaultkv:__shared__/__shared__/mailgun/smtp_password}"

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -71,7 +71,7 @@ local readServices = kube.ClusterRole('appcat:services:read') + {
 // adding namespace for syn-appcat
 local ns = kube.Namespace(params.namespace);
 
-local secret = kube.Secret(params.services.vshn.emailAlerting.secretName) {
+local emailSecret = kube.Secret(params.services.vshn.emailAlerting.secretName) {
   metadata+: {
     namespace: params.services.vshn.emailAlerting.secretNamespace,
   },
@@ -84,7 +84,7 @@ local secret = kube.Secret(params.services.vshn.emailAlerting.secretName) {
   [if isOpenshift then '10_clusterrole_finalizer']: finalizerRole,
   '10_clusterrole_services_read': readServices,
   '10_appcat_namespace': ns,
-  [if params.services.vshn.enabled then '10_mailgun_secret']: secret,
+  [if params.services.vshn.enabled && params.services.vshn.emailAlerting.enabled then '10_mailgun_secret']: emailSecret,
 
 } + if params.slos.enabled then {
   [if params.services.vshn.enabled && params.services.vshn.postgres.enabled then 'sli_exporter/90_slo_vshn_postgresql']: slos.Get('vshn-postgresql'),

--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -829,6 +829,7 @@ local composition(restore=false) =
               data: {
                 imageTag: common.GetAppCatImageTag(),
                 sgNamespace: pgParams.sgNamespace,
+                emailAlertingEnabled: std.toString(params.services.vshn.emailAlerting.enabled),
                 emailAlertingSecretNamespace: params.services.vshn.emailAlerting.secretNamespace,
                 emailAlertingSecretName: params.services.vshn.emailAlerting.secretName,
                 emailAlertingSmtpFromAddress: params.services.vshn.emailAlerting.smtpFromAddress,

--- a/docs/modules/ROOT/pages/references/services-vshn.adoc
+++ b/docs/modules/ROOT/pages/references/services-vshn.adoc
@@ -33,6 +33,12 @@ type:: dict
 Configuration options for email alerting trough an SMTP service.
 Here you can configure the smtp host as well as the credentails required to send out alerts via any SMTP mail relay.
 
+=== `emailAlerting.enabled
+type:: bool
+default:: `false`
+
+If e-mail the alerting feature is enabled.
+
 === `emailAlerting.smtpHost`
 type:: string
 default:: `'smtp.eu.mailgun.org:465'`

--- a/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
@@ -32,7 +32,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: apiserver-envs
-          image: ghcr.io/vshn/appcat:v4.7.0
+          image: ghcr.io/vshn/appcat:v4.8.0
           name: apiserver
           resources:
             limits:

--- a/tests/golden/controllers/appcat/appcat/controllers/postgres/30_deployment.yaml
+++ b/tests/golden/controllers/appcat/appcat/controllers/postgres/30_deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - controller
             - --leader-elect
           env: []
-          image: ghcr.io/vshn/appcat:v4.7.0
+          image: ghcr.io/vshn/appcat:v4.8.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.7.0
+        image: ghcr.io/vshn/appcat:v4.8.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.7.0
+        image: ghcr.io/vshn/appcat:v4.8.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -26,12 +26,13 @@ spec:
     - config:
         apiVersion: v1
         data:
+          emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials
           emailAlertingSecretNamespace: syn-appcat
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.7.0
+          imageTag: v4.8.0
           sgNamespace: stackgres
         kind: ConfigMap
         metadata:

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -26,12 +26,13 @@ spec:
     - config:
         apiVersion: v1
         data:
+          emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials
           emailAlertingSecretNamespace: syn-appcat
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.7.0
+          imageTag: v4.8.0
           sgNamespace: stackgres
         kind: ConfigMap
         metadata:

--- a/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
@@ -32,7 +32,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: apiserver-envs
-          image: ghcr.io/vshn/appcat:v4.7.0
+          image: ghcr.io/vshn/appcat:v4.8.0
           name: apiserver
           resources:
             limits:

--- a/tests/golden/vshn/appcat/appcat/controllers/postgres/30_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/controllers/postgres/30_deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - controller
             - --leader-elect
           env: []
-          image: ghcr.io/vshn/appcat:v4.7.0
+          image: ghcr.io/vshn/appcat:v4.8.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.7.0
+              image: ghcr.io/vshn/appcat:v4.8.0
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: APPCAT_SLI_VSHNPOSTGRESQL
           value: "true"
-        image: ghcr.io/vshn/appcat:v4.7.0
+        image: ghcr.io/vshn/appcat:v4.8.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/vshn.yml
+++ b/tests/vshn.yml
@@ -39,6 +39,7 @@ parameters:
       vshn:
         enabled: true
         emailAlerting:
+          enabled: true
           smtpPassword: "whatever"
         postgres:
           sgNamespace: stackgres


### PR DESCRIPTION
For now we always enabled e-mail alerting if we deploy VSHN services, however on some cluster we might not have an e-mail account to send mail from.

This PR allows us to disable e-mail alerting on these clusters

See function change in https://github.com/vshn/appcat/pull/27

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
