### PR TITLE
Switching to composite

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -39,7 +39,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.28.0
+        tag: v4.29.0
       apiserver:
         registry: ghcr.io
         repository: vshn/appcat-apiserver

--- a/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.28.0
+          image: ghcr.io/vshn/appcat:v4.29.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -28,7 +28,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNREDIS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.28.0
+        image: ghcr.io/vshn/appcat:v4.29.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -47,3 +47,31 @@ rules:
   - vshnredis/status
   verbs:
   - get
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnpostgresqls
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnpostgresqls/status
+  verbs:
+  - get
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnredis
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnredis/status
+  verbs:
+  - get

--- a/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
@@ -25,7 +25,7 @@ spec:
         data:
           controlNamespace: syn-appcat-control
           defaultPlan: standard-1
-          imageTag: v4.28.0
+          imageTag: v4.29.0
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io
           minioChartVersion: 5.0.13

--- a/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.28.0
+          image: ghcr.io/vshn/appcat:v4.29.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.28.0
+              image: ghcr.io/vshn/appcat:v4.29.0
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -28,7 +28,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNREDIS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.28.0
+        image: ghcr.io/vshn/appcat:v4.29.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/minio/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -47,3 +47,31 @@ rules:
   - vshnredis/status
   verbs:
   - get
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnpostgresqls
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnpostgresqls/status
+  verbs:
+  - get
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnredis
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnredis/status
+  verbs:
+  - get

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -28,7 +28,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNREDIS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.28.0
+        image: ghcr.io/vshn/appcat:v4.29.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -47,3 +47,31 @@ rules:
   - vshnredis/status
   verbs:
   - get
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnpostgresqls
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnpostgresqls/status
+  verbs:
+  - get
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnredis
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnredis/status
+  verbs:
+  - get

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_minio.yaml
@@ -25,7 +25,7 @@ spec:
         data:
           controlNamespace: syn-appcat-control
           defaultPlan: standard-1
-          imageTag: v4.28.0
+          imageTag: v4.29.0
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io
           minioChartVersion: 5.0.13

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -33,7 +33,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.28.0
+          imageTag: v4.29.0
           quotasEnabled: 'false'
           sgNamespace: stackgres
         kind: ConfigMap

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -33,7 +33,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.28.0
+          imageTag: v4.29.0
           quotasEnabled: 'false'
           sgNamespace: stackgres
         kind: ConfigMap

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -30,7 +30,7 @@ spec:
         data:
           bucketRegion: lpg
           controlNamespace: syn-appcat-control
-          imageTag: v4.28.0
+          imageTag: v4.29.0
           maintenanceSA: helm-based-service-maintenance
           quotasEnabled: 'false'
           restoreSA: redisrestoreserviceaccount

--- a/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.28.0
+          image: ghcr.io/vshn/appcat:v4.29.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.28.0
+              image: ghcr.io/vshn/appcat:v4.29.0
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: APPCAT_SLI_VSHNREDIS
           value: "true"
-        image: ghcr.io/vshn/appcat:v4.28.0
+        image: ghcr.io/vshn/appcat:v4.29.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/rbac.authorization.k8s.io_v1_clusterrole_appcat-sliexporter-appcat-sli-exporter.yaml
@@ -47,3 +47,31 @@ rules:
   - vshnredis/status
   verbs:
   - get
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnpostgresqls
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnpostgresqls/status
+  verbs:
+  - get
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnredis
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vshn.appcat.vshn.io
+  resources:
+  - xvshnredis/status
+  verbs:
+  - get


### PR DESCRIPTION
switching SLI prober to reconcile over composite, because we need unique names to avoid alert triggering by recreated instances with the same name