### PR TITLE
add liveness and readiness probes to appcat apiserver

### DIFF
--- a/component/component/appcat_apiserver.jsonnet
+++ b/component/component/appcat_apiserver.jsonnet
@@ -92,6 +92,28 @@ local apiserver = loadManifest('aggregated-apiserver.yaml') {
               args: [ super.args[0] ] + common.MergeArgs(common.MergeArgs(super.args[1:], extraDeploymentArgs), apiserverParams.extraArgs),
               env+: com.envList(apiserverParams.extraEnv),
               resources: apiserverParams.resources,
+              livenessProbe: {
+                httpGet: {
+                  path: '/livez',
+                  port: 9443,
+                  scheme: 'HTTPS',
+                },
+                timeoutSeconds: 2,
+                successThreshold: 1,
+                initialDelaySeconds: 10,
+                failureThreshold: 3,
+              },
+              readinessProbe: {
+                httpGet: {
+                  path: '/livez',
+                  port: 9443,
+                  scheme: 'HTTPS',
+                },
+                timeoutSeconds: 2,
+                successThreshold: 1,
+                initialDelaySeconds: 10,
+                failureThreshold: 3,
+              },
             }
           else
             c

--- a/component/component/appcat_apiserver.jsonnet
+++ b/component/component/appcat_apiserver.jsonnet
@@ -105,7 +105,7 @@ local apiserver = loadManifest('aggregated-apiserver.yaml') {
               },
               readinessProbe: {
                 httpGet: {
-                  path: '/livez',
+                  path: '/readyz',
                   port: 9443,
                   scheme: 'HTTPS',
                 },

--- a/component/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
+++ b/component/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
@@ -33,7 +33,25 @@ spec:
             - configMapRef:
                 name: apiserver-envs
           image: ghcr.io/vshn/appcat-apiserver:v0.1.2
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
           name: apiserver
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
           resources:
             limits:
               cpu: 200m

--- a/component/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
+++ b/component/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
@@ -46,7 +46,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /livez
+              path: /readyz
               port: 9443
               scheme: HTTPS
             initialDelaySeconds: 10

--- a/component/tests/golden/minio/appcat/appcat/apiserver/30_deployment.yaml
+++ b/component/tests/golden/minio/appcat/appcat/apiserver/30_deployment.yaml
@@ -33,7 +33,25 @@ spec:
             - configMapRef:
                 name: apiserver-envs
           image: ghcr.io/vshn/appcat-apiserver:v0.1.2
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
           name: apiserver
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
           resources:
             limits:
               cpu: 200m

--- a/component/tests/golden/minio/appcat/appcat/apiserver/30_deployment.yaml
+++ b/component/tests/golden/minio/appcat/appcat/apiserver/30_deployment.yaml
@@ -46,7 +46,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /livez
+              path: /readyz
               port: 9443
               scheme: HTTPS
             initialDelaySeconds: 10

--- a/component/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
@@ -33,7 +33,25 @@ spec:
             - configMapRef:
                 name: apiserver-envs
           image: ghcr.io/vshn/appcat-apiserver:v0.1.2
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
           name: apiserver
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
           resources:
             limits:
               cpu: 200m

--- a/component/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
@@ -46,7 +46,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /livez
+              path: /readyz
               port: 9443
               scheme: HTTPS
             initialDelaySeconds: 10


### PR DESCRIPTION
Due to timeout issues with apiserver as mitigation of an issue I'm introducing liveness and readiness probes which should restart Apiserver whenever it fails to respond. If that won't be enough I suggest adding another probe based on shell command. 

Tested it locally and on lab - it works, it checks. 