### PR TITLE
Use Github action PAT to push to master

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: 'master'
+          token: ${{ secrets.GH_ACTION_PAT }}
       - name: set tag env
         run: echo "TAG_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Change version in package
@@ -43,6 +44,6 @@ jobs:
           yq -i '.parameters."pkg.appcat".componentVersion = "${{ env.TAG_VERSION }}"' package/main.yaml
       - uses: actions-js/push@v1.4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_ACTION_PAT }}
           message: "Update component version in package to ${{ env.TAG_VERSION }}"
           branch: 'master'


### PR DESCRIPTION
We use a custom PAT to push to master and exclude that PAT from the branch_protection, allowing the PAT to push to master.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
