### PR TITLE
Enable resource limits for sidecars and set sensible values

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -275,103 +275,103 @@ parameters:
           sideCars:
             createBackup:
               requests:
-                cpu: "250m"
-                memory: "256Mi"
+                cpu: "100m"
+                memory: "64Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "400m"
+                memory: "500Mi"
             clusterController:
               requests:
                 cpu: "32m"
-                memory: "188Mi"
+                memory: "30Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "32m"
+                memory: "200Mi"
             runDbops:
               requests:
+                cpu: "100m"
+                memory: "64Mi"
+              limits:
                 cpu: "250m"
                 memory: "256Mi"
-              limits:
-                cpu: "600m"
-                memory: "768Mi"
             setDbopsResult:
               requests:
+                cpu: "100m"
+                memory: "64Mi"
+              limits:
                 cpu: "250m"
                 memory: "256Mi"
-              limits:
-                cpu: "600m"
-                memory: "768Mi"
             envoy:
               requests:
                 cpu: "32m"
                 memory: "64Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "64m"
+                memory: "64Mi"
             pgbouncer:
               requests:
                 cpu: "16m"
-                memory: "32Mi"
+                memory: "4Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "32m"
+                memory: "10Mi"
             postgresUtil:
               requests:
                 cpu: "10m"
                 memory: "4Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "20m"
+                memory: "10Mi"
             prometheusPostgresExporter:
               requests:
                 cpu: "10m"
-                memory: "32Mi"
+                memory: "16Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "150m"
+                memory: "256Mi"
           initContainers:
             pgbouncerAuthFile:
               requests:
                 cpu: "100m"
                 memory: "100Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "100m"
+                memory: "100Mi"
             relocateBinaries:
               requests:
                 cpu: "100m"
                 memory: "100Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "100m"
+                memory: "100Mi"
             setupScripts:
               requests:
                 cpu: "100m"
                 memory: "100Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "100m"
+                memory: "100Mi"
             setupArbitraryUser:
               requests:
                 cpu: "100m"
                 memory: "100Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "100m"
+                memory: "100Mi"
             clusterReconciliationCycle:
               requests:
                 cpu: "100m"
                 memory: "100Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "100m"
+                memory: "100Mi"
             setDbopsRunning:
               requests:
                 cpu: "250m"
                 memory: "256Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
+                cpu: "250m"
+                memory: "256Mi"
         redis:
           enabled: true
           enableNetworkPolicy: true

--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -286,7 +286,7 @@ parameters:
                 memory: "30Mi"
               limits:
                 cpu: "32m"
-                memory: "200Mi"
+                memory: "2Gi"
             runDbops:
               requests:
                 cpu: "100m"
@@ -314,14 +314,14 @@ parameters:
                 memory: "4Mi"
               limits:
                 cpu: "32m"
-                memory: "10Mi"
+                memory: "20Mi"
             postgresUtil:
               requests:
                 cpu: "10m"
                 memory: "4Mi"
               limits:
                 cpu: "20m"
-                memory: "10Mi"
+                memory: "20Mi"
             prometheusPostgresExporter:
               requests:
                 cpu: "10m"
@@ -335,35 +335,35 @@ parameters:
                 cpu: "100m"
                 memory: "100Mi"
               limits:
-                cpu: "100m"
-                memory: "100Mi"
+                cpu: "300m"
+                memory: "500Mi"
             relocateBinaries:
               requests:
                 cpu: "100m"
                 memory: "100Mi"
               limits:
-                cpu: "100m"
-                memory: "100Mi"
+                cpu: "300m"
+                memory: "500Mi"
             setupScripts:
               requests:
                 cpu: "100m"
-                memory: "100Mi"
+                memory: "500Mi"
               limits:
-                cpu: "100m"
-                memory: "100Mi"
+                cpu: "300m"
+                memory: "500Mi"
             setupArbitraryUser:
               requests:
                 cpu: "100m"
-                memory: "100Mi"
+                memory: "500Mi"
               limits:
-                cpu: "100m"
-                memory: "100Mi"
+                cpu: "300m"
+                memory: "500Mi"
             clusterReconciliationCycle:
               requests:
                 cpu: "100m"
                 memory: "100Mi"
               limits:
-                cpu: "100m"
+                cpu: "300m"
                 memory: "200Mi"
             setDbopsRunning:
               requests:

--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -364,7 +364,7 @@ parameters:
                 memory: "100Mi"
               limits:
                 cpu: "100m"
-                memory: "100Mi"
+                memory: "200Mi"
             setDbopsRunning:
               requests:
                 cpu: "250m"

--- a/component/component/vshn_postgres.jsonnet
+++ b/component/component/vshn_postgres.jsonnet
@@ -224,39 +224,73 @@ local sgInstanceProfile = {
                   requests: {
                     cpu: null,
                     memory: null,
+                    containers: {
+                      'backup.create-backup': {
+                        cpu: pgParams.sideCars.createBackup.requests.cpu,
+                        memory: pgParams.sideCars.createBackup.requests.memory,
+                      },
+                      'cluster-controller': {
+                        cpu: pgParams.sideCars.clusterController.requests.cpu,
+                        memory: pgParams.sideCars.clusterController.requests.memory,
+                      },
+                      'dbops.run-dbops': {
+                        cpu: pgParams.sideCars.runDbops.requests.cpu,
+                        memory: pgParams.sideCars.runDbops.requests.memory,
+                      },
+                      'dbops.set-dbops-result': {
+                        cpu: pgParams.sideCars.setDbopsResult.requests.cpu,
+                        memory: pgParams.sideCars.setDbopsResult.requests.memory,
+                      },
+                      envoy: {
+                        cpu: pgParams.sideCars.envoy.requests.cpu,
+                        memory: pgParams.sideCars.envoy.requests.memory,
+                      },
+                      pgbouncer: {
+                        cpu: pgParams.sideCars.pgbouncer.requests.cpu,
+                        memory: pgParams.sideCars.pgbouncer.requests.memory,
+                      },
+                      'postgres-util': {
+                        cpu: pgParams.sideCars.postgresUtil.requests.cpu,
+                        memory: pgParams.sideCars.postgresUtil.requests.memory,
+                      },
+                      'prometheus-postgres-exporter': {
+                        cpu: pgParams.sideCars.prometheusPostgresExporter.requests.cpu,
+                        memory: pgParams.sideCars.prometheusPostgresExporter.requests.memory,
+                      },
+                    },
                   },
                   containers: {
                     'backup.create-backup': {
-                      cpu: pgParams.sideCars.createBackup.requests.cpu,
-                      memory: pgParams.sideCars.createBackup.requests.memory,
+                      cpu: pgParams.sideCars.createBackup.limits.cpu,
+                      memory: pgParams.sideCars.createBackup.limits.memory,
                     },
                     'cluster-controller': {
-                      cpu: pgParams.sideCars.clusterController.requests.cpu,
-                      memory: pgParams.sideCars.clusterController.requests.memory,
+                      cpu: pgParams.sideCars.clusterController.limits.cpu,
+                      memory: pgParams.sideCars.clusterController.limits.memory,
                     },
                     'dbops.run-dbops': {
-                      cpu: pgParams.sideCars.runDbops.requests.cpu,
-                      memory: pgParams.sideCars.runDbops.requests.memory,
+                      cpu: pgParams.sideCars.runDbops.limits.cpu,
+                      memory: pgParams.sideCars.runDbops.limits.memory,
                     },
                     'dbops.set-dbops-result': {
-                      cpu: pgParams.sideCars.setDbopsResult.requests.cpu,
-                      memory: pgParams.sideCars.setDbopsResult.requests.memory,
+                      cpu: pgParams.sideCars.setDbopsResult.limits.cpu,
+                      memory: pgParams.sideCars.setDbopsResult.limits.memory,
                     },
                     envoy: {
-                      cpu: pgParams.sideCars.envoy.requests.cpu,
-                      memory: pgParams.sideCars.envoy.requests.memory,
+                      cpu: pgParams.sideCars.envoy.limits.cpu,
+                      memory: pgParams.sideCars.envoy.limits.memory,
                     },
                     pgbouncer: {
-                      cpu: pgParams.sideCars.pgbouncer.requests.cpu,
-                      memory: pgParams.sideCars.pgbouncer.requests.memory,
+                      cpu: pgParams.sideCars.pgbouncer.limits.cpu,
+                      memory: pgParams.sideCars.pgbouncer.limits.memory,
                     },
                     'postgres-util': {
-                      cpu: pgParams.sideCars.postgresUtil.requests.cpu,
-                      memory: pgParams.sideCars.postgresUtil.requests.memory,
+                      cpu: pgParams.sideCars.postgresUtil.limits.cpu,
+                      memory: pgParams.sideCars.postgresUtil.limits.memory,
                     },
                     'prometheus-postgres-exporter': {
-                      cpu: pgParams.sideCars.prometheusPostgresExporter.requests.cpu,
-                      memory: pgParams.sideCars.prometheusPostgresExporter.requests.memory,
+                      cpu: pgParams.sideCars.prometheusPostgresExporter.limits.cpu,
+                      memory: pgParams.sideCars.prometheusPostgresExporter.limits.memory,
                     },
                   },
                   initContainers: {
@@ -372,10 +406,16 @@ local sgCluster = {
                     persistentVolume: {
                       size: '',
                     },
+                    resources: {
+                      enableClusterLimitsRequirements: true,
+                    },
                   },
                   nonProductionOptions: {
                     enableSetPatroniCpuRequests: true,
                     enableSetPatroniMemoryRequests: true,
+                    enableSetClusterCpuRequests: true,
+                    enableSetClusterMemoryRequests: true,
+
                   },
                 },
               },

--- a/component/component/vshn_postgres.jsonnet
+++ b/component/component/vshn_postgres.jsonnet
@@ -258,6 +258,32 @@ local sgInstanceProfile = {
                         memory: pgParams.sideCars.prometheusPostgresExporter.requests.memory,
                       },
                     },
+                    initContainers: {
+                      'pgbouncer-auth-file': {
+                        cpu: pgParams.initContainers.pgbouncerAuthFile.requests.cpu,
+                        memory: pgParams.initContainers.pgbouncerAuthFile.requests.memory,
+                      },
+                      'relocate-binaries': {
+                        cpu: pgParams.initContainers.relocateBinaries.requests.cpu,
+                        memory: pgParams.initContainers.relocateBinaries.requests.memory,
+                      },
+                      'setup-scripts': {
+                        cpu: pgParams.initContainers.setupScripts.requests.cpu,
+                        memory: pgParams.initContainers.setupScripts.requests.memory,
+                      },
+                      'setup-arbitrary-user': {
+                        cpu: pgParams.initContainers.setupArbitraryUser.requests.cpu,
+                        memory: pgParams.initContainers.setupArbitraryUser.requests.memory,
+                      },
+                      'cluster-reconciliation-cycle': {
+                        cpu: pgParams.initContainers.clusterReconciliationCycle.requests.cpu,
+                        memory: pgParams.initContainers.clusterReconciliationCycle.requests.memory,
+                      },
+                      'dbops.set-dbops-running': {
+                        cpu: pgParams.initContainers.setDbopsRunning.requests.cpu,
+                        memory: pgParams.initContainers.setDbopsRunning.requests.memory,
+                      },
+                    }
                   },
                   containers: {
                     'backup.create-backup': {
@@ -295,28 +321,28 @@ local sgInstanceProfile = {
                   },
                   initContainers: {
                     'pgbouncer-auth-file': {
-                      cpu: pgParams.initContainers.pgbouncerAuthFile.requests.cpu,
-                      memory: pgParams.initContainers.pgbouncerAuthFile.requests.memory,
+                      cpu: pgParams.initContainers.pgbouncerAuthFile.limits.cpu,
+                      memory: pgParams.initContainers.pgbouncerAuthFile.limits.memory,
                     },
                     'relocate-binaries': {
-                      cpu: pgParams.initContainers.relocateBinaries.requests.cpu,
-                      memory: pgParams.initContainers.relocateBinaries.requests.memory,
+                      cpu: pgParams.initContainers.relocateBinaries.limits.cpu,
+                      memory: pgParams.initContainers.relocateBinaries.limits.memory,
                     },
                     'setup-scripts': {
-                      cpu: pgParams.initContainers.setupScripts.requests.cpu,
-                      memory: pgParams.initContainers.setupScripts.requests.memory,
+                      cpu: pgParams.initContainers.setupScripts.limits.cpu,
+                      memory: pgParams.initContainers.setupScripts.limits.memory,
                     },
                     'setup-arbitrary-user': {
-                      cpu: pgParams.initContainers.setupArbitraryUser.requests.cpu,
-                      memory: pgParams.initContainers.setupArbitraryUser.requests.memory,
+                      cpu: pgParams.initContainers.setupArbitraryUser.limits.cpu,
+                      memory: pgParams.initContainers.setupArbitraryUser.limits.memory,
                     },
                     'cluster-reconciliation-cycle': {
-                      cpu: pgParams.initContainers.clusterReconciliationCycle.requests.cpu,
-                      memory: pgParams.initContainers.clusterReconciliationCycle.requests.memory,
+                      cpu: pgParams.initContainers.clusterReconciliationCycle.limits.cpu,
+                      memory: pgParams.initContainers.clusterReconciliationCycle.limits.memory,
                     },
                     'dbops.set-dbops-running': {
-                      cpu: pgParams.initContainers.setDbopsRunning.requests.cpu,
-                      memory: pgParams.initContainers.setDbopsRunning.requests.memory,
+                      cpu: pgParams.initContainers.setDbopsRunning.limits.cpu,
+                      memory: pgParams.initContainers.setDbopsRunning.limits.memory,
                     },
                   },
                 },

--- a/component/component/vshn_postgres.jsonnet
+++ b/component/component/vshn_postgres.jsonnet
@@ -283,7 +283,7 @@ local sgInstanceProfile = {
                         cpu: pgParams.initContainers.setDbopsRunning.requests.cpu,
                         memory: pgParams.initContainers.setDbopsRunning.requests.memory,
                       },
-                    }
+                    },
                   },
                   containers: {
                     'backup.create-backup': {

--- a/component/tests/golden/vshn/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -8,13 +8,13 @@ data:
     "standard-2": {"size": {"cpu": "400m", "disk": "20Gi", "enabled": true, "memory":
     "1728Mi"}}, "standard-4": {"size": {"cpu": "900m", "disk": "40Gi", "enabled":
     true, "memory": "3776Mi"}}}'
-  sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "200Mi"}, "requests":
+  sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "2Gi"}, "requests":
     {"cpu": "32m", "memory": "30Mi"}}, "createBackup": {"limits": {"cpu": "400m",
     "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy": {"limits":
     {"cpu": "64m", "memory": "64Mi"}, "requests": {"cpu": "32m", "memory": "64Mi"}},
-    "pgbouncer": {"limits": {"cpu": "32m", "memory": "10Mi"}, "requests": {"cpu":
+    "pgbouncer": {"limits": {"cpu": "32m", "memory": "20Mi"}, "requests": {"cpu":
     "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
-    "10Mi"}, "requests": {"cpu": "10m", "memory": "4Mi"}}, "prometheusPostgresExporter":
+    "20Mi"}, "requests": {"cpu": "10m", "memory": "4Mi"}}, "prometheusPostgresExporter":
     {"limits": {"cpu": "150m", "memory": "256Mi"}, "requests": {"cpu": "10m", "memory":
     "16Mi"}}, "runDbops": {"limits": {"cpu": "250m", "memory": "256Mi"}, "requests":
     {"cpu": "100m", "memory": "64Mi"}}, "setDbopsResult": {"limits": {"cpu": "250m",

--- a/component/tests/golden/vshn/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -8,17 +8,17 @@ data:
     "standard-2": {"size": {"cpu": "400m", "disk": "20Gi", "enabled": true, "memory":
     "1728Mi"}}, "standard-4": {"size": {"cpu": "900m", "disk": "40Gi", "enabled":
     true, "memory": "3776Mi"}}}'
-  sideCars: '{"clusterController": {"limits": {"cpu": "600m", "memory": "768Mi"},
-    "requests": {"cpu": "32m", "memory": "188Mi"}}, "createBackup": {"limits": {"cpu":
-    "600m", "memory": "768Mi"}, "requests": {"cpu": "250m", "memory": "256Mi"}}, "envoy":
-    {"limits": {"cpu": "600m", "memory": "768Mi"}, "requests": {"cpu": "32m", "memory":
-    "64Mi"}}, "pgbouncer": {"limits": {"cpu": "600m", "memory": "768Mi"}, "requests":
-    {"cpu": "16m", "memory": "32Mi"}}, "postgresUtil": {"limits": {"cpu": "600m",
-    "memory": "768Mi"}, "requests": {"cpu": "10m", "memory": "4Mi"}}, "prometheusPostgresExporter":
-    {"limits": {"cpu": "600m", "memory": "768Mi"}, "requests": {"cpu": "10m", "memory":
-    "32Mi"}}, "runDbops": {"limits": {"cpu": "600m", "memory": "768Mi"}, "requests":
-    {"cpu": "250m", "memory": "256Mi"}}, "setDbopsResult": {"limits": {"cpu": "600m",
-    "memory": "768Mi"}, "requests": {"cpu": "250m", "memory": "256Mi"}}}'
+  sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "200Mi"}, "requests":
+    {"cpu": "32m", "memory": "30Mi"}}, "createBackup": {"limits": {"cpu": "400m",
+    "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy": {"limits":
+    {"cpu": "64m", "memory": "64Mi"}, "requests": {"cpu": "32m", "memory": "64Mi"}},
+    "pgbouncer": {"limits": {"cpu": "32m", "memory": "10Mi"}, "requests": {"cpu":
+    "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
+    "10Mi"}, "requests": {"cpu": "10m", "memory": "4Mi"}}, "prometheusPostgresExporter":
+    {"limits": {"cpu": "150m", "memory": "256Mi"}, "requests": {"cpu": "10m", "memory":
+    "16Mi"}}, "runDbops": {"limits": {"cpu": "250m", "memory": "256Mi"}, "requests":
+    {"cpu": "100m", "memory": "64Mi"}}, "setDbopsResult": {"limits": {"cpu": "250m",
+    "memory": "256Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}}'
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -36,13 +36,13 @@ spec:
           imageTag: v4.34.0
           quotasEnabled: 'false'
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "200Mi"},
+          sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "2Gi"},
             "requests": {"cpu": "32m", "memory": "30Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
             "64Mi"}}, "envoy": {"limits": {"cpu": "64m", "memory": "64Mi"}, "requests":
             {"cpu": "32m", "memory": "64Mi"}}, "pgbouncer": {"limits": {"cpu": "32m",
-            "memory": "10Mi"}, "requests": {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil":
-            {"limits": {"cpu": "20m", "memory": "10Mi"}, "requests": {"cpu": "10m",
+            "memory": "20Mi"}, "requests": {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil":
+            {"limits": {"cpu": "20m", "memory": "20Mi"}, "requests": {"cpu": "10m",
             "memory": "4Mi"}}, "prometheusPostgresExporter": {"limits": {"cpu": "150m",
             "memory": "256Mi"}, "requests": {"cpu": "10m", "memory": "16Mi"}}, "runDbops":
             {"limits": {"cpu": "250m", "memory": "256Mi"}, "requests": {"cpu": "100m",
@@ -305,7 +305,7 @@ spec:
                     memory: 500Mi
                   cluster-controller:
                     cpu: 32m
-                    memory: 200Mi
+                    memory: 2Gi
                   dbops.run-dbops:
                     cpu: 250m
                     memory: 256Mi
@@ -317,33 +317,33 @@ spec:
                     memory: 64Mi
                   pgbouncer:
                     cpu: 32m
-                    memory: 10Mi
+                    memory: 20Mi
                   postgres-util:
                     cpu: 20m
-                    memory: 10Mi
+                    memory: 20Mi
                   prometheus-postgres-exporter:
                     cpu: 150m
                     memory: 256Mi
                 cpu: ''
                 initContainers:
                   cluster-reconciliation-cycle:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 300m
+                    memory: 200Mi
                   dbops.set-dbops-running:
                     cpu: 250m
                     memory: 256Mi
                   pgbouncer-auth-file:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 300m
+                    memory: 500Mi
                   relocate-binaries:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 300m
+                    memory: 500Mi
                   setup-arbitrary-user:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 300m
+                    memory: 500Mi
                   setup-scripts:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 300m
+                    memory: 500Mi
                 memory: ''
                 requests:
                   containers:
@@ -372,6 +372,25 @@ spec:
                       cpu: 10m
                       memory: 16Mi
                   cpu: null
+                  initContainers:
+                    cluster-reconciliation-cycle:
+                      cpu: 100m
+                      memory: 100Mi
+                    dbops.set-dbops-running:
+                      cpu: 250m
+                      memory: 256Mi
+                    pgbouncer-auth-file:
+                      cpu: 100m
+                      memory: 100Mi
+                    relocate-binaries:
+                      cpu: 100m
+                      memory: 100Mi
+                    setup-arbitrary-user:
+                      cpu: 100m
+                      memory: 500Mi
+                    setup-scripts:
+                      cpu: 100m
+                      memory: 500Mi
                   memory: null
           providerConfigRef:
             name: kubernetes

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -36,18 +36,18 @@ spec:
           imageTag: v4.34.0
           quotasEnabled: 'false'
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "600m", "memory": "768Mi"},
-            "requests": {"cpu": "32m", "memory": "188Mi"}}, "createBackup": {"limits":
-            {"cpu": "600m", "memory": "768Mi"}, "requests": {"cpu": "250m", "memory":
-            "256Mi"}}, "envoy": {"limits": {"cpu": "600m", "memory": "768Mi"}, "requests":
-            {"cpu": "32m", "memory": "64Mi"}}, "pgbouncer": {"limits": {"cpu": "600m",
-            "memory": "768Mi"}, "requests": {"cpu": "16m", "memory": "32Mi"}}, "postgresUtil":
-            {"limits": {"cpu": "600m", "memory": "768Mi"}, "requests": {"cpu": "10m",
-            "memory": "4Mi"}}, "prometheusPostgresExporter": {"limits": {"cpu": "600m",
-            "memory": "768Mi"}, "requests": {"cpu": "10m", "memory": "32Mi"}}, "runDbops":
-            {"limits": {"cpu": "600m", "memory": "768Mi"}, "requests": {"cpu": "250m",
-            "memory": "256Mi"}}, "setDbopsResult": {"limits": {"cpu": "600m", "memory":
-            "768Mi"}, "requests": {"cpu": "250m", "memory": "256Mi"}}}'
+          sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "200Mi"},
+            "requests": {"cpu": "32m", "memory": "30Mi"}}, "createBackup": {"limits":
+            {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
+            "64Mi"}}, "envoy": {"limits": {"cpu": "64m", "memory": "64Mi"}, "requests":
+            {"cpu": "32m", "memory": "64Mi"}}, "pgbouncer": {"limits": {"cpu": "32m",
+            "memory": "10Mi"}, "requests": {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil":
+            {"limits": {"cpu": "20m", "memory": "10Mi"}, "requests": {"cpu": "10m",
+            "memory": "4Mi"}}, "prometheusPostgresExporter": {"limits": {"cpu": "150m",
+            "memory": "256Mi"}, "requests": {"cpu": "10m", "memory": "16Mi"}}, "runDbops":
+            {"limits": {"cpu": "250m", "memory": "256Mi"}, "requests": {"cpu": "100m",
+            "memory": "64Mi"}}, "setDbopsResult": {"limits": {"cpu": "250m", "memory":
+            "256Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}}'
         kind: ConfigMap
         metadata:
           labels:
@@ -301,11 +301,11 @@ spec:
               spec:
                 containers:
                   backup.create-backup:
-                    cpu: 250m
-                    memory: 256Mi
+                    cpu: 400m
+                    memory: 500Mi
                   cluster-controller:
                     cpu: 32m
-                    memory: 188Mi
+                    memory: 200Mi
                   dbops.run-dbops:
                     cpu: 250m
                     memory: 256Mi
@@ -313,17 +313,17 @@ spec:
                     cpu: 250m
                     memory: 256Mi
                   envoy:
-                    cpu: 32m
+                    cpu: 64m
                     memory: 64Mi
                   pgbouncer:
-                    cpu: 16m
-                    memory: 32Mi
+                    cpu: 32m
+                    memory: 10Mi
                   postgres-util:
-                    cpu: 10m
-                    memory: 4Mi
+                    cpu: 20m
+                    memory: 10Mi
                   prometheus-postgres-exporter:
-                    cpu: 10m
-                    memory: 32Mi
+                    cpu: 150m
+                    memory: 256Mi
                 cpu: ''
                 initContainers:
                   cluster-reconciliation-cycle:
@@ -346,6 +346,31 @@ spec:
                     memory: 100Mi
                 memory: ''
                 requests:
+                  containers:
+                    backup.create-backup:
+                      cpu: 100m
+                      memory: 64Mi
+                    cluster-controller:
+                      cpu: 32m
+                      memory: 30Mi
+                    dbops.run-dbops:
+                      cpu: 100m
+                      memory: 64Mi
+                    dbops.set-dbops-result:
+                      cpu: 100m
+                      memory: 64Mi
+                    envoy:
+                      cpu: 32m
+                      memory: 64Mi
+                    pgbouncer:
+                      cpu: 16m
+                      memory: 4Mi
+                    postgres-util:
+                      cpu: 10m
+                      memory: 4Mi
+                    prometheus-postgres-exporter:
+                      cpu: 10m
+                      memory: 16Mi
                   cpu: null
                   memory: null
           providerConfigRef:
@@ -470,11 +495,15 @@ spec:
                   sgPostgresConfig: ''
                 instances: 1
                 nonProductionOptions:
+                  enableSetClusterCpuRequests: true
+                  enableSetClusterMemoryRequests: true
                   enableSetPatroniCpuRequests: true
                   enableSetPatroniMemoryRequests: true
                 pods:
                   persistentVolume:
                     size: ''
+                  resources:
+                    enableClusterLimitsRequirements: true
                 postgres:
                   ssl:
                     certificateSecretKeySelector:

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -36,18 +36,18 @@ spec:
           imageTag: v4.34.0
           quotasEnabled: 'false'
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "600m", "memory": "768Mi"},
-            "requests": {"cpu": "32m", "memory": "188Mi"}}, "createBackup": {"limits":
-            {"cpu": "600m", "memory": "768Mi"}, "requests": {"cpu": "250m", "memory":
-            "256Mi"}}, "envoy": {"limits": {"cpu": "600m", "memory": "768Mi"}, "requests":
-            {"cpu": "32m", "memory": "64Mi"}}, "pgbouncer": {"limits": {"cpu": "600m",
-            "memory": "768Mi"}, "requests": {"cpu": "16m", "memory": "32Mi"}}, "postgresUtil":
-            {"limits": {"cpu": "600m", "memory": "768Mi"}, "requests": {"cpu": "10m",
-            "memory": "4Mi"}}, "prometheusPostgresExporter": {"limits": {"cpu": "600m",
-            "memory": "768Mi"}, "requests": {"cpu": "10m", "memory": "32Mi"}}, "runDbops":
-            {"limits": {"cpu": "600m", "memory": "768Mi"}, "requests": {"cpu": "250m",
-            "memory": "256Mi"}}, "setDbopsResult": {"limits": {"cpu": "600m", "memory":
-            "768Mi"}, "requests": {"cpu": "250m", "memory": "256Mi"}}}'
+          sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "200Mi"},
+            "requests": {"cpu": "32m", "memory": "30Mi"}}, "createBackup": {"limits":
+            {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
+            "64Mi"}}, "envoy": {"limits": {"cpu": "64m", "memory": "64Mi"}, "requests":
+            {"cpu": "32m", "memory": "64Mi"}}, "pgbouncer": {"limits": {"cpu": "32m",
+            "memory": "10Mi"}, "requests": {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil":
+            {"limits": {"cpu": "20m", "memory": "10Mi"}, "requests": {"cpu": "10m",
+            "memory": "4Mi"}}, "prometheusPostgresExporter": {"limits": {"cpu": "150m",
+            "memory": "256Mi"}, "requests": {"cpu": "10m", "memory": "16Mi"}}, "runDbops":
+            {"limits": {"cpu": "250m", "memory": "256Mi"}, "requests": {"cpu": "100m",
+            "memory": "64Mi"}}, "setDbopsResult": {"limits": {"cpu": "250m", "memory":
+            "256Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}}'
         kind: ConfigMap
         metadata:
           labels:
@@ -382,11 +382,11 @@ spec:
               spec:
                 containers:
                   backup.create-backup:
-                    cpu: 250m
-                    memory: 256Mi
+                    cpu: 400m
+                    memory: 500Mi
                   cluster-controller:
                     cpu: 32m
-                    memory: 188Mi
+                    memory: 200Mi
                   dbops.run-dbops:
                     cpu: 250m
                     memory: 256Mi
@@ -394,17 +394,17 @@ spec:
                     cpu: 250m
                     memory: 256Mi
                   envoy:
-                    cpu: 32m
+                    cpu: 64m
                     memory: 64Mi
                   pgbouncer:
-                    cpu: 16m
-                    memory: 32Mi
+                    cpu: 32m
+                    memory: 10Mi
                   postgres-util:
-                    cpu: 10m
-                    memory: 4Mi
+                    cpu: 20m
+                    memory: 10Mi
                   prometheus-postgres-exporter:
-                    cpu: 10m
-                    memory: 32Mi
+                    cpu: 150m
+                    memory: 256Mi
                 cpu: ''
                 initContainers:
                   cluster-reconciliation-cycle:
@@ -427,6 +427,31 @@ spec:
                     memory: 100Mi
                 memory: ''
                 requests:
+                  containers:
+                    backup.create-backup:
+                      cpu: 100m
+                      memory: 64Mi
+                    cluster-controller:
+                      cpu: 32m
+                      memory: 30Mi
+                    dbops.run-dbops:
+                      cpu: 100m
+                      memory: 64Mi
+                    dbops.set-dbops-result:
+                      cpu: 100m
+                      memory: 64Mi
+                    envoy:
+                      cpu: 32m
+                      memory: 64Mi
+                    pgbouncer:
+                      cpu: 16m
+                      memory: 4Mi
+                    postgres-util:
+                      cpu: 10m
+                      memory: 4Mi
+                    prometheus-postgres-exporter:
+                      cpu: 10m
+                      memory: 16Mi
                   cpu: null
                   memory: null
           providerConfigRef:
@@ -551,11 +576,15 @@ spec:
                   sgPostgresConfig: ''
                 instances: 1
                 nonProductionOptions:
+                  enableSetClusterCpuRequests: true
+                  enableSetClusterMemoryRequests: true
                   enableSetPatroniCpuRequests: true
                   enableSetPatroniMemoryRequests: true
                 pods:
                   persistentVolume:
                     size: ''
+                  resources:
+                    enableClusterLimitsRequirements: true
                 postgres:
                   ssl:
                     certificateSecretKeySelector:

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -36,13 +36,13 @@ spec:
           imageTag: v4.34.0
           quotasEnabled: 'false'
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "200Mi"},
+          sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "2Gi"},
             "requests": {"cpu": "32m", "memory": "30Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
             "64Mi"}}, "envoy": {"limits": {"cpu": "64m", "memory": "64Mi"}, "requests":
             {"cpu": "32m", "memory": "64Mi"}}, "pgbouncer": {"limits": {"cpu": "32m",
-            "memory": "10Mi"}, "requests": {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil":
-            {"limits": {"cpu": "20m", "memory": "10Mi"}, "requests": {"cpu": "10m",
+            "memory": "20Mi"}, "requests": {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil":
+            {"limits": {"cpu": "20m", "memory": "20Mi"}, "requests": {"cpu": "10m",
             "memory": "4Mi"}}, "prometheusPostgresExporter": {"limits": {"cpu": "150m",
             "memory": "256Mi"}, "requests": {"cpu": "10m", "memory": "16Mi"}}, "runDbops":
             {"limits": {"cpu": "250m", "memory": "256Mi"}, "requests": {"cpu": "100m",
@@ -386,7 +386,7 @@ spec:
                     memory: 500Mi
                   cluster-controller:
                     cpu: 32m
-                    memory: 200Mi
+                    memory: 2Gi
                   dbops.run-dbops:
                     cpu: 250m
                     memory: 256Mi
@@ -398,33 +398,33 @@ spec:
                     memory: 64Mi
                   pgbouncer:
                     cpu: 32m
-                    memory: 10Mi
+                    memory: 20Mi
                   postgres-util:
                     cpu: 20m
-                    memory: 10Mi
+                    memory: 20Mi
                   prometheus-postgres-exporter:
                     cpu: 150m
                     memory: 256Mi
                 cpu: ''
                 initContainers:
                   cluster-reconciliation-cycle:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 300m
+                    memory: 200Mi
                   dbops.set-dbops-running:
                     cpu: 250m
                     memory: 256Mi
                   pgbouncer-auth-file:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 300m
+                    memory: 500Mi
                   relocate-binaries:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 300m
+                    memory: 500Mi
                   setup-arbitrary-user:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 300m
+                    memory: 500Mi
                   setup-scripts:
-                    cpu: 100m
-                    memory: 100Mi
+                    cpu: 300m
+                    memory: 500Mi
                 memory: ''
                 requests:
                   containers:
@@ -453,6 +453,25 @@ spec:
                       cpu: 10m
                       memory: 16Mi
                   cpu: null
+                  initContainers:
+                    cluster-reconciliation-cycle:
+                      cpu: 100m
+                      memory: 100Mi
+                    dbops.set-dbops-running:
+                      cpu: 250m
+                      memory: 256Mi
+                    pgbouncer-auth-file:
+                      cpu: 100m
+                      memory: 100Mi
+                    relocate-binaries:
+                      cpu: 100m
+                      memory: 100Mi
+                    setup-arbitrary-user:
+                      cpu: 100m
+                      memory: 500Mi
+                    setup-scripts:
+                      cpu: 100m
+                      memory: 500Mi
                   memory: null
           providerConfigRef:
             name: kubernetes


### PR DESCRIPTION
We need to set the resource limits on the sidecars as well and then set some sensible values for them.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
