### PR TITLE
Fix user permission in DB namespace

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -57,7 +57,12 @@ local readServices = kube.ClusterRole('appcat:services:read') + {
   rules+: [
     {
       apiGroups: [ '' ],
-      resources: [ 'pods', 'pods/log', 'pods/status', 'events', 'services' ],
+      resources: [ 'pods', 'pods/log', 'pods/status', 'events', 'services', 'namespaces' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
+    {
+      apiGroups: [ 'apps' ],
+      resources: [ 'statefulsets' ],
       verbs: [ 'get', 'list', 'watch' ],
     },
     {

--- a/tests/golden/apiserver/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/apiserver/appcat/appcat/10_clusterrole_services_read.yaml
@@ -14,6 +14,15 @@ rules:
       - pods/status
       - events
       - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
     verbs:
       - get
       - list

--- a/tests/golden/cloudscale/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_clusterrole_services_read.yaml
@@ -14,6 +14,15 @@ rules:
       - pods/status
       - events
       - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
     verbs:
       - get
       - list

--- a/tests/golden/controllers/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/controllers/appcat/appcat/10_clusterrole_services_read.yaml
@@ -14,6 +14,15 @@ rules:
       - pods/status
       - events
       - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
     verbs:
       - get
       - list

--- a/tests/golden/defaults/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_clusterrole_services_read.yaml
@@ -14,6 +14,15 @@ rules:
       - pods/status
       - events
       - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
     verbs:
       - get
       - list

--- a/tests/golden/exoscale/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_clusterrole_services_read.yaml
@@ -14,6 +14,15 @@ rules:
       - pods/status
       - events
       - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
     verbs:
       - get
       - list

--- a/tests/golden/openshift/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_clusterrole_services_read.yaml
@@ -14,6 +14,15 @@ rules:
       - pods/status
       - events
       - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
     verbs:
       - get
       - list

--- a/tests/golden/vshn/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_clusterrole_services_read.yaml
@@ -14,6 +14,15 @@ rules:
       - pods/status
       - events
       - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
     verbs:
       - get
       - list


### PR DESCRIPTION
We now additionally give read access for the namespace and statefulsets. This improves the UX in the OpenShift UI as users now see the project as well as see the database deployment in the `Topology` tab.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
