### PR TITLE
Fix vshn appcat reporting time frame

### DIFF
--- a/component/component/billing.jsonnet
+++ b/component/component/billing.jsonnet
@@ -127,7 +127,7 @@ local backfillCJ = function(name, query, sla, type)
         env+: commonEnv + jobEnv,
         command: [ 'sh', '-c' ],
         args: [
-          'appuio-reporting report --timerange 1h --begin=$(date -d "now -3 hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u -Iseconds)',
+          'appuio-reporting report --timerange 1h --begin=$(date -d "now -3 hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u +"%Y-%m-%dT%H:00:00Z)',
         ],
         resources: {},
       },

--- a/component/tests/golden/vshn/appcat/appcat/billing/11_backfill.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/billing/11_backfill.yaml
@@ -32,7 +32,7 @@ spec:
           containers:
             - args:
                 - appuio-reporting report --timerange 1h --begin=$(date -d "now -3
-                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u -Iseconds)
+                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u +"%Y-%m-%dT%H:00:00Z)
               command:
                 - sh
                 - -c
@@ -119,7 +119,7 @@ spec:
           containers:
             - args:
                 - appuio-reporting report --timerange 1h --begin=$(date -d "now -3
-                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u -Iseconds)
+                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u +"%Y-%m-%dT%H:00:00Z)
               command:
                 - sh
                 - -c
@@ -206,7 +206,7 @@ spec:
           containers:
             - args:
                 - appuio-reporting report --timerange 1h --begin=$(date -d "now -3
-                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u -Iseconds)
+                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u +"%Y-%m-%dT%H:00:00Z)
               command:
                 - sh
                 - -c
@@ -293,7 +293,7 @@ spec:
           containers:
             - args:
                 - appuio-reporting report --timerange 1h --begin=$(date -d "now -3
-                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u -Iseconds)
+                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u +"%Y-%m-%dT%H:00:00Z)
               command:
                 - sh
                 - -c
@@ -380,7 +380,7 @@ spec:
           containers:
             - args:
                 - appuio-reporting report --timerange 1h --begin=$(date -d "now -3
-                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u -Iseconds)
+                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u +"%Y-%m-%dT%H:00:00Z)
               command:
                 - sh
                 - -c
@@ -467,7 +467,7 @@ spec:
           containers:
             - args:
                 - appuio-reporting report --timerange 1h --begin=$(date -d "now -3
-                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u -Iseconds)
+                  hours" -u +"%Y-%m-%dT%H:00:00Z") --repeat-until=$(date -u +"%Y-%m-%dT%H:00:00Z)
               command:
                 - sh
                 - -c


### PR DESCRIPTION
The reporting tool offsets the timeframe by +1 hour. So we can't repeat the reporting until "now", as this will lead to a timeframe in the future. We rather need to limit the repeat until the beginning of the current hour.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
