### PR TITLE
Add RBAC rules for minio metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ sloth-output/
 /component/compiled
 
 /package/.cache
+/packages/compiled
 /package/dependencies
 /package/helmcharts
 /package/manifests
@@ -31,5 +32,9 @@ sloth-output/
 /package/jsonnetfile.lock.json
 /package/crds
 /package/compiled
+
+/compiled
+/dependencies
+/vendor
 
 # Additional entries

--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -39,7 +39,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.34.0
+        tag: v4.36.0
       apiserver:
         registry: ghcr.io
         repository: vshn/appcat-apiserver

--- a/component/component/provider.jsonnet
+++ b/component/component/provider.jsonnet
@@ -197,7 +197,7 @@ local controllerConfigRef(config) =
         },
         {
           apiGroups: [ 'monitoring.coreos.com' ],
-          resources: [ 'prometheusrules', 'podmonitors', 'alertmanagerconfigs' ],
+          resources: [ 'prometheusrules', 'podmonitors', 'alertmanagerconfigs', 'servicemonitors' ],
           verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
         },
         {

--- a/component/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/component/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -233,6 +233,7 @@ rules:
       - prometheusrules
       - podmonitors
       - alertmanagerconfigs
+      - servicemonitors
     verbs:
       - get
       - list

--- a/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.34.0
+          image: ghcr.io/vshn/appcat:v4.36.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -28,7 +28,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNREDIS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.34.0
+        image: ghcr.io/vshn/appcat:v4.36.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -233,6 +233,7 @@ rules:
       - prometheusrules
       - podmonitors
       - alertmanagerconfigs
+      - servicemonitors
     verbs:
       - get
       - list

--- a/component/tests/golden/minio/appcat/appcat/10_provider_kubernetes.yaml
+++ b/component/tests/golden/minio/appcat/appcat/10_provider_kubernetes.yaml
@@ -233,6 +233,7 @@ rules:
       - prometheusrules
       - podmonitors
       - alertmanagerconfigs
+      - servicemonitors
     verbs:
       - get
       - list

--- a/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
@@ -25,7 +25,7 @@ spec:
         data:
           controlNamespace: syn-appcat-control
           defaultPlan: standard-1
-          imageTag: v4.34.0
+          imageTag: v4.36.0
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io
           minioChartVersion: 5.0.13

--- a/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.34.0
+          image: ghcr.io/vshn/appcat:v4.36.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.34.0
+              image: ghcr.io/vshn/appcat:v4.36.0
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -28,7 +28,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNREDIS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.34.0
+        image: ghcr.io/vshn/appcat:v4.36.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
@@ -235,6 +235,7 @@ rules:
       - prometheusrules
       - podmonitors
       - alertmanagerconfigs
+      - servicemonitors
     verbs:
       - get
       - list

--- a/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -28,7 +28,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNREDIS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.34.0
+        image: ghcr.io/vshn/appcat:v4.36.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
@@ -233,6 +233,7 @@ rules:
       - prometheusrules
       - podmonitors
       - alertmanagerconfigs
+      - servicemonitors
     verbs:
       - get
       - list

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_minio.yaml
@@ -25,7 +25,7 @@ spec:
         data:
           controlNamespace: syn-appcat-control
           defaultPlan: standard-1
-          imageTag: v4.34.0
+          imageTag: v4.36.0
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io
           minioChartVersion: 5.0.13
@@ -41,7 +41,7 @@ spec:
         image: minio
         imagePullPolicy: IfNotPresent
         runner:
-          endpoint: unix-abstract:crossplane/fn/default.sock
+          endpoint: 172.18.0.1:9547
         timeout: 20s
       name: minio-func
       type: Container

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -33,7 +33,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.34.0
+          imageTag: v4.36.0
           quotasEnabled: 'false'
           sgNamespace: stackgres
           sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "2Gi"},

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -33,7 +33,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.34.0
+          imageTag: v4.36.0
           quotasEnabled: 'false'
           sgNamespace: stackgres
           sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "2Gi"},

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -30,7 +30,7 @@ spec:
         data:
           bucketRegion: lpg
           controlNamespace: syn-appcat-control
-          imageTag: v4.34.0
+          imageTag: v4.36.0
           maintenanceSA: helm-based-service-maintenance
           quotasEnabled: 'false'
           restoreSA: redisrestoreserviceaccount

--- a/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.34.0
+          image: ghcr.io/vshn/appcat:v4.36.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.34.0
+              image: ghcr.io/vshn/appcat:v4.36.0
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: APPCAT_SLI_VSHNREDIS
           value: "true"
-        image: ghcr.io/vshn/appcat:v4.34.0
+        image: ghcr.io/vshn/appcat:v4.36.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/vshn.yml
+++ b/component/tests/vshn.yml
@@ -106,7 +106,7 @@ parameters:
               note: "Will be scheduled on APPUiO Cloud plus nodes"
         minio:
           enabled: true
-          # grpcEndpoint: host.docker.internal:9547
+          grpcEndpoint: 172.18.0.1:9547
 
       generic:
         objectstorage:

--- a/package/main.yaml
+++ b/package/main.yaml
@@ -7,7 +7,7 @@ parameters:
     image:
       registry: ghcr.io
       repository: vshn/appcat
-      tag: v4.35.0
+      tag: v4.36.0
   components:
     appcat:
       url: https://github.com/vshn/component-appcat.git


### PR DESCRIPTION
This PR adds the necessary RBAC rules for provider-kubernetes to be able to create `serviceMonitor` objects
## Checklist

- [X] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [X] PR contains a single logical change (to build a better changelog).
- [X] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
