### PR TITLE
Add option to define namespace labels and annotations

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -31,10 +31,15 @@ parameters:
         tag: v4.9.0
 
     namespace: syn-appcat
+    namespaceLabels: {}
+    namespaceAnnotations: {}
+
 
     controller:
       enabled: false
       namespace: appcat-controllers
+      namespaceLabels: ${appcat:namespaceLabels}
+      namespaceAnnotations: ${appcat:namespaceAnnotations}
       postgres:
         enabled: false
         extraArgs: []
@@ -50,6 +55,8 @@ parameters:
     apiserver:
       enabled: false
       namespace: appcat-apiserver
+      namespaceLabels: ${appcat:namespaceLabels}
+      namespaceAnnotations: ${appcat:namespaceAnnotations}
       env:
         APPCAT_HANDLER_ENABLED: "true"
         VSHN_POSTGRES_BACKUP_HANDLER_ENABLED: "false"
@@ -71,6 +78,8 @@ parameters:
     slos:
       enabled: true
       namespace: appcat-slos
+      namespaceLabels: ${appcat:namespaceLabels}
+      namespaceAnnotations: ${appcat:namespaceAnnotations}
       sla_reporter:
         enabled: false
         resources:

--- a/component/appcat_apiserver.jsonnet
+++ b/component/appcat_apiserver.jsonnet
@@ -12,6 +12,8 @@ local loadManifest(manifest) = std.parseJson(kap.yaml_load('appcat/manifests/' +
 local namespace = loadManifest('namespace.yaml') {
   metadata+: {
     name: apiserverParams.namespace,
+    labels+: apiserverParams.namespaceLabels,
+    annotations+: apiserverParams.namespaceAnnotations,
   },
 };
 

--- a/component/appcat_controller_postgres.jsonnet
+++ b/component/appcat_controller_postgres.jsonnet
@@ -13,6 +13,8 @@ local loadManifest(manifest) = std.parseJson(kap.yaml_load('appcat/manifests/' +
 local namespace = loadManifest('namespace.yaml') {
   metadata+: {
     name: controllersParams.namespace,
+    labels+: controllersParams.namespaceLabels,
+    annotations+: controllersParams.namespaceAnnotations,
   },
 };
 

--- a/component/appcat_sli_exporter.jsonnet
+++ b/component/appcat_sli_exporter.jsonnet
@@ -38,7 +38,8 @@ local namespace_patch = kube.Namespace('system') {
   metadata+: {
     labels: {
       [if isOpenshift then 'openshift.io/cluster-monitoring']: 'true',  // Enable cluster-monitoring on APPUiO Managed OpenShift
-    },
+    } + params.slos.namespaceLabels,
+    annotations+: params.slos.namespaceAnnotations,
   },
 };
 

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -69,7 +69,12 @@ local readServices = kube.ClusterRole('appcat:services:read') + {
 };
 
 // adding namespace for syn-appcat
-local ns = kube.Namespace(params.namespace);
+local ns = kube.Namespace(params.namespace) {
+  metadata+: {
+    labels+: params.namespaceLabels,
+    annotations+: params.namespaceAnnotations,
+  },
+};
 
 local emailSecret = kube.Secret(params.services.vshn.emailAlerting.secretName) {
   metadata+: {

--- a/docs/modules/ROOT/pages/references/appcat-apiserver.adoc
+++ b/docs/modules/ROOT/pages/references/appcat-apiserver.adoc
@@ -17,6 +17,22 @@ default:: `appcat-apiserver`
 A namespace where API Server should run.
 The namespace will be created and managed by this component.
 
+== `namespaceLabels`
+
+[horizontal]
+type:: dict
+default:: `${appcat:namespaceLabels}`
+
+Additional labels to add to the created namespace.
+
+== `namespaceAnnotations`
+
+[horizontal]
+type:: dict
+default:: `${appcat:namespaceAnnotations}`
+
+Additional annotations to add to the created namespace.
+
 == `extraArgs`
 [horizontal]
 type:: array

--- a/docs/modules/ROOT/pages/references/appcat-postgres-controller.adoc
+++ b/docs/modules/ROOT/pages/references/appcat-postgres-controller.adoc
@@ -17,6 +17,22 @@ default:: `appcat-controllers`
 A namespace where PostgreSQL Server should run.
 The namespace will be created and managed by this component.
 
+== `namespaceLabels`
+
+[horizontal]
+type:: dict
+default:: `${appcat:namespaceLabels}`
+
+Additional labels to add to the created namespace.
+
+== `namespaceAnnotations`
+
+[horizontal]
+type:: dict
+default:: `${appcat:namespaceAnnotations}`
+
+Additional annotations to add to the created namespace.
+
 == `extraArgs`
 [horizontal]
 type:: array

--- a/docs/modules/ROOT/pages/references/component-parameters.adoc
+++ b/docs/modules/ROOT/pages/references/component-parameters.adoc
@@ -13,6 +13,31 @@ Each image is specified using keys `registry`, `repository` and `tag`.
 This structure allows easily injecting a registry mirror, if required.
 
 
+== `namespace`
+
+[horizontal]
+type:: string
+default:: `syn-appcat`
+
+The namespace in which to deploy AppCat resources.
+
+== `namespaceLabels`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Additional labels to add to the created namespace.
+
+== `namespaceAnnotations`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Additional annotations to add to the created namespace.
+
+
 == `apiserver`
 [horizontal]
 type:: dict

--- a/docs/modules/ROOT/pages/references/slo-parameters.adoc
+++ b/docs/modules/ROOT/pages/references/slo-parameters.adoc
@@ -17,6 +17,22 @@ default:: `appcat-slos`
 A namespace where all SLO related resources will be deployed to, including the SLI Exporter.
 The namespace will be created and managed by this component.
 
+== `namespaceLabels`
+
+[horizontal]
+type:: dict
+default:: `${appcat:namespaceLabels}`
+
+Additional labels to add to the created namespace.
+
+== `namespaceAnnotations`
+
+[horizontal]
+type:: dict
+default:: `${appcat:namespaceAnnotations}`
+
+Additional annotations to add to the created namespace.
+
 == `sli_exporter.resources`
 [horizontal]
 type:: dict

--- a/tests/golden/apiserver/appcat/appcat/apiserver/10_namespace.yaml
+++ b/tests/golden/apiserver/appcat/appcat/apiserver/10_namespace.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations: {}
+  labels: {}
   name: appcat-apiserver

--- a/tests/golden/controllers/appcat/appcat/controllers/postgres/10_namespace.yaml
+++ b/tests/golden/controllers/appcat/appcat/controllers/postgres/10_namespace.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations: {}
+  labels: {}
   name: appcat-controllers

--- a/tests/golden/openshift/appcat/appcat/10_appcat_namespace.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_appcat_namespace.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations: {}
+  annotations:
+    openshift.io/node-selector: node-role.kubernetes.io/infra=
   labels:
+    foo: bar
     name: syn-appcat
   name: syn-appcat

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/v1_namespace_appcat-slos.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/v1_namespace_appcat-slos.yaml
@@ -1,7 +1,10 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: node-role.kubernetes.io/infra=
   labels:
     control-plane: controller-manager
+    foo: bar
     openshift.io/cluster-monitoring: "true"
   name: appcat-slos

--- a/tests/golden/vshn/appcat/appcat/apiserver/10_namespace.yaml
+++ b/tests/golden/vshn/appcat/appcat/apiserver/10_namespace.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations: {}
+  labels: {}
   name: appcat-apiserver

--- a/tests/golden/vshn/appcat/appcat/controllers/postgres/10_namespace.yaml
+++ b/tests/golden/vshn/appcat/appcat/controllers/postgres/10_namespace.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations: {}
+  labels: {}
   name: appcat-controllers

--- a/tests/openshift.yml
+++ b/tests/openshift.yml
@@ -13,6 +13,11 @@ parameters:
     namespace: syn-crossplane
 
   appcat:
+    namespaceLabels:
+      foo: bar
+    namespaceAnnotations:
+      openshift.io/node-selector: node-role.kubernetes.io/infra=
+
     providers:
       cloudscale:
         enabled: true


### PR DESCRIPTION
This gives us some flexibilty and can be helpful in multiple situations. The main usecase currently is that we can schedule appcat on infra nodes on OpenShift using the annotation `openshift.io/node-selector`




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
