### PR TITLE
Patch name of the inner ns object as well

### DIFF
--- a/component/component/vshn_postgres.jsonnet
+++ b/component/component/vshn_postgres.jsonnet
@@ -125,6 +125,7 @@ local instanceNamespace = {
     comp.ToCompositeFieldPath('status.conditions', 'status.namespaceConditions'),
     comp.ToCompositeFieldPath('metadata.name', 'status.instanceNamespace'),
     comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'vshn-postgresql'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'vshn-postgresql'),
     comp.FromCompositeFieldPath('metadata.labels[crossplane.io/claim-namespace]', 'spec.forProvider.manifest.metadata.labels[%s]' % serviceNamespaceLabelKey),
     comp.FromCompositeFieldPath('spec.parameters.service.serviceLevel', 'spec.forProvider.manifest.metadata.labels[appcat.vshn.io/sla]'),
     comp.FromCompositeFieldPath('metadata.labels[appuio.io/organization]', 'spec.forProvider.manifest.metadata.labels[appuio.io/organization]'),

--- a/component/component/vshn_redis.jsonnet
+++ b/component/component/vshn_redis.jsonnet
@@ -535,6 +535,7 @@ local composition =
                   patches: [
                     comp.ToCompositeFieldPath('status.conditions', 'status.namespaceConditions'),
                     comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'vshn-redis'),
+                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'vshn-redis'),
                     comp.FromCompositeFieldPath('metadata.labels[crossplane.io/claim-namespace]', 'spec.forProvider.manifest.metadata.labels[%s]' % serviceNamespaceLabelKey),
                     comp.FromCompositeFieldPath('metadata.labels[appuio.io/organization]', 'spec.forProvider.manifest.metadata.labels[appuio.io/organization]'),
                     comp.ToCompositeFieldPath('metadata.name', 'status.instanceNamespace'),

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -103,6 +103,14 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
+              - fromFieldPath: metadata.labels[crossplane.io/composite]
+                toFieldPath: spec.forProvider.manifest.metadata.name
+                transforms:
+                  - string:
+                      fmt: vshn-postgresql-%s
+                      type: Format
+                    type: string
+                type: FromCompositeFieldPath
               - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
                 toFieldPath: spec.forProvider.manifest.metadata.labels[appcat.vshn.io/claim-namespace]
                 type: FromCompositeFieldPath

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -103,6 +103,14 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
+              - fromFieldPath: metadata.labels[crossplane.io/composite]
+                toFieldPath: spec.forProvider.manifest.metadata.name
+                transforms:
+                  - string:
+                      fmt: vshn-postgresql-%s
+                      type: Format
+                    type: string
+                type: FromCompositeFieldPath
               - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
                 toFieldPath: spec.forProvider.manifest.metadata.labels[appcat.vshn.io/claim-namespace]
                 type: FromCompositeFieldPath

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -196,6 +196,14 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
+              - fromFieldPath: metadata.labels[crossplane.io/composite]
+                toFieldPath: spec.forProvider.manifest.metadata.name
+                transforms:
+                  - string:
+                      fmt: vshn-redis-%s
+                      type: Format
+                    type: string
+                type: FromCompositeFieldPath
               - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
                 toFieldPath: spec.forProvider.manifest.metadata.labels[appcat.vshn.io/claim-namespace]
                 type: FromCompositeFieldPath

--- a/package/main.yaml
+++ b/package/main.yaml
@@ -3,11 +3,11 @@ applications:
   - crossplane
 parameters:
   pkg.appcat:
-    componentVersion: v2.10.1
+    componentVersion: v2.10.2
     image:
       registry: ghcr.io
       repository: vshn/appcat
-      tag: v4.43.1
+      tag: v4.43.2
   components:
     appcat:
       url: https://github.com/vshn/component-appcat.git


### PR DESCRIPTION
Up to this point we only patched the name of the kube object, but forgot to actually patch the name of the inner namespace object. This worked because `provider-kubernetes` will automatically apply the name of the outer object to the inner object during its reconcile. This got to be a problem with 1.14 as the AppCat function would mess up the quotas if the name was empty in the desired objects.

However this object does not adhere to our naming scheme of `metadata.labels[crossplane.io/composite]+"-description"`. Unfortunately we can't change that name now without re-creating the namespaces.




## Checklist

- [ ] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
