### PR TITLE
fixing issue with insecure Redis certificates

### DIFF
--- a/component/vshn_redis.jsonnet
+++ b/component/vshn_redis.jsonnet
@@ -194,9 +194,7 @@ local composition =
                                     encoding: 'PKCS1',
                                     size: 4096,
                                   },
-                                  dnsNames: [
-                                    'vshn.appcat.vshn.ch',
-                                  ],
+                                  dnsNames: [],
                                   issuerRef: {
                                     name: '',
                                     kind: 'Issuer',
@@ -253,9 +251,7 @@ local composition =
                                         'server auth',
                                         'client auth',
                                       ],
-                                      dnsNames: [
-                                        'vshn.appcat.vshn.ch',
-                                      ],
+                                      dnsNames: [],
                                       issuerRef: {
                                         name: '',
                                         kind: 'Issuer',
@@ -293,9 +289,7 @@ local composition =
                                       usages: [
                                         'client auth',
                                       ],
-                                      dnsNames: [
-                                        'vshn.appcat.vshn.ch',
-                                      ],
+                                      dnsNames: [],
                                       issuerRef: {
                                         name: '',
                                         kind: 'Issuer',
@@ -527,6 +521,8 @@ local composition =
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'ca'),
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.issuerRef.name', 'selfsigned-issuer'),
             comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
+            comp.CombineCompositeFromOneFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.dnsNames[0]', 'redis-headless.vshn-redis-%s.svc.cluster.local'),
+
           ],
         },
         {
@@ -538,6 +534,8 @@ local composition =
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'server'),
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.issuerRef.name', 'ca-issuer'),
             comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
+            comp.CombineCompositeFromOneFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.dnsNames[0]', 'redis-headless.vshn-redis-%s.svc.cluster.local'),
+
           ],
         },
         {
@@ -549,6 +547,7 @@ local composition =
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'client'),
             comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.issuerRef.name', 'ca-issuer'),
             comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
+            comp.CombineCompositeFromOneFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.dnsNames[0]', 'redis-headless.vshn-redis-%s.svc.cluster.local'),
           ],
         },
         {

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -268,8 +268,7 @@ spec:
                 name: ''
                 namespace: ''
               spec:
-                dnsNames:
-                  - vshn.appcat.vshn.ch
+                dnsNames: []
                 duration: 87600h
                 isCA: true
                 issuerRef:
@@ -324,6 +323,14 @@ spec:
                 type: Format
               type: string
           type: FromCompositeFieldPath
+        - combine:
+            strategy: string
+            string:
+              fmt: redis-headless.vshn-redis-%s.svc.cluster.local
+            variables:
+              - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.manifest.spec.dnsNames[0]
+          type: CombineFromComposite
     - base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
         kind: Object
@@ -337,8 +344,7 @@ spec:
                 name: ''
                 namespace: ''
               spec:
-                dnsNames:
-                  - vshn.appcat.vshn.ch
+                dnsNames: []
                 duration: 87600h
                 isCA: false
                 issuerRef:
@@ -396,6 +402,14 @@ spec:
                 type: Format
               type: string
           type: FromCompositeFieldPath
+        - combine:
+            strategy: string
+            string:
+              fmt: redis-headless.vshn-redis-%s.svc.cluster.local
+            variables:
+              - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.manifest.spec.dnsNames[0]
+          type: CombineFromComposite
     - base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
         kind: Object
@@ -409,8 +423,7 @@ spec:
                 name: ''
                 namespace: ''
               spec:
-                dnsNames:
-                  - vshn.appcat.vshn.ch
+                dnsNames: []
                 duration: 87600h
                 isCA: false
                 issuerRef:
@@ -467,6 +480,14 @@ spec:
                 type: Format
               type: string
           type: FromCompositeFieldPath
+        - combine:
+            strategy: string
+            string:
+              fmt: redis-headless.vshn-redis-%s.svc.cluster.local
+            variables:
+              - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.manifest.spec.dnsNames[0]
+          type: CombineFromComposite
     - base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
         kind: Object


### PR DESCRIPTION
Setting correct name to certificates, so they can be trusted after adding ca.crt to chain.
This change is necessary because of: https://github.com/vshn/appcat/pull/63

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.