### PR TITLE
Reduce collected metrics from pg exporter

### DIFF
--- a/component/component/vshn_postgres.jsonnet
+++ b/component/component/vshn_postgres.jsonnet
@@ -796,6 +796,38 @@ local prometheusRule = prom.GeneratePrometheusNonSLORules(
   ],
 };
 
+local keepMetrics = [
+  'pg_locks_count',
+  'pg_postmaster_start_time_seconds',
+  'pg_replication_lag',
+  'pg_settings_effective_cache_size_bytes',
+  'pg_settings_maintenance_work_mem_bytes',
+  'pg_settings_max_connections',
+  'pg_settings_max_parallel_workers',
+  'pg_settings_max_wal_size_bytes',
+  'pg_settings_max_worker_processes',
+  'pg_settings_shared_buffers_bytes',
+  'pg_settings_work_mem_bytes',
+  'pg_stat_activity_count',
+  'pg_stat_bgwriter_buffers_alloc_total',
+  'pg_stat_bgwriter_buffers_backend_fsync_total',
+  'pg_stat_bgwriter_buffers_backend_total',
+  'pg_stat_bgwriter_buffers_checkpoint_total',
+  'pg_stat_bgwriter_buffers_clean_total',
+  'pg_stat_database_blks_hit',
+  'pg_stat_database_blks_read',
+  'pg_stat_database_conflicts',
+  'pg_stat_database_deadlocks',
+  'pg_stat_database_temp_bytes',
+  'pg_stat_database_xact_commit',
+  'pg_stat_database_xact_rollback',
+  'pg_static',
+  'pg_up',
+  'pgbouncer_show_stats_total_xact_count',
+  'pgbouncer_show_stats_totals_bytes_received',
+  'pgbouncer_show_stats_totals_bytes_sent',
+];
+
 local podMonitor = {
   name: 'podmonitor',
   base: comp.KubeObject('monitoring.coreos.com/v1', 'PodMonitor') + {
@@ -809,6 +841,15 @@ local podMonitor = {
             podMetricsEndpoints: [
               {
                 port: 'pgexporter',
+                metricRelabelings: [
+                  {
+                    action: 'keep',
+                    sourceLabels: [
+                      '__name__',
+                    ],
+                    regex: '(' + std.join('|', keepMetrics) + ')',
+                  },
+                ],
               },
             ],
             selector: {

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -749,7 +749,12 @@ spec:
                       name: postgresql-podmonitor
                     spec:
                       podMetricsEndpoints:
-                        - port: pgexporter
+                        - metricRelabelings:
+                            - action: keep
+                              regex: (pg_locks_count|pg_postmaster_start_time_seconds|pg_replication_lag|pg_settings_effective_cache_size_bytes|pg_settings_maintenance_work_mem_bytes|pg_settings_max_connections|pg_settings_max_parallel_workers|pg_settings_max_wal_size_bytes|pg_settings_max_worker_processes|pg_settings_shared_buffers_bytes|pg_settings_work_mem_bytes|pg_stat_activity_count|pg_stat_bgwriter_buffers_alloc_total|pg_stat_bgwriter_buffers_backend_fsync_total|pg_stat_bgwriter_buffers_backend_total|pg_stat_bgwriter_buffers_checkpoint_total|pg_stat_bgwriter_buffers_clean_total|pg_stat_database_blks_hit|pg_stat_database_blks_read|pg_stat_database_conflicts|pg_stat_database_deadlocks|pg_stat_database_temp_bytes|pg_stat_database_xact_commit|pg_stat_database_xact_rollback|pg_static|pg_up|pgbouncer_show_stats_total_xact_count|pgbouncer_show_stats_totals_bytes_received|pgbouncer_show_stats_totals_bytes_sent)
+                              sourceLabels:
+                                - __name__
+                          port: pgexporter
                       selector:
                         matchLabels:
                           app: StackGresCluster

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -851,7 +851,12 @@ spec:
                       name: postgresql-podmonitor
                     spec:
                       podMetricsEndpoints:
-                        - port: pgexporter
+                        - metricRelabelings:
+                            - action: keep
+                              regex: (pg_locks_count|pg_postmaster_start_time_seconds|pg_replication_lag|pg_settings_effective_cache_size_bytes|pg_settings_maintenance_work_mem_bytes|pg_settings_max_connections|pg_settings_max_parallel_workers|pg_settings_max_wal_size_bytes|pg_settings_max_worker_processes|pg_settings_shared_buffers_bytes|pg_settings_work_mem_bytes|pg_stat_activity_count|pg_stat_bgwriter_buffers_alloc_total|pg_stat_bgwriter_buffers_backend_fsync_total|pg_stat_bgwriter_buffers_backend_total|pg_stat_bgwriter_buffers_checkpoint_total|pg_stat_bgwriter_buffers_clean_total|pg_stat_database_blks_hit|pg_stat_database_blks_read|pg_stat_database_conflicts|pg_stat_database_deadlocks|pg_stat_database_temp_bytes|pg_stat_database_xact_commit|pg_stat_database_xact_rollback|pg_static|pg_up|pgbouncer_show_stats_total_xact_count|pgbouncer_show_stats_totals_bytes_received|pgbouncer_show_stats_totals_bytes_sent)
+                              sourceLabels:
+                                - __name__
+                          port: pgexporter
                       selector:
                         matchLabels:
                           app: StackGresCluster


### PR DESCRIPTION
For databases with a non-trivial amount of data, the exporter generates a lot of metrics. This triggers the `sample_limit` and the targets are actually marked as down in prometheus.

To get below the `sample_limit` threshold, we only collect the necessary metrics for our dashboards.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
