### PR TITLE
Increasing the sts resizer's resources

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -60,6 +60,15 @@ parameters:
             cpu: 200m
             memory: 200Mi
 
+    stsResizer:
+      resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            cpu: 250m
+            memory: 200Mi
+
     apiserver:
       enabled: false
       namespace: appcat-apiserver

--- a/component/statefuleset-resize-controller.jsonnet
+++ b/component/statefuleset-resize-controller.jsonnet
@@ -7,6 +7,7 @@ local params = inv.parameters.appcat;
 local srcImage = params.images.statefulSetResizer;
 local imageTag = std.strReplace(srcImage.tag, '/', '_');
 local image = srcImage.registry + '/' + srcImage.repository + ':' + imageTag;
+local stsParams = params.stsResizer;
 
 local loadManifest(manifest) =
   std.parseJson(kap.yaml_load(inv.parameters._base_directory + '/dependencies/appcat/manifests/statefulset-resize-controller/' + srcImage.tag + '/' + manifest));
@@ -54,7 +55,7 @@ local deployment = loadManifest('config/manager/manager.yaml') + {
             c {
               image: image,
               args: args,
-              // resources+: params.operator.resources,
+              resources+: stsParams.resources,
             }
           else
             c

--- a/tests/golden/vshn/appcat/appcat/controllers/sts-resizer/10_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/controllers/sts-resizer/10_deployment.yaml
@@ -34,11 +34,11 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 100m
-              memory: 30Mi
+              cpu: 250m
+              memory: 200Mi
             requests:
               cpu: 100m
-              memory: 20Mi
+              memory: 50Mi
           securityContext:
             allowPrivilegeEscalation: false
       securityContext:


### PR DESCRIPTION
The sts resizer didn't have enough resources, which resulted in missed health checks and thus it got regularly killed by k8s.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
