### PR TITLE
Add prometheus rule to aggregate AppCat billing data per cluster

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -34,6 +34,8 @@ parameters:
     namespaceLabels: {}
     namespaceAnnotations: {}
 
+    appuioManaged: true
+    tenantID: ${cluster:tenant}
 
     controller:
       enabled: false

--- a/component/promql/appcat.promql
+++ b/component/promql/appcat.promql
@@ -1,0 +1,67 @@
+sum by (label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla,product,provider,architecture, category, claim_namespace,tenant_id) (
+# Sum values over one hour and get mean
+sum_over_time(
+  # Udpate label product: $product:$provider:$tenant_id:$claim_namespace:$architecture
+  label_join(
+    # Add label category: $provider:$claim_namespace
+    label_join(
+      # Add label architecture: $SLA, where $SLA is the content of label appcat.vshn.io/sla
+      label_replace(
+        # Add label provider: vshn
+        label_replace(
+          # Add label product: postgres
+          label_replace(
+            # Default appcat.vshn.io/sla to besteffort if it is not set
+            label_replace(
+              # Copy label appcat.vshn.io/namespace to label claim_namespace
+              label_replace(
+                # Populate tenant_id
+                label_replace(
+                  # Fetch all namespaces with label label_appuio_io_billing_name=~"appcat-.+"
+                  kube_namespace_labels{{{ORGLABEL}} label_appuio_io_billing_name=~"appcat-.+"} *
+                  on (namespace) group_right(label_appuio_io_organization,label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla, label_appuio_io_billing_name)
+                  kube_pod_info{created_by_kind!="Job"},
+                  {{TENANT_REPLACE}}
+                ),
+                "claim_namespace",
+                "$1",
+                "label_appcat_vshn_io_claim_namespace",
+                "(.*)"
+              ),
+              "label_appcat_vshn_io_sla",
+              "besteffort",
+              "label_appcat_vshn_io_sla",
+              "^$"
+            ),
+            "product",
+            "appcat_$1",
+            "label_appuio_io_billing_name",
+            "appcat-(.+)"
+          ),
+          "provider",
+          "vshn",
+          "",
+          ""
+        ),
+        "sla",
+        "$1",
+        "label_appcat_vshn_io_sla",
+        "(.*)"
+      ),
+      "category",
+      ":",
+      "provider",
+      "claim_namespace"
+    ),
+    "product",
+    ":",
+    "product",
+    "provider",
+    "tenant_id",
+    "claim_namespace",
+    "sla"
+  # other billing queries have [59m:1m] here. This is due to some
+  # obscure discrepancies between how the cloud-reporting evaluates the query
+  # and how the GUI/recording rules evaluate the query.
+  )[60m:1m]
+)/60 )

--- a/docs/modules/ROOT/pages/how-tos/billing.adoc
+++ b/docs/modules/ROOT/pages/how-tos/billing.adoc
@@ -1,0 +1,8 @@
+= Add a new VSHN service to billing
+
+If you want to add a new service to billing please ensure the following points:
+
+* The instance namespace contains a label of the form `'appuio.io/billing-name': 'appcat-$servicename',`
+* There's a product in the billing database's product table in the form of `appcat_$servicename:vshn:*:*:besteffort` and `appcat_$servicename:vshn:*:*:guaranteed`.
+* There's a discount in the discount table in the form of `appcat_$servicename:vshn`.
+* Matching products are added to the ERP

--- a/docs/modules/ROOT/pages/references/component-parameters.adoc
+++ b/docs/modules/ROOT/pages/references/component-parameters.adoc
@@ -12,6 +12,19 @@ This parameter allows selecting the Docker images to us.
 Each image is specified using keys `registry`, `repository` and `tag`.
 This structure allows easily injecting a registry mirror, if required.
 
+== `appuioManaged`
+[horizontal]
+type:: bool
+default:: true
+
+Determines if the cluster is APPUiO Managed or APPUiO Cloud.
+
+== `tenantID`
+[horizontal]
+type:: string
+default:: ${cluster:tenant}
+
+The tenant ID that should get hardcoded into the billing query.
 
 == `namespace`
 

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -27,5 +27,8 @@
 ** xref:references/services-vshn.adoc[VSHN Services]
 ** xref:references/service-objectstorage.adoc[Objectstorage Service]
 
+* How-Tos
+** xref:how-tos/billing.adoc[]
+
 .Runbooks
 * xref:runbooks/vshn-postgresql.adoc[]

--- a/tests/golden/apiserver/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/apiserver/appcat/appcat/10_appcat_namespace.yaml
@@ -4,4 +4,5 @@ metadata:
   annotations: {}
   labels:
     name: syn-appcat
+    openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/tests/golden/apiserver/appcat/appcat/10_appcat_recording_rule.yaml
+++ b/tests/golden/apiserver/appcat/appcat/10_appcat_recording_rule.yaml
@@ -1,0 +1,85 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-billing
+  name: appcat-billing
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-billing
+      rules:
+        - expr: |
+            sum by (label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla,product,provider,architecture, category, claim_namespace,tenant_id) (
+            # Sum values over one hour and get mean
+            sum_over_time(
+              # Udpate label product: $product:$provider:$tenant_id:$claim_namespace:$architecture
+              label_join(
+                # Add label category: $provider:$claim_namespace
+                label_join(
+                  # Add label architecture: $SLA, where $SLA is the content of label appcat.vshn.io/sla
+                  label_replace(
+                    # Add label provider: vshn
+                    label_replace(
+                      # Add label product: postgres
+                      label_replace(
+                        # Default appcat.vshn.io/sla to besteffort if it is not set
+                        label_replace(
+                          # Copy label appcat.vshn.io/namespace to label claim_namespace
+                          label_replace(
+                            # Populate tenant_id
+                            label_replace(
+                              # Fetch all namespaces with label label_appuio_io_billing_name=~"appcat-.+"
+                              kube_namespace_labels{ label_appuio_io_billing_name=~"appcat-.+"} *
+                              on (namespace) group_right(label_appuio_io_organization,label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla, label_appuio_io_billing_name)
+                              kube_pod_info{created_by_kind!="Job"},
+                              "tenant_id",
+            "t-silent-test-1234",
+            "",
+            ""
+
+                            ),
+                            "claim_namespace",
+                            "$1",
+                            "label_appcat_vshn_io_claim_namespace",
+                            "(.*)"
+                          ),
+                          "label_appcat_vshn_io_sla",
+                          "besteffort",
+                          "label_appcat_vshn_io_sla",
+                          "^$"
+                        ),
+                        "product",
+                        "appcat_$1",
+                        "label_appuio_io_billing_name",
+                        "appcat-(.+)"
+                      ),
+                      "provider",
+                      "vshn",
+                      "",
+                      ""
+                    ),
+                    "sla",
+                    "$1",
+                    "label_appcat_vshn_io_sla",
+                    "(.*)"
+                  ),
+                  "category",
+                  ":",
+                  "provider",
+                  "claim_namespace"
+                ),
+                "product",
+                ":",
+                "product",
+                "provider",
+                "tenant_id",
+                "claim_namespace",
+                "sla"
+              # other billing queries have [59m:1m] here. This is due to some
+              # obscure discrepancies between how the cloud-reporting evaluates the query
+              # and how the GUI/recording rules evaluate the query.
+              )[60m:1m]
+            )/60 )
+          record: appcat:billing

--- a/tests/golden/cloudscale/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_appcat_namespace.yaml
@@ -4,4 +4,5 @@ metadata:
   annotations: {}
   labels:
     name: syn-appcat
+    openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/tests/golden/cloudscale/appcat/appcat/10_appcat_recording_rule.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_appcat_recording_rule.yaml
@@ -1,0 +1,85 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-billing
+  name: appcat-billing
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-billing
+      rules:
+        - expr: |
+            sum by (label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla,product,provider,architecture, category, claim_namespace,tenant_id) (
+            # Sum values over one hour and get mean
+            sum_over_time(
+              # Udpate label product: $product:$provider:$tenant_id:$claim_namespace:$architecture
+              label_join(
+                # Add label category: $provider:$claim_namespace
+                label_join(
+                  # Add label architecture: $SLA, where $SLA is the content of label appcat.vshn.io/sla
+                  label_replace(
+                    # Add label provider: vshn
+                    label_replace(
+                      # Add label product: postgres
+                      label_replace(
+                        # Default appcat.vshn.io/sla to besteffort if it is not set
+                        label_replace(
+                          # Copy label appcat.vshn.io/namespace to label claim_namespace
+                          label_replace(
+                            # Populate tenant_id
+                            label_replace(
+                              # Fetch all namespaces with label label_appuio_io_billing_name=~"appcat-.+"
+                              kube_namespace_labels{ label_appuio_io_billing_name=~"appcat-.+"} *
+                              on (namespace) group_right(label_appuio_io_organization,label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla, label_appuio_io_billing_name)
+                              kube_pod_info{created_by_kind!="Job"},
+                              "tenant_id",
+            "t-silent-test-1234",
+            "",
+            ""
+
+                            ),
+                            "claim_namespace",
+                            "$1",
+                            "label_appcat_vshn_io_claim_namespace",
+                            "(.*)"
+                          ),
+                          "label_appcat_vshn_io_sla",
+                          "besteffort",
+                          "label_appcat_vshn_io_sla",
+                          "^$"
+                        ),
+                        "product",
+                        "appcat_$1",
+                        "label_appuio_io_billing_name",
+                        "appcat-(.+)"
+                      ),
+                      "provider",
+                      "vshn",
+                      "",
+                      ""
+                    ),
+                    "sla",
+                    "$1",
+                    "label_appcat_vshn_io_sla",
+                    "(.*)"
+                  ),
+                  "category",
+                  ":",
+                  "provider",
+                  "claim_namespace"
+                ),
+                "product",
+                ":",
+                "product",
+                "provider",
+                "tenant_id",
+                "claim_namespace",
+                "sla"
+              # other billing queries have [59m:1m] here. This is due to some
+              # obscure discrepancies between how the cloud-reporting evaluates the query
+              # and how the GUI/recording rules evaluate the query.
+              )[60m:1m]
+            )/60 )
+          record: appcat:billing

--- a/tests/golden/controllers/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/controllers/appcat/appcat/10_appcat_namespace.yaml
@@ -4,4 +4,5 @@ metadata:
   annotations: {}
   labels:
     name: syn-appcat
+    openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/tests/golden/controllers/appcat/appcat/10_appcat_recording_rule.yaml
+++ b/tests/golden/controllers/appcat/appcat/10_appcat_recording_rule.yaml
@@ -1,0 +1,85 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-billing
+  name: appcat-billing
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-billing
+      rules:
+        - expr: |
+            sum by (label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla,product,provider,architecture, category, claim_namespace,tenant_id) (
+            # Sum values over one hour and get mean
+            sum_over_time(
+              # Udpate label product: $product:$provider:$tenant_id:$claim_namespace:$architecture
+              label_join(
+                # Add label category: $provider:$claim_namespace
+                label_join(
+                  # Add label architecture: $SLA, where $SLA is the content of label appcat.vshn.io/sla
+                  label_replace(
+                    # Add label provider: vshn
+                    label_replace(
+                      # Add label product: postgres
+                      label_replace(
+                        # Default appcat.vshn.io/sla to besteffort if it is not set
+                        label_replace(
+                          # Copy label appcat.vshn.io/namespace to label claim_namespace
+                          label_replace(
+                            # Populate tenant_id
+                            label_replace(
+                              # Fetch all namespaces with label label_appuio_io_billing_name=~"appcat-.+"
+                              kube_namespace_labels{ label_appuio_io_billing_name=~"appcat-.+"} *
+                              on (namespace) group_right(label_appuio_io_organization,label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla, label_appuio_io_billing_name)
+                              kube_pod_info{created_by_kind!="Job"},
+                              "tenant_id",
+            "t-silent-test-1234",
+            "",
+            ""
+
+                            ),
+                            "claim_namespace",
+                            "$1",
+                            "label_appcat_vshn_io_claim_namespace",
+                            "(.*)"
+                          ),
+                          "label_appcat_vshn_io_sla",
+                          "besteffort",
+                          "label_appcat_vshn_io_sla",
+                          "^$"
+                        ),
+                        "product",
+                        "appcat_$1",
+                        "label_appuio_io_billing_name",
+                        "appcat-(.+)"
+                      ),
+                      "provider",
+                      "vshn",
+                      "",
+                      ""
+                    ),
+                    "sla",
+                    "$1",
+                    "label_appcat_vshn_io_sla",
+                    "(.*)"
+                  ),
+                  "category",
+                  ":",
+                  "provider",
+                  "claim_namespace"
+                ),
+                "product",
+                ":",
+                "product",
+                "provider",
+                "tenant_id",
+                "claim_namespace",
+                "sla"
+              # other billing queries have [59m:1m] here. This is due to some
+              # obscure discrepancies between how the cloud-reporting evaluates the query
+              # and how the GUI/recording rules evaluate the query.
+              )[60m:1m]
+            )/60 )
+          record: appcat:billing

--- a/tests/golden/defaults/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_appcat_namespace.yaml
@@ -4,4 +4,5 @@ metadata:
   annotations: {}
   labels:
     name: syn-appcat
+    openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/tests/golden/defaults/appcat/appcat/10_appcat_recording_rule.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_appcat_recording_rule.yaml
@@ -1,0 +1,85 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-billing
+  name: appcat-billing
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-billing
+      rules:
+        - expr: |
+            sum by (label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla,product,provider,architecture, category, claim_namespace,tenant_id) (
+            # Sum values over one hour and get mean
+            sum_over_time(
+              # Udpate label product: $product:$provider:$tenant_id:$claim_namespace:$architecture
+              label_join(
+                # Add label category: $provider:$claim_namespace
+                label_join(
+                  # Add label architecture: $SLA, where $SLA is the content of label appcat.vshn.io/sla
+                  label_replace(
+                    # Add label provider: vshn
+                    label_replace(
+                      # Add label product: postgres
+                      label_replace(
+                        # Default appcat.vshn.io/sla to besteffort if it is not set
+                        label_replace(
+                          # Copy label appcat.vshn.io/namespace to label claim_namespace
+                          label_replace(
+                            # Populate tenant_id
+                            label_replace(
+                              # Fetch all namespaces with label label_appuio_io_billing_name=~"appcat-.+"
+                              kube_namespace_labels{ label_appuio_io_billing_name=~"appcat-.+"} *
+                              on (namespace) group_right(label_appuio_io_organization,label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla, label_appuio_io_billing_name)
+                              kube_pod_info{created_by_kind!="Job"},
+                              "tenant_id",
+            "t-silent-test-1234",
+            "",
+            ""
+
+                            ),
+                            "claim_namespace",
+                            "$1",
+                            "label_appcat_vshn_io_claim_namespace",
+                            "(.*)"
+                          ),
+                          "label_appcat_vshn_io_sla",
+                          "besteffort",
+                          "label_appcat_vshn_io_sla",
+                          "^$"
+                        ),
+                        "product",
+                        "appcat_$1",
+                        "label_appuio_io_billing_name",
+                        "appcat-(.+)"
+                      ),
+                      "provider",
+                      "vshn",
+                      "",
+                      ""
+                    ),
+                    "sla",
+                    "$1",
+                    "label_appcat_vshn_io_sla",
+                    "(.*)"
+                  ),
+                  "category",
+                  ":",
+                  "provider",
+                  "claim_namespace"
+                ),
+                "product",
+                ":",
+                "product",
+                "provider",
+                "tenant_id",
+                "claim_namespace",
+                "sla"
+              # other billing queries have [59m:1m] here. This is due to some
+              # obscure discrepancies between how the cloud-reporting evaluates the query
+              # and how the GUI/recording rules evaluate the query.
+              )[60m:1m]
+            )/60 )
+          record: appcat:billing

--- a/tests/golden/exoscale/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_appcat_namespace.yaml
@@ -4,4 +4,5 @@ metadata:
   annotations: {}
   labels:
     name: syn-appcat
+    openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/tests/golden/exoscale/appcat/appcat/10_appcat_recording_rule.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_appcat_recording_rule.yaml
@@ -1,0 +1,85 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-billing
+  name: appcat-billing
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-billing
+      rules:
+        - expr: |
+            sum by (label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla,product,provider,architecture, category, claim_namespace,tenant_id) (
+            # Sum values over one hour and get mean
+            sum_over_time(
+              # Udpate label product: $product:$provider:$tenant_id:$claim_namespace:$architecture
+              label_join(
+                # Add label category: $provider:$claim_namespace
+                label_join(
+                  # Add label architecture: $SLA, where $SLA is the content of label appcat.vshn.io/sla
+                  label_replace(
+                    # Add label provider: vshn
+                    label_replace(
+                      # Add label product: postgres
+                      label_replace(
+                        # Default appcat.vshn.io/sla to besteffort if it is not set
+                        label_replace(
+                          # Copy label appcat.vshn.io/namespace to label claim_namespace
+                          label_replace(
+                            # Populate tenant_id
+                            label_replace(
+                              # Fetch all namespaces with label label_appuio_io_billing_name=~"appcat-.+"
+                              kube_namespace_labels{ label_appuio_io_billing_name=~"appcat-.+"} *
+                              on (namespace) group_right(label_appuio_io_organization,label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla, label_appuio_io_billing_name)
+                              kube_pod_info{created_by_kind!="Job"},
+                              "tenant_id",
+            "t-silent-test-1234",
+            "",
+            ""
+
+                            ),
+                            "claim_namespace",
+                            "$1",
+                            "label_appcat_vshn_io_claim_namespace",
+                            "(.*)"
+                          ),
+                          "label_appcat_vshn_io_sla",
+                          "besteffort",
+                          "label_appcat_vshn_io_sla",
+                          "^$"
+                        ),
+                        "product",
+                        "appcat_$1",
+                        "label_appuio_io_billing_name",
+                        "appcat-(.+)"
+                      ),
+                      "provider",
+                      "vshn",
+                      "",
+                      ""
+                    ),
+                    "sla",
+                    "$1",
+                    "label_appcat_vshn_io_sla",
+                    "(.*)"
+                  ),
+                  "category",
+                  ":",
+                  "provider",
+                  "claim_namespace"
+                ),
+                "product",
+                ":",
+                "product",
+                "provider",
+                "tenant_id",
+                "claim_namespace",
+                "sla"
+              # other billing queries have [59m:1m] here. This is due to some
+              # obscure discrepancies between how the cloud-reporting evaluates the query
+              # and how the GUI/recording rules evaluate the query.
+              )[60m:1m]
+            )/60 )
+          record: appcat:billing

--- a/tests/golden/openshift/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_appcat_namespace.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     foo: bar
     name: syn-appcat
+    openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/tests/golden/openshift/appcat/appcat/10_appcat_recording_rule.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_appcat_recording_rule.yaml
@@ -1,0 +1,85 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-billing
+  name: appcat-billing
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-billing
+      rules:
+        - expr: |
+            sum by (label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla,product,provider,architecture, category, claim_namespace,tenant_id) (
+            # Sum values over one hour and get mean
+            sum_over_time(
+              # Udpate label product: $product:$provider:$tenant_id:$claim_namespace:$architecture
+              label_join(
+                # Add label category: $provider:$claim_namespace
+                label_join(
+                  # Add label architecture: $SLA, where $SLA is the content of label appcat.vshn.io/sla
+                  label_replace(
+                    # Add label provider: vshn
+                    label_replace(
+                      # Add label product: postgres
+                      label_replace(
+                        # Default appcat.vshn.io/sla to besteffort if it is not set
+                        label_replace(
+                          # Copy label appcat.vshn.io/namespace to label claim_namespace
+                          label_replace(
+                            # Populate tenant_id
+                            label_replace(
+                              # Fetch all namespaces with label label_appuio_io_billing_name=~"appcat-.+"
+                              kube_namespace_labels{ label_appuio_io_billing_name=~"appcat-.+"} *
+                              on (namespace) group_right(label_appuio_io_organization,label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla, label_appuio_io_billing_name)
+                              kube_pod_info{created_by_kind!="Job"},
+                              "tenant_id",
+            "t-silent-test-1234",
+            "",
+            ""
+
+                            ),
+                            "claim_namespace",
+                            "$1",
+                            "label_appcat_vshn_io_claim_namespace",
+                            "(.*)"
+                          ),
+                          "label_appcat_vshn_io_sla",
+                          "besteffort",
+                          "label_appcat_vshn_io_sla",
+                          "^$"
+                        ),
+                        "product",
+                        "appcat_$1",
+                        "label_appuio_io_billing_name",
+                        "appcat-(.+)"
+                      ),
+                      "provider",
+                      "vshn",
+                      "",
+                      ""
+                    ),
+                    "sla",
+                    "$1",
+                    "label_appcat_vshn_io_sla",
+                    "(.*)"
+                  ),
+                  "category",
+                  ":",
+                  "provider",
+                  "claim_namespace"
+                ),
+                "product",
+                ":",
+                "product",
+                "provider",
+                "tenant_id",
+                "claim_namespace",
+                "sla"
+              # other billing queries have [59m:1m] here. This is due to some
+              # obscure discrepancies between how the cloud-reporting evaluates the query
+              # and how the GUI/recording rules evaluate the query.
+              )[60m:1m]
+            )/60 )
+          record: appcat:billing

--- a/tests/golden/vshn/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_appcat_namespace.yaml
@@ -4,4 +4,5 @@ metadata:
   annotations: {}
   labels:
     name: syn-appcat
+    openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/tests/golden/vshn/appcat/appcat/10_appcat_recording_rule.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_appcat_recording_rule.yaml
@@ -1,0 +1,85 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-billing
+  name: appcat-billing
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-billing
+      rules:
+        - expr: |
+            sum by (label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla,product,provider,architecture, category, claim_namespace,tenant_id) (
+            # Sum values over one hour and get mean
+            sum_over_time(
+              # Udpate label product: $product:$provider:$tenant_id:$claim_namespace:$architecture
+              label_join(
+                # Add label category: $provider:$claim_namespace
+                label_join(
+                  # Add label architecture: $SLA, where $SLA is the content of label appcat.vshn.io/sla
+                  label_replace(
+                    # Add label provider: vshn
+                    label_replace(
+                      # Add label product: postgres
+                      label_replace(
+                        # Default appcat.vshn.io/sla to besteffort if it is not set
+                        label_replace(
+                          # Copy label appcat.vshn.io/namespace to label claim_namespace
+                          label_replace(
+                            # Populate tenant_id
+                            label_replace(
+                              # Fetch all namespaces with label label_appuio_io_billing_name=~"appcat-.+"
+                              kube_namespace_labels{ label_appuio_io_billing_name=~"appcat-.+"} *
+                              on (namespace) group_right(label_appuio_io_organization,label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla, label_appuio_io_billing_name)
+                              kube_pod_info{created_by_kind!="Job"},
+                              "tenant_id",
+            "t-silent-test-1234",
+            "",
+            ""
+
+                            ),
+                            "claim_namespace",
+                            "$1",
+                            "label_appcat_vshn_io_claim_namespace",
+                            "(.*)"
+                          ),
+                          "label_appcat_vshn_io_sla",
+                          "besteffort",
+                          "label_appcat_vshn_io_sla",
+                          "^$"
+                        ),
+                        "product",
+                        "appcat_$1",
+                        "label_appuio_io_billing_name",
+                        "appcat-(.+)"
+                      ),
+                      "provider",
+                      "vshn",
+                      "",
+                      ""
+                    ),
+                    "sla",
+                    "$1",
+                    "label_appcat_vshn_io_sla",
+                    "(.*)"
+                  ),
+                  "category",
+                  ":",
+                  "provider",
+                  "claim_namespace"
+                ),
+                "product",
+                ":",
+                "product",
+                "provider",
+                "tenant_id",
+                "claim_namespace",
+                "sla"
+              # other billing queries have [59m:1m] here. This is due to some
+              # obscure discrepancies between how the cloud-reporting evaluates the query
+              # and how the GUI/recording rules evaluate the query.
+              )[60m:1m]
+            )/60 )
+          record: appcat:billing


### PR DESCRIPTION
## Summary

This will add a recording rule which is slightly different between appuio managed and appuio cloud. There's a new flag to handle this.
    
If the cluster is APPUiO Managed then the recording rule will get the customer's ID hardcoded into the rule.
    
If the cluster is APPUiO Cloud, then the rule will use the provided organization information.
    
Additionally, the query has been reworked so it's generic. It's now able to query all current and future AppCat services as long as the namespace where it's deployed contains a label of the pattern `label_appuio_io_billing_name=~"appcat-.+"`.

Example output of the rule with a postgres and redis instance:
![Screenshot 2023-07-04 at 08 37 40](https://github.com/vshn/component-appcat/assets/7460550/b78d5967-9794-4b16-80a3-e37c70f36ef8)

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
