### PR TITLE
Ignore integration metrics looking up sales order

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -155,7 +155,8 @@ parameters:
                 severity: warning
                 syn_team: schedar
       network_policies:
-        target_namespaces: {}
+        target_namespaces:
+          vshn-appuio-mimir: true
       prometheus:
         url: http://vshn-appuio-mimir-query-frontend.vshn-appuio-mimir.svc:8080/prometheus
         org_id: appuio-cloud-metering-c-appuio-cloudscale-lpg-2|appuio-cloud-metering-c-appuio-exoscale-ch-gva-2-0

--- a/component/component/billing.jsonnet
+++ b/component/component/billing.jsonnet
@@ -193,7 +193,7 @@ if params.billing.vshn.enableCronjobs then
         },
       },
     },
-    [if std.length(params.billing.network_policies.target_namespaces) != 0 then 'billing/01_netpol']: netPol.Policies,
+    [if std.length(std.filter(function(name) params.billing.network_policies.target_namespaces[name] == true, std.objectFields(params.billing.network_policies.target_namespaces))) > 0 then 'billing/01_netpol']: netPol.Policies,
     'billing/10_odoo_secret': odooSecret,
     'billing/11_backfill': billingCronjobs,
     [if params.billing.monitoring.enabled then 'billing/50_alerts']: alerts.Alerts,

--- a/component/component/billing.jsonnet
+++ b/component/component/billing.jsonnet
@@ -152,7 +152,7 @@ local generateCloudAndManaged = function(name)
   local queryName = if name == 'postgres' then name + 'ql' else name;
 
   local managedQuery = 'appcat:metering{label_appuio_io_billing_name="appcat-' + queryName + '",label_appcat_vshn_io_sla="%s"}';
-  local cloudQuery = managedQuery + ' * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info, "label_appuio_io_organization", "$1", "organization", "(.*)")';
+  local cloudQuery = managedQuery + ' * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info{namespace="appuio-control-api-production"}, "label_appuio_io_organization", "$1", "organization", "(.*)")';
 
   local permutations = [
     {

--- a/component/tests/golden/vshn/appcat/appcat/billing/11_backfill.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/billing/11_backfill.yaml
@@ -62,7 +62,7 @@ spec:
                   value: appcat-vshn-minio-besteffort
                 - name: AR_QUERY
                   value: appcat:metering{label_appuio_io_billing_name="appcat-minio",label_appcat_vshn_io_sla="besteffort"}
-                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info,
+                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info{namespace="appuio-control-api-production"},
                     "label_appuio_io_organization", "$1", "organization", "(.*)")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "%(label_appcat_vshn_io_claim_namespace)s/%(label_appcat_vshn_io_claim_name)s"
@@ -149,7 +149,7 @@ spec:
                   value: appcat-vshn-minio-guaranteed
                 - name: AR_QUERY
                   value: appcat:metering{label_appuio_io_billing_name="appcat-minio",label_appcat_vshn_io_sla="guaranteed"}
-                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info,
+                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info{namespace="appuio-control-api-production"},
                     "label_appuio_io_organization", "$1", "organization", "(.*)")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "%(label_appcat_vshn_io_claim_namespace)s/%(label_appcat_vshn_io_claim_name)s"
@@ -236,7 +236,7 @@ spec:
                   value: appcat-vshn-postgres-besteffort
                 - name: AR_QUERY
                   value: appcat:metering{label_appuio_io_billing_name="appcat-postgresql",label_appcat_vshn_io_sla="besteffort"}
-                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info,
+                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info{namespace="appuio-control-api-production"},
                     "label_appuio_io_organization", "$1", "organization", "(.*)")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "%(label_appcat_vshn_io_claim_namespace)s/%(label_appcat_vshn_io_claim_name)s"
@@ -323,7 +323,7 @@ spec:
                   value: appcat-vshn-postgres-guaranteed
                 - name: AR_QUERY
                   value: appcat:metering{label_appuio_io_billing_name="appcat-postgresql",label_appcat_vshn_io_sla="guaranteed"}
-                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info,
+                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info{namespace="appuio-control-api-production"},
                     "label_appuio_io_organization", "$1", "organization", "(.*)")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "%(label_appcat_vshn_io_claim_namespace)s/%(label_appcat_vshn_io_claim_name)s"
@@ -410,7 +410,7 @@ spec:
                   value: appcat-vshn-redis-besteffort
                 - name: AR_QUERY
                   value: appcat:metering{label_appuio_io_billing_name="appcat-redis",label_appcat_vshn_io_sla="besteffort"}
-                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info,
+                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info{namespace="appuio-control-api-production"},
                     "label_appuio_io_organization", "$1", "organization", "(.*)")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "%(label_appcat_vshn_io_claim_namespace)s/%(label_appcat_vshn_io_claim_name)s"
@@ -497,7 +497,7 @@ spec:
                   value: appcat-vshn-redis-guaranteed
                 - name: AR_QUERY
                   value: appcat:metering{label_appuio_io_billing_name="appcat-redis",label_appcat_vshn_io_sla="guaranteed"}
-                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info,
+                    * on(label_appuio_io_organization) group_left(sales_order) label_replace(appuio_control_organization_info{namespace="appuio-control-api-production"},
                     "label_appuio_io_organization", "$1", "organization", "(.*)")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "%(label_appcat_vshn_io_claim_namespace)s/%(label_appcat_vshn_io_claim_name)s"

--- a/component/tests/vshn.yml
+++ b/component/tests/vshn.yml
@@ -21,6 +21,9 @@ parameters:
         meteringRules: true
       enableMockOrgInfo: true
       instanceUOM: uom_uom_45_1e112771
+      network_policies:
+        target_namespaces:
+          vshn-appuio-mimir: false
       prometheus:
         url: http://prometheus-operated.prometheus-system:9090/prometheus
 


### PR DESCRIPTION
This modifies the PromQL join such that we ignore any `appuio_control_organization_info` not originating from the production namespace.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
