### PR TITLE
Add missing project permissions on appcat service namespace

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -70,6 +70,11 @@ local readServices = kube.ClusterRole('appcat:services:read') + {
       resources: [ 'pods/portforward' ],
       verbs: [ 'get', 'list', 'create' ],
     },
+    {
+      apiGroups: [ '', 'project.openshift.io' ],
+      resources: [ 'projects' ],
+      verbs: [ 'get' ],
+    },
   ],
 };
 

--- a/tests/golden/apiserver/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/apiserver/appcat/appcat/10_clusterrole_services_read.yaml
@@ -35,3 +35,10 @@ rules:
       - get
       - list
       - create
+  - apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projects
+    verbs:
+      - get

--- a/tests/golden/cloudscale/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_clusterrole_services_read.yaml
@@ -35,3 +35,10 @@ rules:
       - get
       - list
       - create
+  - apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projects
+    verbs:
+      - get

--- a/tests/golden/controllers/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/controllers/appcat/appcat/10_clusterrole_services_read.yaml
@@ -35,3 +35,10 @@ rules:
       - get
       - list
       - create
+  - apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projects
+    verbs:
+      - get

--- a/tests/golden/defaults/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_clusterrole_services_read.yaml
@@ -35,3 +35,10 @@ rules:
       - get
       - list
       - create
+  - apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projects
+    verbs:
+      - get

--- a/tests/golden/exoscale/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_clusterrole_services_read.yaml
@@ -35,3 +35,10 @@ rules:
       - get
       - list
       - create
+  - apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projects
+    verbs:
+      - get

--- a/tests/golden/openshift/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_clusterrole_services_read.yaml
@@ -35,3 +35,10 @@ rules:
       - get
       - list
       - create
+  - apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projects
+    verbs:
+      - get

--- a/tests/golden/vshn/appcat/appcat/10_clusterrole_services_read.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_clusterrole_services_read.yaml
@@ -35,3 +35,10 @@ rules:
       - get
       - list
       - create
+  - apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projects
+    verbs:
+      - get


### PR DESCRIPTION
In order for the end user to properly see the logs in the console, the project permission is required.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
