### PR TITLE
Add rbac rule for redis restore to be able to create events

### DIFF
--- a/component/vshn_redis.jsonnet
+++ b/component/vshn_redis.jsonnet
@@ -84,6 +84,11 @@ local restoreRole = kube.ClusterRole(restoreRoleName) {
       resources: [ 'jobs' ],
       verbs: [ 'get' ],
     },
+    {
+      apiGroups: [ '' ],
+      resources: [ 'events' ],
+      verbs: [ 'get', 'create', 'patch' ],
+    },
   ],
 };
 

--- a/tests/golden/vshn/appcat/appcat/20_role_vshn_redisrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_role_vshn_redisrestore.yaml
@@ -45,6 +45,14 @@ rules:
       - jobs
     verbs:
       - get
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - get
+      - create
+      - patch
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
The restore process creates events to notify the user if a restore succeeded or failed. Therefore the job's SA requires those additional rbac rules


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
