### PR TITLE
disable certificates verification in redis metrics exporter

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -3,7 +3,7 @@ parameters:
     charts:
       redis:
         source: https://charts.bitnami.com/bitnami
-        version: 18.1.3
+        version: 17.7.1
       minio:
         source: https://charts.min.io
         version: 5.0.13

--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -3,7 +3,7 @@ parameters:
     charts:
       redis:
         source: https://charts.bitnami.com/bitnami
-        version: 17.7.1
+        version: 18.1.3
       minio:
         source: https://charts.min.io
         version: 5.0.13

--- a/component/component/vshn_redis.jsonnet
+++ b/component/component/vshn_redis.jsonnet
@@ -398,7 +398,7 @@ local composition =
           values: {
             metrics: {
               enabled: true,
-              // before all Your warning lapmp start flashing,
+              // before all Your warning lamps start blinking,
               // this is internal communication on loopback interface
               // full mTLS isn't necessary
               extraEnvVars: [

--- a/component/component/vshn_redis.jsonnet
+++ b/component/component/vshn_redis.jsonnet
@@ -398,12 +398,15 @@ local composition =
           values: {
             metrics: {
               enabled: true,
-              extraEvnVars: [
-                // before all Your warning lapmp start flashing,
-                // this is internal communication on loopback interface
-                // full mTLS isn't necessary
-                'REDIS_EXPORTER_SKIP_TLS_VERIFICATION',
-                'true',
+              // before all Your warning lapmp start flashing,
+              // this is internal communication on loopback interface
+              // full mTLS isn't necessary
+              extraEnvVars: [
+                {
+                  name: 'REDIS_EXPORTER_SKIP_TLS_VERIFICATION',
+                  value: 'true',
+
+                },
               ],
               containerSecurityContext: {
                 enabled: securityContext,

--- a/component/component/vshn_redis.jsonnet
+++ b/component/component/vshn_redis.jsonnet
@@ -398,6 +398,13 @@ local composition =
           values: {
             metrics: {
               enabled: true,
+              extraEvnVars: [
+                // before all Your warning lapmp start flashing,
+                // this is internal communication on loopback interface
+                // full mTLS isn't necessary
+                'REDIS_EXPORTER_SKIP_TLS_VERIFICATION',
+                'true',
+              ],
               containerSecurityContext: {
                 enabled: securityContext,
               },

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -676,7 +676,7 @@ spec:
             chart:
               name: redis
               repository: https://charts.bitnami.com/bitnami
-              version: 17.7.1
+              version: 18.1.3
             values:
               architecture: standalone
               commonConfiguration: ''

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -703,9 +703,9 @@ spec:
                 containerSecurityContext:
                   enabled: true
                 enabled: true
-                extraEvnVars:
-                  - REDIS_EXPORTER_SKIP_TLS_VERIFICATION
-                  - 'true'
+                extraEnvVars:
+                  - name: REDIS_EXPORTER_SKIP_TLS_VERIFICATION
+                    value: 'true'
                 serviceMonitor:
                   enabled: true
                   namespace: ''

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -703,6 +703,9 @@ spec:
                 containerSecurityContext:
                   enabled: true
                 enabled: true
+                extraEvnVars:
+                  - REDIS_EXPORTER_SKIP_TLS_VERIFICATION
+                  - 'true'
                 serviceMonitor:
                   enabled: true
                   namespace: ''

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -676,7 +676,7 @@ spec:
             chart:
               name: redis
               repository: https://charts.bitnami.com/bitnami
-              version: 18.1.3
+              version: 17.7.1
             values:
               architecture: standalone
               commonConfiguration: ''


### PR DESCRIPTION
This small PR fixes issue with problematic exporter in helm chart. For some reason mTLS setup provided by bitnami, or my own manipulations with config didn't solve the issue. I don't think it's a big threat to allow insecure TLS on loopback interface inside one pod. No data flows in cleartext.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
