### PR TITLE
Fix restore operation not working for PostgreSQL by VSHN

### DIFF
--- a/component/component/vshn_postgres.jsonnet
+++ b/component/component/vshn_postgres.jsonnet
@@ -739,7 +739,7 @@ local copyJob = {
 };
 
 local clusterRestoreConfig = {
-  name: 'cluster-restore',
+  name: 'cluster',
   base+: {
     spec+: {
       references+: [

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -621,7 +621,7 @@ spec:
             - dependsOn:
                 apiVersion: stackgres.io/v1
                 kind: SGBackup
-      name: cluster-restore
+      name: cluster
       patches:
         - fromFieldPath: status.conditions
           toFieldPath: status.pgclusterConditions


### PR DESCRIPTION
Restore operation does not work anymore for PostgreSQL by VSHN because in some of out composition functions we are referencing name `cluster` for and SGCluster object in the _iof_ function. We need to keep the same name between restore and main compositions. This name change is purely internal and is not used outside the code.
Tested it in local cluster and it worked.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
