### PR TITLE
Add SA, Clusterrole and Clusterrolebinding for redis restores

### DIFF
--- a/component/provider.jsonnet
+++ b/component/provider.jsonnet
@@ -134,6 +134,16 @@ local controllerConfigRef(config) =
           verbs: [ 'get', 'list', 'watch', 'create', 'watch', 'patch', 'update', 'delete' ],
         },
         {
+          apiGroups: [ 'apps' ],
+          resources: [ 'statefulsets/scale' ],
+          verbs: [ 'update', 'patch' ],
+        },
+        {
+          apiGroups: [ 'apps' ],
+          resources: [ 'statefulsets' ],
+          verbs: [ 'get' ],
+        },
+        {
           apiGroups: [ 'rbac.authorization.k8s.io' ],
           resources: [ 'clusterroles' ],
           resourceNames: [ 'appcat:services:read' ],
@@ -176,6 +186,11 @@ local controllerConfigRef(config) =
           verbs: [ 'get', 'update' ],
         },
         {
+          apiGroups: [ 'vshn.appcat.vshn.io' ],
+          resources: [ 'vshnredis' ],
+          verbs: [ 'get', 'update' ],
+        },
+        {
           apiGroups: [ 'monitoring.coreos.com' ],
           resources: [ 'prometheusrules', 'podmonitors', 'alertmanagerconfigs' ],
           verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
@@ -184,6 +199,11 @@ local controllerConfigRef(config) =
           apiGroups: [ 'k8up.io' ],
           resources: [ 'schedules' ],
           verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
+        },
+        {
+          apiGroups: [ 'k8up.io' ],
+          resources: [ 'snapshots' ],
+          verbs: [ 'get' ],
         },
       ],
     };

--- a/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -97,6 +97,19 @@ rules:
       - update
       - delete
   - apiGroups:
+      - apps
+    resources:
+      - statefulsets/scale
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+  - apiGroups:
       - rbac.authorization.k8s.io
     resourceNames:
       - appcat:services:read
@@ -193,6 +206,13 @@ rules:
       - get
       - update
   - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnredis
+    verbs:
+      - get
+      - update
+  - apiGroups:
       - monitoring.coreos.com
     resources:
       - prometheusrules
@@ -218,6 +238,12 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - k8up.io
+    resources:
+      - snapshots
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -97,6 +97,19 @@ rules:
       - update
       - delete
   - apiGroups:
+      - apps
+    resources:
+      - statefulsets/scale
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+  - apiGroups:
       - rbac.authorization.k8s.io
     resourceNames:
       - appcat:services:read
@@ -193,6 +206,13 @@ rules:
       - get
       - update
   - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnredis
+    verbs:
+      - get
+      - update
+  - apiGroups:
       - monitoring.coreos.com
     resources:
       - prometheusrules
@@ -218,6 +238,12 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - k8up.io
+    resources:
+      - snapshots
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
@@ -99,6 +99,19 @@ rules:
       - update
       - delete
   - apiGroups:
+      - apps
+    resources:
+      - statefulsets/scale
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+  - apiGroups:
       - rbac.authorization.k8s.io
     resourceNames:
       - appcat:services:read
@@ -195,6 +208,13 @@ rules:
       - get
       - update
   - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnredis
+    verbs:
+      - get
+      - update
+  - apiGroups:
       - monitoring.coreos.com
     resources:
       - prometheusrules
@@ -220,6 +240,12 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - k8up.io
+    resources:
+      - snapshots
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
@@ -97,6 +97,19 @@ rules:
       - update
       - delete
   - apiGroups:
+      - apps
+    resources:
+      - statefulsets/scale
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+  - apiGroups:
       - rbac.authorization.k8s.io
     resourceNames:
       - appcat:services:read
@@ -193,6 +206,13 @@ rules:
       - get
       - update
   - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnredis
+    verbs:
+      - get
+      - update
+  - apiGroups:
       - monitoring.coreos.com
     resources:
       - prometheusrules
@@ -218,6 +238,12 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - k8up.io
+    resources:
+      - snapshots
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/golden/vshn/appcat/appcat/20_role_vshn_redisrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_role_vshn_redisrestore.yaml
@@ -1,0 +1,72 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: crossplane-appcat-job-redis-restorejob
+  name: crossplane:appcat:job:redis:restorejob
+rules:
+  - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnredis
+    verbs:
+      - get
+  - apiGroups:
+      - k8up.io
+    resources:
+      - snapshots
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets/scale
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: redisrestoreserviceaccount
+  name: redisrestoreserviceaccount
+  namespace: syn-appcat-control
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-job-redis-restorejob
+  name: appcat:job:redis:restorejob
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane:appcat:job:redis:restorejob
+subjects:
+  - kind: ServiceAccount
+    name: redisrestoreserviceaccount
+    namespace: syn-appcat-control

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -32,6 +32,7 @@ spec:
           controlNamespace: syn-appcat-control
           imageTag: v4.12.0
           maintenanceSA: helm-based-service-maintenance
+          restoreSA: redisrestoreserviceaccount
         kind: ConfigMap
         metadata:
           labels:
@@ -43,7 +44,7 @@ spec:
         runner:
           endpoint: unix-abstract:crossplane/fn/default.sock
         timeout: 20s
-      name: pgsql-func
+      name: redis-func
       type: Container
   resources:
     - base:


### PR DESCRIPTION
This PR adds the necessary SA, Clusterrole and Clusterrolebinding in order to provide the necessary permissions for restoring a redis instance.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
