### PR TITLE
Explicitly allow provider kubernetes to bind `appcat:services:read`

### DIFF
--- a/component/provider.jsonnet
+++ b/component/provider.jsonnet
@@ -134,6 +134,13 @@ local controllerConfigRef(config) =
           verbs: [ 'get', 'list', 'watch', 'create', 'watch', 'patch', 'update', 'delete' ],
         },
         {
+          apiGroups: [ 'rbac.authorization.k8s.io' ],
+          resources: [ 'clusterroles' ],
+          resourceNames: [ 'appcat:services:read' ],
+          verbs: [ 'bind' ],
+        },
+
+        {
           apiGroups: [ 'stackgres.io' ],
           resources: [ 'sginstanceprofiles', 'sgclusters', 'sgpgconfigs', 'sgobjectstorages', 'sgbackups', 'sgdbops' ],
           verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
@@ -184,7 +191,6 @@ local controllerConfigRef(config) =
       roleRef_: role,
       subjects_: [ sa ],
     };
-
 
     local controllerConf = controllerConfig('kubernetes', provider.controllerConfig);
 

--- a/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -97,6 +97,14 @@ rules:
       - update
       - delete
   - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - appcat:services:read
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+  - apiGroups:
       - stackgres.io
     resources:
       - sginstanceprofiles

--- a/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -97,6 +97,14 @@ rules:
       - update
       - delete
   - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - appcat:services:read
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+  - apiGroups:
       - stackgres.io
     resources:
       - sginstanceprofiles

--- a/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
@@ -99,6 +99,14 @@ rules:
       - update
       - delete
   - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - appcat:services:read
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+  - apiGroups:
       - stackgres.io
     resources:
       - sginstanceprofiles

--- a/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
@@ -97,6 +97,14 @@ rules:
       - update
       - delete
   - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - appcat:services:read
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+  - apiGroups:
       - stackgres.io
     resources:
       - sginstanceprofiles


### PR DESCRIPTION

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
