### PR TITLE
Generate a valid `kustomization.yaml` when SLOs are disabled

### DIFF
--- a/component/appcat_sli_exporter.jsonnet
+++ b/component/appcat_sli_exporter.jsonnet
@@ -72,7 +72,7 @@ local kustomization =
       namespace_patch: namespace_patch,
     }
   else {
-    kustomization: {},
+    kustomization: { resources: [] },
   };
 
 


### PR DESCRIPTION
We had various reports where catalog compilation sometimes failed with `Error: kustomization.yaml is empty`. After some investigation, it turns out that this error is caused by kustomize v5.1.1 when a completely empty file is provided as `kustomization.yaml`.

We fix the issue by generating a `kustomization.yaml` which contains `resources: []` when SLOs are disabled.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
