### PR TITLE
Add Keycloak

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -10,6 +10,9 @@ parameters:
       minio:
         source: https://charts.min.io
         version: 5.0.13
+      keycloak:
+        source: https://charts.bitnami.com/bitnami
+        version: 18.3.0
     images:
       provider-kubernetes:
         registry: xpkg.upbound.io
@@ -42,7 +45,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.52.0
+        tag: v4.53.0
       apiserver:
         registry: ghcr.io
         repository: vshn/appcat-apiserver
@@ -335,6 +338,8 @@ parameters:
           uptime: ${appcat:slos:uptimeDefaults}
         MariaDB:
           uptime: ${appcat:slos:uptimeDefaults}
+        Keycloak:
+          uptime: ${appcat:slos:uptimeDefaults}
 
     providers:
       cloudscale:
@@ -609,69 +614,120 @@ parameters:
                 memory: "1Gi"
                 disk: 50Gi
           instances: []
-        services:
-          mariadb:
-            serviceName: VSHNMariaDB
-            connectionSecretKeys:
-              - ca.crt
-              - MARIADB_HOST
-              - MARIADB_PORT
-              - MARIADB_USERNAME
-              - MARIADB_PASSWORD
-              - MARIADB_URL
-            mode: standalone
-            offered: true
-            enabled: false
-            restoreSA: mariadbrestoreserviceaccount
-            restoreRoleRules: ${appcat:defaultRestoreRoleRules}
-            openshiftTemplate:
-              serviceName: mariadbbyvshn
-              description: "The open source relational database management system (DBMS) that is a compatible drop-in replacement for the widely used MySQL database technology"
-              message: 'Your MariaDB by VSHN instance is being provisioned, please see \${SECRET_NAME} for access.'
-              url: https://vs.hn/vshn-mariadb
-              tags: "database,sql,mariadb"
-              icon: "icon-mariadb"
-              defaultVersion: "11.2"
-            enableNetworkPolicy: false
-            secretNamespace: ${appcat:services:vshn:secretNamespace}
-            helmChartVersion: ${appcat:charts:mariadb:version}
-            imageRegistry: ""
-            bucket_region: "lpg"
-            grpcEndpoint: ${appcat:grpcEndpoint}
-            proxyFunction: false
-            defaultPlan: standard-1
-            sla: 99.25
-            plans:
-              standard-512m:
-                size:
-                  enabled: true
-                  cpu: "125m"
-                  memory: "512Mi"
-                  disk: 16Gi
-              standard-1:
-                size:
-                  enabled: true
-                  cpu: "250m"
-                  memory: "1Gi"
-                  disk: 16Gi
-              standard-2:
-                size:
-                  enabled: true
-                  cpu: "500m"
-                  memory: "2Gi"
-                  disk: 16Gi
-              standard-4:
-                size:
-                  enabled: true
-                  cpu: "1"
-                  memory: "4Gi"
-                  disk: 16Gi
-              standard-8:
-                size:
-                  enabled: true
-                  cpu: "2"
-                  memory: "8Gi"
-                  disk: 16Gi
+        mariadb:
+          billing: true
+          serviceName: VSHNMariaDB
+          compFunctionsOnly: true
+          connectionSecretKeys:
+            - ca.crt
+            - MARIADB_HOST
+            - MARIADB_PORT
+            - MARIADB_USERNAME
+            - MARIADB_PASSWORD
+            - MARIADB_URL
+          mode: standalone
+          offered: true
+          enabled: false
+          restoreSA: mariadbrestoreserviceaccount
+          restoreRoleRules: ${appcat:defaultRestoreRoleRules}
+          openshiftTemplate:
+            serviceName: mariadbbyvshn
+            description: "The open source relational database management system (DBMS) that is a compatible drop-in replacement for the widely used MySQL database technology"
+            message: 'Your MariaDB by VSHN instance is being provisioned, please see \${SECRET_NAME} for access.'
+            url: https://vs.hn/vshn-mariadb
+            tags: "database,sql,mariadb"
+            icon: "icon-mariadb"
+            defaultVersion: "11.2"
+          enableNetworkPolicy: false
+          secretNamespace: ${appcat:services:vshn:secretNamespace}
+          helmChartVersion: ${appcat:charts:mariadb:version}
+          imageRegistry: ""
+          bucket_region: "lpg"
+          grpcEndpoint: ${appcat:grpcEndpoint}
+          proxyFunction: false
+          defaultPlan: standard-1
+          sla: 99.25
+          plans:
+            standard-512m:
+              size:
+                enabled: true
+                cpu: "125m"
+                memory: "512Mi"
+                disk: 16Gi
+            standard-1:
+              size:
+                enabled: true
+                cpu: "250m"
+                memory: "1Gi"
+                disk: 16Gi
+            standard-2:
+              size:
+                enabled: true
+                cpu: "500m"
+                memory: "2Gi"
+                disk: 16Gi
+            standard-4:
+              size:
+                enabled: true
+                cpu: "1"
+                memory: "4Gi"
+                disk: 16Gi
+            standard-8:
+              size:
+                enabled: true
+                cpu: "2"
+                memory: "8Gi"
+                disk: 16Gi
+        keycloak:
+          billing: true
+          serviceName: VSHNKeycloak
+          compFunctionsOnly: true
+          connectionSecretKeys:
+            - KEYCLOAK_HOST
+            - KEYCLOAK_PASSWORD
+            - KEYCLOAK_URL
+            - KEYCLOAK_USERNAME
+          mode: standalone
+          offered: true
+          enabled: false
+          restoreSA: mariadbrestoreserviceaccount
+          restoreRoleRules: ${appcat:defaultRestoreRoleRules}
+          openshiftTemplate:
+            serviceName: keycloakbyvshn
+            description: "Keycloak is an open source identity and access management solution."
+            message: 'Your Keycloak by VSHN instance is being provisioned, please see \${SECRET_NAME} for access.'
+            url: https://vs.hn/vshn-keycloak
+            tags: "idp,keycloak"
+            icon: "icon-keycloak"
+            defaultVersion: "22"
+          enableNetworkPolicy: false
+          secretNamespace: ${appcat:services:vshn:secretNamespace}
+          helmChartVersion: ${appcat:charts:keycloak:version}
+          imageRegistry: ""
+          bucket_region: "lpg"
+          grpcEndpoint: ${appcat:grpcEndpoint}
+          proxyFunction: false
+          defaultPlan: standard-2
+          sla: 99.25
+          plans:
+            standard-2:
+              size:
+                enabled: true
+                cpu: "500m"
+                memory: "2Gi"
+                disk: 16Gi
+            standard-4:
+              size:
+                enabled: true
+                cpu: "1"
+                memory: "4Gi"
+                disk: 16Gi
+            standard-8:
+              size:
+                enabled: true
+                cpu: "2"
+                memory: "8Gi"
+                disk: 16Gi
 
       # Config for exoscale composites
       exoscale:

--- a/component/component/billing.jsonnet
+++ b/component/component/billing.jsonnet
@@ -184,8 +184,7 @@ local generateCloudAndManaged = function(name)
 
   std.flatMap(function(r) [ backfillCJ(name, r.query, r.sla, r.type) ], permutations);
 
-local keysAndValues(obj) = std.map(function(x) { name: x, value: obj[x] }, std.objectFields(obj));
-local vshnServices = std.filter(function(r) std.type(r.value) == 'object' && std.objectHas(r.value, 'billing') && r.value.billing, keysAndValues(params.services.vshn));
+local vshnServices = common.FilterServiceByBoolean('billing');
 local billingCronjobs = std.flattenArrays(std.flatMap(function(r) [ generateCloudAndManaged(r.name) ], vshnServices));
 
 if paramsBilling.vshn.enableCronjobs then

--- a/component/component/common.libsonnet
+++ b/component/component/common.libsonnet
@@ -201,6 +201,10 @@ local defaultRuntimeConfigWithSaName(name) = {
 local capitalize = function(str)
   std.join('', std.mapWithIndex(function(i, c) if i == 0 then std.asciiUpper(c) else c, std.stringChars(str)));
 
+local keysAndValues(obj) = std.map(function(x) { name: x, value: obj[x] }, std.objectFields(obj));
+
+local filterServiceByBoolean(fieldName) = std.filter(function(r) std.type(r.value) == 'object' && std.objectHas(r.value, fieldName) && r.value[fieldName], keysAndValues(params.services.vshn));
+
 {
   SyncOptions: syncOptions,
   VshnMetaDBaaSExoscale(dbname):
@@ -237,4 +241,8 @@ local capitalize = function(str)
     defaultRuntimeConfigWithSaName(name),
   Capitalize(str):
     capitalize(str),
+  KeysAndValues(obj):
+    keysAndValues(obj),
+  FilterServiceByBoolean(fieldName):
+    filterServiceByBoolean(fieldName),
 }

--- a/component/component/main.jsonnet
+++ b/component/component/main.jsonnet
@@ -1,3 +1,4 @@
+local common = import 'common.libsonnet';
 local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
@@ -193,6 +194,7 @@ local emailSecret = kube.Secret(params.services.vshn.emailAlerting.secretName) {
     password: params.services.vshn.emailAlerting.smtpPassword,
   },
 };
+
 {
   '10_clusterrole_view': xrdBrowseRole,
   [if isOpenshift then '10_clusterrole_finalizer']: finalizerRole,
@@ -202,15 +204,4 @@ local emailSecret = kube.Secret(params.services.vshn.emailAlerting.secretName) {
   [if params.billing.vshn.meteringRules then '10_appcat_metering_recording_rule']: meteringRule,
   [if params.services.vshn.enabled && params.services.vshn.emailAlerting.enabled then '10_mailgun_secret']: emailSecret,
   [if params.billing.enableMockOrgInfo then '10_mock_org_info']: mockOrgInfo,
-
-} + if params.slos.enabled && params.services.vshn.enabled then {
-  [if params.services.vshn.postgres.enabled then 'sli_exporter/90_slo_vshn_postgresql']: slos.Get('vshn-postgresql'),
-  [if params.services.vshn.postgres.enabled then 'sli_exporter/90_slo_vshn_postgresql_ha']: slos.Get('vshn-postgresql-ha'),
-  [if params.services.vshn.redis.enabled then 'sli_exporter/90_slo_vshn_redis']: slos.Get('vshn-redis'),
-  [if params.services.vshn.redis.enabled then 'sli_exporter/90_slo_vshn_redis_ha']: slos.Get('vshn-redis-ha'),
-  [if params.services.vshn.minio.enabled then 'sli_exporter/90_slo_vshn_minio']: slos.Get('vshn-minio'),
-  [if params.services.vshn.minio.enabled then 'sli_exporter/90_slo_vshn_minio_ha']: slos.Get('vshn-minio-ha'),
-  [if params.services.vshn.services.mariadb.enabled then 'sli_exporter/90_slo_vshn_mariadb']: slos.Get('vshn-mariadb'),
-  [if params.services.vshn.services.mariadb.enabled then 'sli_exporter/90_slo_vshn_mariadb_ha']: slos.Get('vshn-mariadb-ha'),
 }
-else {}

--- a/component/component/provider.jsonnet
+++ b/component/component/provider.jsonnet
@@ -148,7 +148,7 @@ local runtimeConfigRef(name) = {
         },
         {
           apiGroups: [ 'stackgres.io' ],
-          resources: [ 'sginstanceprofiles', 'sgclusters', 'sgpgconfigs', 'sgobjectstorages', 'sgbackups', 'sgdbops' ],
+          resources: [ 'sginstanceprofiles', 'sgclusters', 'sgpgconfigs', 'sgobjectstorages', 'sgbackups', 'sgdbops', 'sgpoolconfigs' ],
           verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
         },
         {
@@ -288,6 +288,11 @@ local runtimeConfigRef(name) = {
         {
           apiGroups: [ 'monitoring.coreos.com' ],
           resources: [ 'servicemonitors' ],
+          verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
+        },
+        {
+          apiGroups: [ 'networking.k8s.io' ],
+          resources: [ 'ingresses' ],
           verbs: [ 'get', 'list', 'watch', 'update', 'patch', 'create', 'delete' ],
         },
       ],

--- a/component/component/statefuleset-resize-controller.jsonnet
+++ b/component/component/statefuleset-resize-controller.jsonnet
@@ -103,7 +103,7 @@ local resizeClusterRoleBinding = kube.ClusterRoleBinding('appcat:job:resizejob')
 };
 
 // Curently we only need this for redis.
-if params.services.vshn.enabled && (params.services.vshn.redis.enabled || params.services.vshn.services.mariadb.enabled) then {
+if params.services.vshn.enabled && (params.services.vshn.redis.enabled || params.services.vshn.mariadb.enabled) then {
   'controllers/sts-resizer/10_role': role,
   'controllers/sts-resizer/10_sa': sa,
   'controllers/sts-resizer/10_binding': binding,

--- a/component/component/vshn_appcat_services.jsonnet
+++ b/component/component/vshn_appcat_services.jsonnet
@@ -24,10 +24,9 @@ local getServiceNamePlural(serviceName) =
   else
     serviceNameLower + 's';
 
-local vshn_appcat_service(name) =
+local vshn_appcat_service(name, serviceParams) =
   local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
 
-  local serviceParams = params.services.vshn.services[name];
   local connectionSecretKeys = serviceParams.connectionSecretKeys;
   local promRuleSLA = prom.PromRuleSLA(serviceParams.sla, serviceParams.serviceName);
   local plans = common.FilterDisabledParams(serviceParams.plans);
@@ -172,4 +171,4 @@ local vshn_appcat_service(name) =
   } else {}
 ;
 
-std.foldl(function(objOut, name) objOut + vshn_appcat_service(name), std.objectFields(params.services.vshn.services), {})
+std.foldl(function(objOut, newObj) objOut + vshn_appcat_service(newObj.name, newObj.value), common.FilterServiceByBoolean('compFunctionsOnly'), {})

--- a/component/component/vshn_postgres.jsonnet
+++ b/component/component/vshn_postgres.jsonnet
@@ -158,9 +158,9 @@ local localca = {
         },
   patches: [
     comp.ToCompositeFieldPath('status.conditions', 'status.localCAConditions'),
-    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'localca'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
+    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'localca'),
+    comp.FromCompositeFieldPath('metadata.name', 'spec.forProvider.manifest.metadata.name'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
   ],
 };
 
@@ -209,10 +209,14 @@ local certificate = {
         },
   patches: [
     comp.ToCompositeFieldPath('status.conditions', 'status.certificateConditions'),
-    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'certificate'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.issuerRef.name'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
+    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'certificate'),
+    comp.FromCompositeFieldPath('metadata.name', 'spec.forProvider.manifest.metadata.name'),
+    comp.FromCompositeFieldPath('metadata.name', 'spec.forProvider.manifest.spec.issuerRef.name'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
+
+    // We should actually set the dns name...
+    comp.CombineCompositeFromTwoFieldPaths('metadata.name', 'metadata.name', 'spec.forProvider.manifest.spec.dnsNames[0]', '%s.vshn-postgresql-%s.svc.cluster.local'),
+    comp.CombineCompositeFromTwoFieldPaths('metadata.name', 'metadata.name', 'spec.forProvider.manifest.spec.dnsNames[1]', '%s.vshn-postgresql-%s.svc'),
   ],
 };
 
@@ -358,9 +362,9 @@ local sgInstanceProfile = {
         },
   patches: [
     comp.ToCompositeFieldPath('status.conditions', 'status.profileConditions'),
-    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'profile'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name'),
+    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'profile'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
+    comp.FromCompositeFieldPath('metadata.name', 'spec.forProvider.manifest.metadata.name'),
 
     comp.FromCompositeFieldPathWithTransformMap('spec.parameters.size.plan', 'spec.forProvider.manifest.spec.cpu', std.mapWithKey(function(key, x) x.size.cpu, pgPlans)),
     comp.FromCompositeFieldPathWithTransformMap('spec.parameters.size.plan', 'spec.forProvider.manifest.spec.memory', std.mapWithKey(function(key, x) x.size.memory, pgPlans)),
@@ -389,9 +393,9 @@ local sgPostgresConfig = {
         },
   patches: [
     comp.ToCompositeFieldPath('status.conditions', 'status.pgconfigConditions'),
-    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'pgconf'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name'),
+    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'pgconf'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
+    comp.FromCompositeFieldPath('metadata.name', 'spec.forProvider.manifest.metadata.name'),
 
     comp.FromCompositeFieldPath('spec.parameters.service.majorVersion', 'spec.forProvider.manifest.spec.postgresVersion'),
     comp.FromCompositeFieldPath('spec.parameters.service.pgSettings', 'spec.forProvider.manifest.spec[postgresql.conf]'),
@@ -455,9 +459,9 @@ local sgCluster = {
         },
   patches: [
     comp.ToCompositeFieldPath('status.conditions', 'status.pgclusterConditions'),
-    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'cluster'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name'),
+    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'cluster'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
+    comp.FromCompositeFieldPath('metadata.name', 'spec.forProvider.manifest.metadata.name'),
 
     comp.FromCompositeFieldPathWithTransformMap('spec.parameters.size.plan',
                                                 'spec.forProvider.manifest.spec.pods.persistentVolume.size',
@@ -472,9 +476,9 @@ local sgCluster = {
     comp.FromCompositeFieldPath('spec.parameters.scheduling.nodeSelector', 'spec.forProvider.manifest.spec.pods.scheduling.nodeSelector'),
 
     comp.FromCompositeFieldPath('spec.parameters.service.majorVersion', 'spec.forProvider.manifest.spec.postgres.version'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.sgInstanceProfile'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.configurations.sgPostgresConfig'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.configurations.backups[0].sgObjectStorage', 'sgbackup'),
+    comp.FromCompositeFieldPath('metadata.name', 'spec.forProvider.manifest.spec.sgInstanceProfile'),
+    comp.FromCompositeFieldPath('metadata.name', 'spec.forProvider.manifest.spec.configurations.sgPostgresConfig'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.spec.configurations.backups[0].sgObjectStorage', 'sgbackup'),
 
     comp.FromCompositeFieldPath('spec.parameters.backup.retention', 'spec.forProvider.manifest.spec.configurations.backups[0].retention'),
   ],
@@ -499,11 +503,11 @@ local xobjectBucket = {
   },
   patches: [
     comp.ToCompositeFieldPath('status.conditions', 'status.objectBackupConfigConditions'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.parameters.bucketName'),
+    comp.FromCompositeFieldPath('metadata.name', 'metadata.name'),
+    comp.FromCompositeFieldPath('metadata.name', 'spec.parameters.bucketName'),
 
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.writeConnectionSecretToRef.namespace', 'vshn-postgresql'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.writeConnectionSecretToRef.name', 'pgbucket'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.writeConnectionSecretToRef.namespace', 'vshn-postgresql'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.writeConnectionSecretToRef.name', 'pgbucket'),
   ],
 };
 
@@ -545,13 +549,13 @@ local sgObjectStorage = {
         },
   patches: [
     comp.ToCompositeFieldPath('status.conditions', 'status.objectBucketConditions'),
-    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'object-storage'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'sgbackup'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.s3Compatible.bucket'),
+    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'object-storage'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.name', 'sgbackup'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
+    comp.FromCompositeFieldPath('metadata.name', 'spec.forProvider.manifest.spec.s3Compatible.bucket'),
 
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.s3Compatible.awsCredentials.secretKeySelectors.accessKeyId.name', 'pgbucket'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.s3Compatible.awsCredentials.secretKeySelectors.secretAccessKey.name', 'pgbucket'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.spec.s3Compatible.awsCredentials.secretKeySelectors.accessKeyId.name', 'pgbucket'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.spec.s3Compatible.awsCredentials.secretKeySelectors.secretAccessKey.name', 'pgbucket'),
   ],
 };
 
@@ -595,9 +599,9 @@ local networkPolicy = {
         },
   patches: [
     comp.ToCompositeFieldPath('status.conditions', 'status.networkPolicyConditions'),
-    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'network-policy'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'allow-from-claim-namespace'),
+    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'network-policy'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.name', 'allow-from-claim-namespace'),
 
     comp.FromCompositeFieldPath('metadata.labels[crossplane.io/claim-namespace]', 'spec.forProvider.manifest.spec.ingress[0].from[0].namespaceSelector.matchLabels[kubernetes.io/metadata.name]'),
   ],
@@ -648,12 +652,12 @@ local copyJob = {
     },
   },
   patches: [
-    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'copyjob'),
-    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'copyjob'),
+    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'copyjob'),
+    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'spec.forProvider.manifest.metadata.name', 'copyjob'),
     comp.FromCompositeFieldPath('metadata.labels[crossplane.io/claim-namespace]', 'spec.forProvider.manifest.spec.template.spec.containers[0].env[0].value'),
     comp.FromCompositeFieldPath('spec.parameters.restore.claimName', 'spec.forProvider.manifest.spec.template.spec.containers[0].env[1].value'),
     comp.FromCompositeFieldPath('spec.parameters.restore.backupName', 'spec.forProvider.manifest.spec.template.spec.containers[0].env[2].value'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.template.spec.containers[0].env[3].value', 'vshn-postgresql'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.spec.template.spec.containers[0].env[3].value', 'vshn-postgresql'),
   ],
 };
 
@@ -674,7 +678,7 @@ local clusterRestoreConfig = {
   patches+: [
     comp.FromCompositeFieldPath('spec.parameters.restore.backupName', 'spec.forProvider.manifest.spec.initialData.restore.fromBackup.name'),
     comp.FromCompositeFieldPath('spec.parameters.restore.recoveryTimeStamp', 'spec.forProvider.manifest.spec.initialData.restore.fromBackup.pointInTimeRecovery.restoreToTimestamp'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.references[0].dependsOn.namespace', 'vshn-postgresql'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.references[0].dependsOn.namespace', 'vshn-postgresql'),
     comp.FromCompositeFieldPath('spec.parameters.restore.backupName', 'spec.references[0].dependsOn.name'),
   ],
 };
@@ -764,8 +768,8 @@ local prometheusRule = prom.GeneratePrometheusNonSLORules(
   ]
 ) + {
   patches: [
-    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'prometheusrule'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
+    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'prometheusrule'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
   ],
 };
 
@@ -836,10 +840,10 @@ local podMonitor = {
     },
   },
   patches: [
-    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'podmonitor'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
-    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.selector.matchLabels[stackgres.io/cluster-name]'),
-    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.namespaceSelector.matchNames[0]', 'vshn-postgresql'),
+    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'podmonitor'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-postgresql'),
+    comp.FromCompositeFieldPath('metadata.name', 'spec.forProvider.manifest.spec.selector.matchLabels[stackgres.io/cluster-name]'),
+    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.spec.namespaceSelector.matchNames[0]', 'vshn-postgresql'),
   ],
 };
 

--- a/component/component/vshn_redis.jsonnet
+++ b/component/component/vshn_redis.jsonnet
@@ -254,8 +254,8 @@ local composition =
 
   local prometheusRule = prom.GeneratePrometheusNonSLORules('redis', 'redis', []) + {
     patches: [
-      comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'prometheusrule'),
-      comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
+      comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'prometheusrule'),
+      comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
     ],
   };
 
@@ -387,9 +387,9 @@ local composition =
                   base: selfSignedIssuer,
                   patches: [
                     comp.ToCompositeFieldPath('status.conditions', 'status.selfSignedIssuerConditions'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'selfsigned-issuer'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'selfsigned-issuer'),
-                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'selfsigned-issuer'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'spec.forProvider.manifest.metadata.name', 'selfsigned-issuer'),
+                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
                   ],
                 },
                 {
@@ -397,9 +397,9 @@ local composition =
                   base: caIssuer,
                   patches: [
                     comp.ToCompositeFieldPath('status.conditions', 'status.localCAConditions'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'ca-issuer'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'ca-issuer'),
-                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'ca-issuer'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'spec.forProvider.manifest.metadata.name', 'ca-issuer'),
+                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
                   ],
                 },
                 {
@@ -407,12 +407,12 @@ local composition =
                   base: caCertificate,
                   patches: [
                     comp.ToCompositeFieldPath('status.conditions', 'status.caCertificateConditions'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'ca-certificate'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'ca'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.issuerRef.name', 'selfsigned-issuer'),
-                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
-                    comp.CombineCompositeFromOneFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.dnsNames[0]', 'redis-headless.vshn-redis-%s.svc.cluster.local'),
-                    comp.CombineCompositeFromOneFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.dnsNames[1]', 'redis-headless.vshn-redis-%s.svc'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'ca-certificate'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'spec.forProvider.manifest.metadata.name', 'ca'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'spec.forProvider.manifest.spec.issuerRef.name', 'selfsigned-issuer'),
+                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
+                    comp.CombineCompositeFromOneFieldPath('metadata.name', 'spec.forProvider.manifest.spec.dnsNames[0]', 'redis-headless.vshn-redis-%s.svc.cluster.local'),
+                    comp.CombineCompositeFromOneFieldPath('metadata.name', 'spec.forProvider.manifest.spec.dnsNames[1]', 'redis-headless.vshn-redis-%s.svc'),
 
                   ],
                 },
@@ -421,12 +421,12 @@ local composition =
                   base: serverCertificate,
                   patches: [
                     comp.ToCompositeFieldPath('status.conditions', 'status.serverCertificateConditions'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'server-certificate'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'server'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.issuerRef.name', 'ca-issuer'),
-                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
-                    comp.CombineCompositeFromOneFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.dnsNames[0]', 'redis-headless.vshn-redis-%s.svc.cluster.local'),
-                    comp.CombineCompositeFromOneFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.dnsNames[1]', 'redis-headless.vshn-redis-%s.svc'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'server-certificate'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'spec.forProvider.manifest.metadata.name', 'server'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'spec.forProvider.manifest.spec.issuerRef.name', 'ca-issuer'),
+                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
+                    comp.CombineCompositeFromOneFieldPath('metadata.name', 'spec.forProvider.manifest.spec.dnsNames[0]', 'redis-headless.vshn-redis-%s.svc.cluster.local'),
+                    comp.CombineCompositeFromOneFieldPath('metadata.name', 'spec.forProvider.manifest.spec.dnsNames[1]', 'redis-headless.vshn-redis-%s.svc'),
 
                   ],
                 },
@@ -435,22 +435,22 @@ local composition =
                   base: clientCertificate,
                   patches: [
                     comp.ToCompositeFieldPath('status.conditions', 'status.clientCertificateConditions'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'metadata.name', 'client-certificate'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name', 'client'),
-                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.issuerRef.name', 'ca-issuer'),
-                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
-                    comp.CombineCompositeFromOneFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.dnsNames[0]', 'redis-headless.vshn-redis-%s.svc.cluster.local'),
-                    comp.CombineCompositeFromOneFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.spec.dnsNames[1]', 'redis-headless.vshn-redis-%s.svc'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'metadata.name', 'client-certificate'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'spec.forProvider.manifest.metadata.name', 'client'),
+                    comp.FromCompositeFieldPathWithTransformSuffix('metadata.name', 'spec.forProvider.manifest.spec.issuerRef.name', 'ca-issuer'),
+                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
+                    comp.CombineCompositeFromOneFieldPath('metadata.name', 'spec.forProvider.manifest.spec.dnsNames[0]', 'redis-headless.vshn-redis-%s.svc.cluster.local'),
+                    comp.CombineCompositeFromOneFieldPath('metadata.name', 'spec.forProvider.manifest.spec.dnsNames[1]', 'redis-headless.vshn-redis-%s.svc'),
                   ],
                 },
                 {
                   name: 'release',
                   base: redisHelmChart,
                   patches: [
-                    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'metadata.name'),
-                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.namespace', 'vshn-redis'),
-                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
-                    comp.FromCompositeFieldPath('metadata.labels[crossplane.io/composite]', 'spec.forProvider.manifest.metadata.name'),
+                    comp.FromCompositeFieldPath('metadata.name', 'metadata.name'),
+                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.namespace', 'vshn-redis'),
+                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.manifest.metadata.namespace', 'vshn-redis'),
+                    comp.FromCompositeFieldPath('metadata.name', 'spec.forProvider.manifest.metadata.name'),
                     comp.FromCompositeFieldPath('metadata.labels[crossplane.io/claim-namespace]', 'spec.forProvider.values.networkPolicy.ingressNSMatchLabels[kubernetes.io/metadata.name]'),
 
                     comp.FromCompositeFieldPathWithTransformMap('spec.parameters.size.plan', 'spec.forProvider.values.master.resources.requests.memory', std.mapWithKey(function(key, x) x.size.memory, redisPlans)),
@@ -469,7 +469,7 @@ local composition =
                     comp.FromCompositeFieldPath('spec.parameters.tls.enabled', 'spec.forProvider.values.tls.enabled'),
                     comp.FromCompositeFieldPath('spec.parameters.tls.authClients', 'spec.forProvider.values.tls.authClients'),
 
-                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.labels[crossplane.io/composite]', 'spec.forProvider.values.metrics.serviceMonitor.namespace', 'vshn-redis'),
+                    comp.FromCompositeFieldPathWithTransformPrefix('metadata.name', 'spec.forProvider.values.metrics.serviceMonitor.namespace', 'vshn-redis'),
 
                     comp.FromCompositeFieldPathWithTransformMap('spec.parameters.size.plan',
                                                                 'spec.forProvider.values.master.nodeSelector',

--- a/component/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.52.0
+        image: ghcr.io/vshn/appcat:v4.53.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.52.0
+        image: ghcr.io/vshn/appcat:v4.53.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/component/tests/golden/cloudscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -145,6 +145,7 @@ rules:
       - sgobjectstorages
       - sgbackups
       - sgdbops
+      - sgpoolconfigs
     verbs:
       - get
       - list

--- a/component/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.52.0
+          image: ghcr.io/vshn/appcat:v4.53.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.52.0
+        image: ghcr.io/vshn/appcat:v4.53.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.52.0
+        image: ghcr.io/vshn/appcat:v4.53.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.52.0
+        image: ghcr.io/vshn/appcat:v4.53.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/10_provider_kubernetes.yaml
@@ -145,6 +145,7 @@ rules:
       - sgobjectstorages
       - sgbackups
       - sgdbops
+      - sgpoolconfigs
     verbs:
       - get
       - list

--- a/component/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/minio/appcat/appcat/10_provider_helm.yaml
+++ b/component/tests/golden/minio/appcat/appcat/10_provider_helm.yaml
@@ -134,6 +134,18 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/component/tests/golden/minio/appcat/appcat/10_provider_kubernetes.yaml
+++ b/component/tests/golden/minio/appcat/appcat/10_provider_kubernetes.yaml
@@ -145,6 +145,7 @@ rules:
       - sgobjectstorages
       - sgbackups
       - sgdbops
+      - sgpoolconfigs
     verbs:
       - get
       - list

--- a/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
@@ -28,7 +28,7 @@ spec:
         data:
           controlNamespace: syn-appcat-control
           defaultPlan: standard-1
-          imageTag: v4.52.0
+          imageTag: v4.53.0
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io
           minioChartVersion: 5.0.13

--- a/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.52.0
+          image: ghcr.io/vshn/appcat:v4.53.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.52.0
+              image: ghcr.io/vshn/appcat:v4.53.0
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.52.0
+        image: ghcr.io/vshn/appcat:v4.53.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/10_provider_kubernetes.yaml
@@ -145,6 +145,7 @@ rules:
       - sgobjectstorages
       - sgbackups
       - sgdbops
+      - sgpoolconfigs
     verbs:
       - get
       - list

--- a/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.52.0
+        image: ghcr.io/vshn/appcat:v4.53.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.52.0-func
+  package: ghcr.io/vshn/appcat:v4.53.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/vshn/appcat/appcat/10_provider_helm.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/10_provider_helm.yaml
@@ -134,6 +134,18 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/component/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/10_provider_kubernetes.yaml
@@ -145,6 +145,7 @@ rules:
       - sgobjectstorages
       - sgbackups
       - sgdbops
+      - sgpoolconfigs
     verbs:
       - get
       - list

--- a/component/tests/golden/vshn/appcat/appcat/20_plans_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/20_plans_vshn_keycloak.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  plans: '{"standard-2": {"size": {"cpu": "500m", "disk": "16Gi", "enabled": true,
+    "memory": "2Gi"}}, "standard-4": {"size": {"cpu": "1", "disk": "16Gi", "enabled":
+    true, "memory": "4Gi"}}, "standard-8": {"size": {"cpu": "2", "disk": "16Gi", "enabled":
+    true, "memory": "8Gi"}}}'
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: vshnkeycloakplans
+  name: vshnkeycloakplans
+  namespace: syn-appcat

--- a/component/tests/golden/vshn/appcat/appcat/20_rbac_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/20_rbac_vshn_keycloak.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: appcat:composite:xvshnkeycloaks.vshn.appcat.vshn.io:claim-view
+rules:
+  - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnkeycloaks
+      - vshnkeycloaks/status
+      - vshnkeycloaks/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: appcat:composite:xvshnkeycloaks.vshn.appcat.vshn.io:claim-edit
+rules:
+  - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - vshnkeycloaks
+      - vshnkeycloaks/status
+      - vshnkeycloaks/finalizers
+    verbs:
+      - '*'

--- a/component/tests/golden/vshn/appcat/appcat/20_role_vshn_keycloak_restore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/20_role_vshn_keycloak_restore.yaml
@@ -1,0 +1,80 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: crossplane-appcat-job-keycloak-restorejob
+  name: crossplane:appcat:job:keycloak:restorejob
+rules:
+  - apiGroups:
+      - vshn.appcat.vshn.io
+    resources:
+      - '*'
+    verbs:
+      - get
+  - apiGroups:
+      - k8up.io
+    resources:
+      - snapshots
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets/scale
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - get
+      - create
+      - patch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: mariadbrestoreserviceaccount
+  name: mariadbrestoreserviceaccount
+  namespace: syn-appcat-control
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appcat-job-keycloak-restorejob
+  name: appcat:job:keycloak:restorejob
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane:appcat:job:keycloak:restorejob
+subjects:
+  - kind: ServiceAccount
+    name: mariadbrestoreserviceaccount
+    namespace: syn-appcat-control

--- a/component/tests/golden/vshn/appcat/appcat/20_xrd_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/20_xrd_vshn_keycloak.yaml
@@ -1,0 +1,6478 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '10'
+  labels:
+    name: xvshnkeycloaks.vshn.appcat.vshn.io
+  name: xvshnkeycloaks.vshn.appcat.vshn.io
+spec:
+  claimNames:
+    kind: VSHNKeycloak
+    plural: vshnkeycloaks
+  connectionSecretKeys:
+    - KEYCLOAK_HOST
+    - KEYCLOAK_PASSWORD
+    - KEYCLOAK_URL
+    - KEYCLOAK_USERNAME
+  defaultCompositionRef:
+    name: vshnkeycloak.vshn.appcat.vshn.io
+  group: vshn.appcat.vshn.io
+  names:
+    kind: XVSHNKeycloak
+    plural: xvshnkeycloaks
+  versions:
+    - name: v1
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          description: VSHNKeycloak is the API for creating keycloak instances.
+          properties:
+            spec:
+              description: Spec defines the desired state of a VSHNKeycloak.
+              properties:
+                parameters:
+                  default: {}
+                  description: Parameters are the configurable fields of a VSHNKeycloak.
+                  properties:
+                    backup:
+                      default: {}
+                      description: Backup contains settings to control how the instance
+                        should get backed up.
+                      properties:
+                        retention:
+                          description: K8upRetentionPolicy describes the retention
+                            configuration for a K8up backup.
+                          properties:
+                            keepDaily:
+                              default: 6
+                              type: integer
+                            keepHourly:
+                              type: integer
+                            keepLast:
+                              type: integer
+                            keepMonthly:
+                              type: integer
+                            keepWeekly:
+                              type: integer
+                            keepYearly:
+                              type: integer
+                          type: object
+                        schedule:
+                          pattern: ^(\*|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])|\*\/([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]))
+                            (\*|([0-9]|1[0-9]|2[0-3])|\*\/([0-9]|1[0-9]|2[0-3])) (\*|([1-9]|1[0-9]|2[0-9]|3[0-1])|\*\/([1-9]|1[0-9]|2[0-9]|3[0-1]))
+                            (\*|([1-9]|1[0-2])|\*\/([1-9]|1[0-2])) (\*|([0-6])|\*\/([0-6]))$
+                          type: string
+                      type: object
+                    maintenance:
+                      description: Maintenance contains settings to control the maintenance
+                        of an instance.
+                      properties:
+                        dayOfWeek:
+                          description: DayOfWeek specifies at which weekday the maintenance
+                            is held place. Allowed values are [monday, tuesday, wednesday,
+                            thursday, friday, saturday, sunday]
+                          enum:
+                            - monday
+                            - tuesday
+                            - wednesday
+                            - thursday
+                            - friday
+                            - saturday
+                            - sunday
+                          type: string
+                        timeOfDay:
+                          description: 'TimeOfDay for installing updates in UTC. Format:
+                            "hh:mm:ss".'
+                          pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
+                          type: string
+                      type: object
+                    restore:
+                      description: Restore contains settings to control the restore
+                        of an instance.
+                      properties:
+                        backupName:
+                          description: BackupName is the name of the specific backup
+                            you want to restore.
+                          type: string
+                        claimName:
+                          description: ClaimName specifies the name of the instance
+                            you want to restore from. The claim has to be in the same
+                            namespace as this new instance.
+                          type: string
+                      type: object
+                    scheduling:
+                      description: Scheduling contains settings to control the scheduling
+                        of an instance.
+                      properties:
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: "NodeSelector is a selector which must match\
+                            \ a node\u2019s labels for the pod to be scheduled on\
+                            \ that node"
+                          type: object
+                      type: object
+                    service:
+                      default: {}
+                      description: Service contains keycloak DBaaS specific properties
+                      properties:
+                        fqdn:
+                          description: FQDN contains the FQDN which will be used for
+                            the ingress. If it's not set, no ingress will be deployed.
+                            This also enables strict hostname checking for this FQDN.
+                          type: string
+                        postgreSQLParameters:
+                          default: {}
+                          description: PostgreSQLParameters can be used to set any
+                            supported setting in the underlying PostgreSQL instance.
+                          properties:
+                            backup:
+                              description: Backup contains settings to control the
+                                backups of an instance.
+                              properties:
+                                deletionProtection:
+                                  default: true
+                                  description: DeletionProtection will protect the
+                                    instance from being deleted for the given retention
+                                    time. This is enabled by default.
+                                  type: boolean
+                                deletionRetention:
+                                  default: 7
+                                  description: DeletionRetention specifies in days
+                                    how long the instance should be kept after deletion.
+                                    The default is keeping it one week.
+                                  type: integer
+                                retention:
+                                  default: 6
+                                  pattern: ^[1-9][0-9]*$
+                                  type: integer
+                                  x-kubernetes-int-or-string: true
+                                schedule:
+                                  pattern: ^(\*|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])|\*\/([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]))
+                                    (\*|([0-9]|1[0-9]|2[0-3])|\*\/([0-9]|1[0-9]|2[0-3]))
+                                    (\*|([1-9]|1[0-9]|2[0-9]|3[0-1])|\*\/([1-9]|1[0-9]|2[0-9]|3[0-1]))
+                                    (\*|([1-9]|1[0-2])|\*\/([1-9]|1[0-2])) (\*|([0-6])|\*\/([0-6]))$
+                                  type: string
+                              type: object
+                            encryption:
+                              description: Encryption contains settings to control
+                                the storage encryption of an instance.
+                              properties:
+                                enabled:
+                                  description: Enabled specifies if the instance should
+                                    use encrypted storage for the instance.
+                                  type: boolean
+                              type: object
+                            instances:
+                              default: 1
+                              description: Instances configures the number of PostgreSQL
+                                instances for the cluster. Each instance contains
+                                one Postgres server. Out of all Postgres servers,
+                                one is elected as the primary, the rest remain as
+                                read-only replicas.
+                              maximum: 3
+                              minimum: 1
+                              type: integer
+                            maintenance:
+                              description: Maintenance contains settings to control
+                                the maintenance of an instance.
+                              properties:
+                                dayOfWeek:
+                                  description: DayOfWeek specifies at which weekday
+                                    the maintenance is held place. Allowed values
+                                    are [monday, tuesday, wednesday, thursday, friday,
+                                    saturday, sunday]
+                                  enum:
+                                    - monday
+                                    - tuesday
+                                    - wednesday
+                                    - thursday
+                                    - friday
+                                    - saturday
+                                    - sunday
+                                  type: string
+                                timeOfDay:
+                                  description: 'TimeOfDay for installing updates in
+                                    UTC. Format: "hh:mm:ss".'
+                                  pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
+                                  type: string
+                              type: object
+                            monitoring:
+                              description: Monitoring contains settings to control
+                                monitoring.
+                              properties:
+                                alertmanagerConfigRef:
+                                  description: AlertmanagerConfigRef contains the
+                                    name of the AlertmanagerConfig that should be
+                                    copied over to the namespace of the instance.
+                                  type: string
+                                alertmanagerConfigSecretRef:
+                                  description: AlertmanagerConfigSecretRef contains
+                                    the name of the secret that is used in the referenced
+                                    AlertmanagerConfig
+                                  type: string
+                                alertmanagerConfigTemplate:
+                                  description: AlertmanagerConfigSpecTemplate takes
+                                    an AlertmanagerConfigSpec object. This takes precedence
+                                    over the AlertmanagerConfigRef.
+                                  properties:
+                                    inhibitRules:
+                                      description: List of inhibition rules. The rules
+                                        will only apply to alerts matching the resource's
+                                        namespace.
+                                      items:
+                                        description: InhibitRule defines an inhibition
+                                          rule that allows to mute alerts when other
+                                          alerts are already firing. See https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
+                                        properties:
+                                          equal:
+                                            description: Labels that must have an
+                                              equal value in the source and target
+                                              alert for the inhibition to take effect.
+                                            items:
+                                              type: string
+                                            type: array
+                                          sourceMatch:
+                                            description: Matchers for which one or
+                                              more alerts have to exist for the inhibition
+                                              to take effect. The operator enforces
+                                              that the alert matches the resource's
+                                              namespace.
+                                            items:
+                                              description: Matcher defines how to
+                                                match on alert's labels.
+                                              properties:
+                                                matchType:
+                                                  description: Match operation available
+                                                    with AlertManager >= v0.22.0 and
+                                                    takes precedence over Regex (deprecated)
+                                                    if non-empty.
+                                                  enum:
+                                                    - '!='
+                                                    - '='
+                                                    - =~
+                                                    - '!~'
+                                                  type: string
+                                                name:
+                                                  description: Label to match.
+                                                  minLength: 1
+                                                  type: string
+                                                regex:
+                                                  description: Whether to match on
+                                                    equality (false) or regular-expression
+                                                    (true). Deprecated as of AlertManager
+                                                    >= v0.22.0 where a user should
+                                                    use MatchType instead.
+                                                  type: boolean
+                                                value:
+                                                  description: Label value to match.
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                          targetMatch:
+                                            description: Matchers that have to be
+                                              fulfilled in the alerts to be muted.
+                                              The operator enforces that the alert
+                                              matches the resource's namespace.
+                                            items:
+                                              description: Matcher defines how to
+                                                match on alert's labels.
+                                              properties:
+                                                matchType:
+                                                  description: Match operation available
+                                                    with AlertManager >= v0.22.0 and
+                                                    takes precedence over Regex (deprecated)
+                                                    if non-empty.
+                                                  enum:
+                                                    - '!='
+                                                    - '='
+                                                    - =~
+                                                    - '!~'
+                                                  type: string
+                                                name:
+                                                  description: Label to match.
+                                                  minLength: 1
+                                                  type: string
+                                                regex:
+                                                  description: Whether to match on
+                                                    equality (false) or regular-expression
+                                                    (true). Deprecated as of AlertManager
+                                                    >= v0.22.0 where a user should
+                                                    use MatchType instead.
+                                                  type: boolean
+                                                value:
+                                                  description: Label value to match.
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    muteTimeIntervals:
+                                      description: List of MuteTimeInterval specifying
+                                        when the routes should be muted.
+                                      items:
+                                        description: MuteTimeInterval specifies the
+                                          periods in time when notifications will
+                                          be muted
+                                        properties:
+                                          name:
+                                            description: Name of the time interval
+                                            type: string
+                                          timeIntervals:
+                                            description: TimeIntervals is a list of
+                                              TimeInterval
+                                            items:
+                                              description: TimeInterval describes
+                                                intervals of time
+                                              properties:
+                                                daysOfMonth:
+                                                  description: DaysOfMonth is a list
+                                                    of DayOfMonthRange
+                                                  items:
+                                                    description: DayOfMonthRange is
+                                                      an inclusive range of days of
+                                                      the month beginning at 1
+                                                    properties:
+                                                      end:
+                                                        description: End of the inclusive
+                                                          range
+                                                        maximum: 31
+                                                        minimum: -31
+                                                        type: integer
+                                                      start:
+                                                        description: Start of the
+                                                          inclusive range
+                                                        maximum: 31
+                                                        minimum: -31
+                                                        type: integer
+                                                    type: object
+                                                  type: array
+                                                months:
+                                                  description: Months is a list of
+                                                    MonthRange
+                                                  items:
+                                                    description: MonthRange is an
+                                                      inclusive range of months of
+                                                      the year beginning in January
+                                                      Months can be specified by name
+                                                      (e.g 'January') by numerical
+                                                      month (e.g '1') or as an inclusive
+                                                      range (e.g 'January:March',
+                                                      '1:3', '1:March')
+                                                    pattern: ^((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12])(?:((:((?i)january|february|march|april|may|june|july|august|september|october|november|december|[1-12]))$)|$)
+                                                    type: string
+                                                  type: array
+                                                times:
+                                                  description: Times is a list of
+                                                    TimeRange
+                                                  items:
+                                                    description: TimeRange defines
+                                                      a start and end time in 24hr
+                                                      format
+                                                    properties:
+                                                      endTime:
+                                                        description: EndTime is the
+                                                          end time in 24hr format.
+                                                        pattern: ^((([01][0-9])|(2[0-3])):[0-5][0-9])$|(^24:00$)
+                                                        type: string
+                                                      startTime:
+                                                        description: StartTime is
+                                                          the start time in 24hr format.
+                                                        pattern: ^((([01][0-9])|(2[0-3])):[0-5][0-9])$|(^24:00$)
+                                                        type: string
+                                                    type: object
+                                                  type: array
+                                                weekdays:
+                                                  description: Weekdays is a list
+                                                    of WeekdayRange
+                                                  items:
+                                                    description: WeekdayRange is an
+                                                      inclusive range of days of the
+                                                      week beginning on Sunday Days
+                                                      can be specified by name (e.g
+                                                      'Sunday') or as an inclusive
+                                                      range (e.g 'Monday:Friday')
+                                                    pattern: ^((?i)sun|mon|tues|wednes|thurs|fri|satur)day(?:((:(sun|mon|tues|wednes|thurs|fri|satur)day)$)|$)
+                                                    type: string
+                                                  type: array
+                                                years:
+                                                  description: Years is a list of
+                                                    YearRange
+                                                  items:
+                                                    description: YearRange is an inclusive
+                                                      range of years
+                                                    pattern: ^2\d{3}(?::2\d{3}|$)
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    receivers:
+                                      description: List of receivers.
+                                      items:
+                                        description: Receiver defines one or more
+                                          notification integrations.
+                                        properties:
+                                          emailConfigs:
+                                            description: List of Email configurations.
+                                            items:
+                                              description: EmailConfig configures
+                                                notifications via Email.
+                                              properties:
+                                                authIdentity:
+                                                  description: The identity to use
+                                                    for authentication.
+                                                  type: string
+                                                authPassword:
+                                                  description: The secret's key that
+                                                    contains the password to use for
+                                                    authentication. The secret needs
+                                                    to be in the same namespace as
+                                                    the AlertmanagerConfig object
+                                                    and accessible by the Prometheus
+                                                    Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                authSecret:
+                                                  description: The secret's key that
+                                                    contains the CRAM-MD5 secret.
+                                                    The secret needs to be in the
+                                                    same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus
+                                                    Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                authUsername:
+                                                  description: The username to use
+                                                    for authentication.
+                                                  type: string
+                                                from:
+                                                  description: The sender address.
+                                                  type: string
+                                                headers:
+                                                  description: Further headers email
+                                                    header key/value pairs. Overrides
+                                                    any headers previously set by
+                                                    the notification implementation.
+                                                  items:
+                                                    description: KeyValue defines
+                                                      a (key, value) tuple.
+                                                    properties:
+                                                      key:
+                                                        description: Key of the tuple.
+                                                        minLength: 1
+                                                        type: string
+                                                      value:
+                                                        description: Value of the
+                                                          tuple.
+                                                        type: string
+                                                    required:
+                                                      - key
+                                                      - value
+                                                    type: object
+                                                  type: array
+                                                hello:
+                                                  description: The hostname to identify
+                                                    to the SMTP server.
+                                                  type: string
+                                                html:
+                                                  description: The HTML body of the
+                                                    email notification.
+                                                  type: string
+                                                requireTLS:
+                                                  description: The SMTP TLS requirement.
+                                                    Note that Go does not support
+                                                    unencrypted connections to remote
+                                                    SMTP endpoints.
+                                                  type: boolean
+                                                sendResolved:
+                                                  description: Whether or not to notify
+                                                    about resolved alerts.
+                                                  type: boolean
+                                                smarthost:
+                                                  description: The SMTP host and port
+                                                    through which emails are sent.
+                                                    E.g. example.com:25
+                                                  type: string
+                                                text:
+                                                  description: The text body of the
+                                                    email notification.
+                                                  type: string
+                                                tlsConfig:
+                                                  description: TLS configuration
+                                                  properties:
+                                                    ca:
+                                                      description: Certificate authority
+                                                        used when verifying server
+                                                        certificates.
+                                                      properties:
+                                                        configMap:
+                                                          description: ConfigMap containing
+                                                            data to use for the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                to select.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the ConfigMap
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        secret:
+                                                          description: Secret containing
+                                                            data to use for the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                    cert:
+                                                      description: Client certificate
+                                                        to present when doing client-authentication.
+                                                      properties:
+                                                        configMap:
+                                                          description: ConfigMap containing
+                                                            data to use for the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                to select.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the ConfigMap
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        secret:
+                                                          description: Secret containing
+                                                            data to use for the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                    insecureSkipVerify:
+                                                      description: Disable target
+                                                        certificate validation.
+                                                      type: boolean
+                                                    keySecret:
+                                                      description: Secret containing
+                                                        the client key file for the
+                                                        targets.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    serverName:
+                                                      description: Used to verify
+                                                        the hostname for the targets.
+                                                      type: string
+                                                  type: object
+                                                to:
+                                                  description: The email address to
+                                                    send notifications to.
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: Name of the receiver. Must
+                                              be unique across all items from the
+                                              list.
+                                            minLength: 1
+                                            type: string
+                                          opsgenieConfigs:
+                                            description: List of OpsGenie configurations.
+                                            items:
+                                              description: OpsGenieConfig configures
+                                                notifications via OpsGenie. See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
+                                              properties:
+                                                actions:
+                                                  description: Comma separated list
+                                                    of actions that will be available
+                                                    for the alert.
+                                                  type: string
+                                                apiKey:
+                                                  description: The secret's key that
+                                                    contains the OpsGenie API key.
+                                                    The secret needs to be in the
+                                                    same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus
+                                                    Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                apiURL:
+                                                  description: The URL to send OpsGenie
+                                                    API requests to.
+                                                  type: string
+                                                description:
+                                                  description: Description of the
+                                                    incident.
+                                                  type: string
+                                                details:
+                                                  description: A set of arbitrary
+                                                    key/value pairs that provide further
+                                                    detail about the incident.
+                                                  items:
+                                                    description: KeyValue defines
+                                                      a (key, value) tuple.
+                                                    properties:
+                                                      key:
+                                                        description: Key of the tuple.
+                                                        minLength: 1
+                                                        type: string
+                                                      value:
+                                                        description: Value of the
+                                                          tuple.
+                                                        type: string
+                                                    required:
+                                                      - key
+                                                      - value
+                                                    type: object
+                                                  type: array
+                                                entity:
+                                                  description: Optional field that
+                                                    can be used to specify which domain
+                                                    alert is related to.
+                                                  type: string
+                                                httpConfig:
+                                                  description: HTTP client configuration.
+                                                  properties:
+                                                    authorization:
+                                                      description: Authorization header
+                                                        configuration for the client.
+                                                        This is mutually exclusive
+                                                        with BasicAuth and is only
+                                                        available starting from Alertmanager
+                                                        v0.22+.
+                                                      properties:
+                                                        credentials:
+                                                          description: The secret's
+                                                            key that contains the
+                                                            credentials of the request
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type:
+                                                          description: Set the authentication
+                                                            type. Defaults to Bearer,
+                                                            Basic will cause an error
+                                                          type: string
+                                                      type: object
+                                                    basicAuth:
+                                                      description: BasicAuth for the
+                                                        client. This is mutually exclusive
+                                                        with Authorization. If both
+                                                        are defined, BasicAuth takes
+                                                        precedence.
+                                                      properties:
+                                                        password:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the password for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        username:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the username for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                    bearerTokenSecret:
+                                                      description: The secret's key
+                                                        that contains the bearer token
+                                                        to be used by the client for
+                                                        authentication. The secret
+                                                        needs to be in the same namespace
+                                                        as the AlertmanagerConfig
+                                                        object and accessible by the
+                                                        Prometheus Operator.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    followRedirects:
+                                                      description: FollowRedirects
+                                                        specifies whether the client
+                                                        should follow HTTP 3xx redirects.
+                                                      type: boolean
+                                                    oauth2:
+                                                      description: OAuth2 client credentials
+                                                        used to fetch a token for
+                                                        the targets.
+                                                      properties:
+                                                        clientId:
+                                                          description: The secret
+                                                            or configmap containing
+                                                            the OAuth2 client id
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        clientSecret:
+                                                          description: The secret
+                                                            containing the OAuth2
+                                                            client secret
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        endpointParams:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: Parameters
+                                                            to append to the token
+                                                            URL
+                                                          type: object
+                                                        scopes:
+                                                          description: OAuth2 scopes
+                                                            used for the token request
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        tokenUrl:
+                                                          description: The URL to
+                                                            fetch the token from
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                        - clientId
+                                                        - clientSecret
+                                                        - tokenUrl
+                                                      type: object
+                                                    proxyURL:
+                                                      description: Optional proxy
+                                                        URL.
+                                                      type: string
+                                                    tlsConfig:
+                                                      description: TLS configuration
+                                                        for the client.
+                                                      properties:
+                                                        ca:
+                                                          description: Certificate
+                                                            authority used when verifying
+                                                            server certificates.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        cert:
+                                                          description: Client certificate
+                                                            to present when doing
+                                                            client-authentication.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        insecureSkipVerify:
+                                                          description: Disable target
+                                                            certificate validation.
+                                                          type: boolean
+                                                        keySecret:
+                                                          description: Secret containing
+                                                            the client key file for
+                                                            the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        serverName:
+                                                          description: Used to verify
+                                                            the hostname for the targets.
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                message:
+                                                  description: Alert text limited
+                                                    to 130 characters.
+                                                  type: string
+                                                note:
+                                                  description: Additional alert note.
+                                                  type: string
+                                                priority:
+                                                  description: Priority level of alert.
+                                                    Possible values are P1, P2, P3,
+                                                    P4, and P5.
+                                                  type: string
+                                                responders:
+                                                  description: List of responders
+                                                    responsible for notifications.
+                                                  items:
+                                                    description: OpsGenieConfigResponder
+                                                      defines a responder to an incident.
+                                                      One of `id`, `name` or `username`
+                                                      has to be defined.
+                                                    properties:
+                                                      id:
+                                                        description: ID of the responder.
+                                                        type: string
+                                                      name:
+                                                        description: Name of the responder.
+                                                        type: string
+                                                      type:
+                                                        description: Type of responder.
+                                                        enum:
+                                                          - team
+                                                          - teams
+                                                          - user
+                                                          - escalation
+                                                          - schedule
+                                                        minLength: 1
+                                                        type: string
+                                                      username:
+                                                        description: Username of the
+                                                          responder.
+                                                        type: string
+                                                    required:
+                                                      - type
+                                                    type: object
+                                                  type: array
+                                                sendResolved:
+                                                  description: Whether or not to notify
+                                                    about resolved alerts.
+                                                  type: boolean
+                                                source:
+                                                  description: Backlink to the sender
+                                                    of the notification.
+                                                  type: string
+                                                tags:
+                                                  description: Comma separated list
+                                                    of tags attached to the notifications.
+                                                  type: string
+                                                updateAlerts:
+                                                  description: Whether to update message
+                                                    and description of the alert in
+                                                    OpsGenie if it already exists
+                                                    By default, the alert is never
+                                                    updated in OpsGenie, the new message
+                                                    only appears in activity log.
+                                                  type: boolean
+                                              type: object
+                                            type: array
+                                          pagerdutyConfigs:
+                                            description: List of PagerDuty configurations.
+                                            items:
+                                              description: PagerDutyConfig configures
+                                                notifications via PagerDuty. See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
+                                              properties:
+                                                class:
+                                                  description: The class/type of the
+                                                    event.
+                                                  type: string
+                                                client:
+                                                  description: Client identification.
+                                                  type: string
+                                                clientURL:
+                                                  description: Backlink to the sender
+                                                    of notification.
+                                                  type: string
+                                                component:
+                                                  description: The part or component
+                                                    of the affected system that is
+                                                    broken.
+                                                  type: string
+                                                description:
+                                                  description: Description of the
+                                                    incident.
+                                                  type: string
+                                                details:
+                                                  description: Arbitrary key/value
+                                                    pairs that provide further detail
+                                                    about the incident.
+                                                  items:
+                                                    description: KeyValue defines
+                                                      a (key, value) tuple.
+                                                    properties:
+                                                      key:
+                                                        description: Key of the tuple.
+                                                        minLength: 1
+                                                        type: string
+                                                      value:
+                                                        description: Value of the
+                                                          tuple.
+                                                        type: string
+                                                    required:
+                                                      - key
+                                                      - value
+                                                    type: object
+                                                  type: array
+                                                group:
+                                                  description: A cluster or grouping
+                                                    of sources.
+                                                  type: string
+                                                httpConfig:
+                                                  description: HTTP client configuration.
+                                                  properties:
+                                                    authorization:
+                                                      description: Authorization header
+                                                        configuration for the client.
+                                                        This is mutually exclusive
+                                                        with BasicAuth and is only
+                                                        available starting from Alertmanager
+                                                        v0.22+.
+                                                      properties:
+                                                        credentials:
+                                                          description: The secret's
+                                                            key that contains the
+                                                            credentials of the request
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type:
+                                                          description: Set the authentication
+                                                            type. Defaults to Bearer,
+                                                            Basic will cause an error
+                                                          type: string
+                                                      type: object
+                                                    basicAuth:
+                                                      description: BasicAuth for the
+                                                        client. This is mutually exclusive
+                                                        with Authorization. If both
+                                                        are defined, BasicAuth takes
+                                                        precedence.
+                                                      properties:
+                                                        password:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the password for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        username:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the username for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                    bearerTokenSecret:
+                                                      description: The secret's key
+                                                        that contains the bearer token
+                                                        to be used by the client for
+                                                        authentication. The secret
+                                                        needs to be in the same namespace
+                                                        as the AlertmanagerConfig
+                                                        object and accessible by the
+                                                        Prometheus Operator.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    followRedirects:
+                                                      description: FollowRedirects
+                                                        specifies whether the client
+                                                        should follow HTTP 3xx redirects.
+                                                      type: boolean
+                                                    oauth2:
+                                                      description: OAuth2 client credentials
+                                                        used to fetch a token for
+                                                        the targets.
+                                                      properties:
+                                                        clientId:
+                                                          description: The secret
+                                                            or configmap containing
+                                                            the OAuth2 client id
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        clientSecret:
+                                                          description: The secret
+                                                            containing the OAuth2
+                                                            client secret
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        endpointParams:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: Parameters
+                                                            to append to the token
+                                                            URL
+                                                          type: object
+                                                        scopes:
+                                                          description: OAuth2 scopes
+                                                            used for the token request
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        tokenUrl:
+                                                          description: The URL to
+                                                            fetch the token from
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                        - clientId
+                                                        - clientSecret
+                                                        - tokenUrl
+                                                      type: object
+                                                    proxyURL:
+                                                      description: Optional proxy
+                                                        URL.
+                                                      type: string
+                                                    tlsConfig:
+                                                      description: TLS configuration
+                                                        for the client.
+                                                      properties:
+                                                        ca:
+                                                          description: Certificate
+                                                            authority used when verifying
+                                                            server certificates.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        cert:
+                                                          description: Client certificate
+                                                            to present when doing
+                                                            client-authentication.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        insecureSkipVerify:
+                                                          description: Disable target
+                                                            certificate validation.
+                                                          type: boolean
+                                                        keySecret:
+                                                          description: Secret containing
+                                                            the client key file for
+                                                            the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        serverName:
+                                                          description: Used to verify
+                                                            the hostname for the targets.
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                pagerDutyImageConfigs:
+                                                  description: A list of image details
+                                                    to attach that provide further
+                                                    detail about an incident.
+                                                  items:
+                                                    description: PagerDutyImageConfig
+                                                      attaches images to an incident
+                                                    properties:
+                                                      alt:
+                                                        description: Alt is the optional
+                                                          alternative text for the
+                                                          image.
+                                                        type: string
+                                                      href:
+                                                        description: Optional URL;
+                                                          makes the image a clickable
+                                                          link.
+                                                        type: string
+                                                      src:
+                                                        description: Src of the image
+                                                          being attached to the incident
+                                                        type: string
+                                                    type: object
+                                                  type: array
+                                                pagerDutyLinkConfigs:
+                                                  description: A list of link details
+                                                    to attach that provide further
+                                                    detail about an incident.
+                                                  items:
+                                                    description: PagerDutyLinkConfig
+                                                      attaches text links to an incident
+                                                    properties:
+                                                      alt:
+                                                        description: Text that describes
+                                                          the purpose of the link,
+                                                          and can be used as the link's
+                                                          text.
+                                                        type: string
+                                                      href:
+                                                        description: Href is the URL
+                                                          of the link to be attached
+                                                        type: string
+                                                    type: object
+                                                  type: array
+                                                routingKey:
+                                                  description: The secret's key that
+                                                    contains the PagerDuty integration
+                                                    key (when using Events API v2).
+                                                    Either this field or `serviceKey`
+                                                    needs to be defined. The secret
+                                                    needs to be in the same namespace
+                                                    as the AlertmanagerConfig object
+                                                    and accessible by the Prometheus
+                                                    Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                sendResolved:
+                                                  description: Whether or not to notify
+                                                    about resolved alerts.
+                                                  type: boolean
+                                                serviceKey:
+                                                  description: The secret's key that
+                                                    contains the PagerDuty service
+                                                    key (when using integration type
+                                                    "Prometheus"). Either this field
+                                                    or `routingKey` needs to be defined.
+                                                    The secret needs to be in the
+                                                    same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus
+                                                    Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                severity:
+                                                  description: Severity of the incident.
+                                                  type: string
+                                                url:
+                                                  description: The URL to send requests
+                                                    to.
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          pushoverConfigs:
+                                            description: List of Pushover configurations.
+                                            items:
+                                              description: PushoverConfig configures
+                                                notifications via Pushover. See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
+                                              properties:
+                                                expire:
+                                                  description: How long your notification
+                                                    will continue to be retried for,
+                                                    unless the user acknowledges the
+                                                    notification.
+                                                  pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                                  type: string
+                                                html:
+                                                  description: Whether notification
+                                                    message is HTML or plain text.
+                                                  type: boolean
+                                                httpConfig:
+                                                  description: HTTP client configuration.
+                                                  properties:
+                                                    authorization:
+                                                      description: Authorization header
+                                                        configuration for the client.
+                                                        This is mutually exclusive
+                                                        with BasicAuth and is only
+                                                        available starting from Alertmanager
+                                                        v0.22+.
+                                                      properties:
+                                                        credentials:
+                                                          description: The secret's
+                                                            key that contains the
+                                                            credentials of the request
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type:
+                                                          description: Set the authentication
+                                                            type. Defaults to Bearer,
+                                                            Basic will cause an error
+                                                          type: string
+                                                      type: object
+                                                    basicAuth:
+                                                      description: BasicAuth for the
+                                                        client. This is mutually exclusive
+                                                        with Authorization. If both
+                                                        are defined, BasicAuth takes
+                                                        precedence.
+                                                      properties:
+                                                        password:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the password for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        username:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the username for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                    bearerTokenSecret:
+                                                      description: The secret's key
+                                                        that contains the bearer token
+                                                        to be used by the client for
+                                                        authentication. The secret
+                                                        needs to be in the same namespace
+                                                        as the AlertmanagerConfig
+                                                        object and accessible by the
+                                                        Prometheus Operator.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    followRedirects:
+                                                      description: FollowRedirects
+                                                        specifies whether the client
+                                                        should follow HTTP 3xx redirects.
+                                                      type: boolean
+                                                    oauth2:
+                                                      description: OAuth2 client credentials
+                                                        used to fetch a token for
+                                                        the targets.
+                                                      properties:
+                                                        clientId:
+                                                          description: The secret
+                                                            or configmap containing
+                                                            the OAuth2 client id
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        clientSecret:
+                                                          description: The secret
+                                                            containing the OAuth2
+                                                            client secret
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        endpointParams:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: Parameters
+                                                            to append to the token
+                                                            URL
+                                                          type: object
+                                                        scopes:
+                                                          description: OAuth2 scopes
+                                                            used for the token request
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        tokenUrl:
+                                                          description: The URL to
+                                                            fetch the token from
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                        - clientId
+                                                        - clientSecret
+                                                        - tokenUrl
+                                                      type: object
+                                                    proxyURL:
+                                                      description: Optional proxy
+                                                        URL.
+                                                      type: string
+                                                    tlsConfig:
+                                                      description: TLS configuration
+                                                        for the client.
+                                                      properties:
+                                                        ca:
+                                                          description: Certificate
+                                                            authority used when verifying
+                                                            server certificates.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        cert:
+                                                          description: Client certificate
+                                                            to present when doing
+                                                            client-authentication.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        insecureSkipVerify:
+                                                          description: Disable target
+                                                            certificate validation.
+                                                          type: boolean
+                                                        keySecret:
+                                                          description: Secret containing
+                                                            the client key file for
+                                                            the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        serverName:
+                                                          description: Used to verify
+                                                            the hostname for the targets.
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                message:
+                                                  description: Notification message.
+                                                  type: string
+                                                priority:
+                                                  description: Priority, see https://pushover.net/api#priority
+                                                  type: string
+                                                retry:
+                                                  description: How often the Pushover
+                                                    servers will send the same notification
+                                                    to the user. Must be at least
+                                                    30 seconds.
+                                                  pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                                  type: string
+                                                sendResolved:
+                                                  description: Whether or not to notify
+                                                    about resolved alerts.
+                                                  type: boolean
+                                                sound:
+                                                  description: The name of one of
+                                                    the sounds supported by device
+                                                    clients to override the user's
+                                                    default sound choice
+                                                  type: string
+                                                title:
+                                                  description: Notification title.
+                                                  type: string
+                                                token:
+                                                  description: The secret's key that
+                                                    contains the registered application's
+                                                    API token, see https://pushover.net/apps.
+                                                    The secret needs to be in the
+                                                    same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus
+                                                    Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                url:
+                                                  description: A supplementary URL
+                                                    shown alongside the message.
+                                                  type: string
+                                                urlTitle:
+                                                  description: A title for supplementary
+                                                    URL, otherwise just the URL is
+                                                    shown
+                                                  type: string
+                                                userKey:
+                                                  description: The secret's key that
+                                                    contains the recipient user's
+                                                    user key. The secret needs to
+                                                    be in the same namespace as the
+                                                    AlertmanagerConfig object and
+                                                    accessible by the Prometheus Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            type: array
+                                          slackConfigs:
+                                            description: List of Slack configurations.
+                                            items:
+                                              description: SlackConfig configures
+                                                notifications via Slack. See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
+                                              properties:
+                                                actions:
+                                                  description: A list of Slack actions
+                                                    that are sent with each notification.
+                                                  items:
+                                                    description: SlackAction configures
+                                                      a single Slack action that is
+                                                      sent with each notification.
+                                                      See https://api.slack.com/docs/message-attachments#action_fields
+                                                      and https://api.slack.com/docs/message-buttons
+                                                      for more information.
+                                                    properties:
+                                                      confirm:
+                                                        description: SlackConfirmationField
+                                                          protect users from destructive
+                                                          actions or particularly
+                                                          distinguished decisions
+                                                          by asking them to confirm
+                                                          their button click one more
+                                                          time. See https://api.slack.com/docs/interactive-message-field-guide#confirmation_fields
+                                                          for more information.
+                                                        properties:
+                                                          dismissText:
+                                                            type: string
+                                                          okText:
+                                                            type: string
+                                                          text:
+                                                            minLength: 1
+                                                            type: string
+                                                          title:
+                                                            type: string
+                                                        required:
+                                                          - text
+                                                        type: object
+                                                      name:
+                                                        type: string
+                                                      style:
+                                                        type: string
+                                                      text:
+                                                        minLength: 1
+                                                        type: string
+                                                      type:
+                                                        minLength: 1
+                                                        type: string
+                                                      url:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                      - text
+                                                      - type
+                                                    type: object
+                                                  type: array
+                                                apiURL:
+                                                  description: The secret's key that
+                                                    contains the Slack webhook URL.
+                                                    The secret needs to be in the
+                                                    same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus
+                                                    Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                callbackId:
+                                                  type: string
+                                                channel:
+                                                  description: The channel or user
+                                                    to send notifications to.
+                                                  type: string
+                                                color:
+                                                  type: string
+                                                fallback:
+                                                  type: string
+                                                fields:
+                                                  description: A list of Slack fields
+                                                    that are sent with each notification.
+                                                  items:
+                                                    description: SlackField configures
+                                                      a single Slack field that is
+                                                      sent with each notification.
+                                                      Each field must contain a title,
+                                                      value, and optionally, a boolean
+                                                      value to indicate if the field
+                                                      is short enough to be displayed
+                                                      next to other fields designated
+                                                      as short. See https://api.slack.com/docs/message-attachments#fields
+                                                      for more information.
+                                                    properties:
+                                                      short:
+                                                        type: boolean
+                                                      title:
+                                                        minLength: 1
+                                                        type: string
+                                                      value:
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                      - title
+                                                      - value
+                                                    type: object
+                                                  type: array
+                                                footer:
+                                                  type: string
+                                                httpConfig:
+                                                  description: HTTP client configuration.
+                                                  properties:
+                                                    authorization:
+                                                      description: Authorization header
+                                                        configuration for the client.
+                                                        This is mutually exclusive
+                                                        with BasicAuth and is only
+                                                        available starting from Alertmanager
+                                                        v0.22+.
+                                                      properties:
+                                                        credentials:
+                                                          description: The secret's
+                                                            key that contains the
+                                                            credentials of the request
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type:
+                                                          description: Set the authentication
+                                                            type. Defaults to Bearer,
+                                                            Basic will cause an error
+                                                          type: string
+                                                      type: object
+                                                    basicAuth:
+                                                      description: BasicAuth for the
+                                                        client. This is mutually exclusive
+                                                        with Authorization. If both
+                                                        are defined, BasicAuth takes
+                                                        precedence.
+                                                      properties:
+                                                        password:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the password for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        username:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the username for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                    bearerTokenSecret:
+                                                      description: The secret's key
+                                                        that contains the bearer token
+                                                        to be used by the client for
+                                                        authentication. The secret
+                                                        needs to be in the same namespace
+                                                        as the AlertmanagerConfig
+                                                        object and accessible by the
+                                                        Prometheus Operator.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    followRedirects:
+                                                      description: FollowRedirects
+                                                        specifies whether the client
+                                                        should follow HTTP 3xx redirects.
+                                                      type: boolean
+                                                    oauth2:
+                                                      description: OAuth2 client credentials
+                                                        used to fetch a token for
+                                                        the targets.
+                                                      properties:
+                                                        clientId:
+                                                          description: The secret
+                                                            or configmap containing
+                                                            the OAuth2 client id
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        clientSecret:
+                                                          description: The secret
+                                                            containing the OAuth2
+                                                            client secret
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        endpointParams:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: Parameters
+                                                            to append to the token
+                                                            URL
+                                                          type: object
+                                                        scopes:
+                                                          description: OAuth2 scopes
+                                                            used for the token request
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        tokenUrl:
+                                                          description: The URL to
+                                                            fetch the token from
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                        - clientId
+                                                        - clientSecret
+                                                        - tokenUrl
+                                                      type: object
+                                                    proxyURL:
+                                                      description: Optional proxy
+                                                        URL.
+                                                      type: string
+                                                    tlsConfig:
+                                                      description: TLS configuration
+                                                        for the client.
+                                                      properties:
+                                                        ca:
+                                                          description: Certificate
+                                                            authority used when verifying
+                                                            server certificates.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        cert:
+                                                          description: Client certificate
+                                                            to present when doing
+                                                            client-authentication.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        insecureSkipVerify:
+                                                          description: Disable target
+                                                            certificate validation.
+                                                          type: boolean
+                                                        keySecret:
+                                                          description: Secret containing
+                                                            the client key file for
+                                                            the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        serverName:
+                                                          description: Used to verify
+                                                            the hostname for the targets.
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                iconEmoji:
+                                                  type: string
+                                                iconURL:
+                                                  type: string
+                                                imageURL:
+                                                  type: string
+                                                linkNames:
+                                                  type: boolean
+                                                mrkdwnIn:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                pretext:
+                                                  type: string
+                                                sendResolved:
+                                                  description: Whether or not to notify
+                                                    about resolved alerts.
+                                                  type: boolean
+                                                shortFields:
+                                                  type: boolean
+                                                text:
+                                                  type: string
+                                                thumbURL:
+                                                  type: string
+                                                title:
+                                                  type: string
+                                                titleLink:
+                                                  type: string
+                                                username:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          snsConfigs:
+                                            description: List of SNS configurations
+                                            items:
+                                              description: SNSConfig configures notifications
+                                                via AWS SNS. See https://prometheus.io/docs/alerting/latest/configuration/#sns_configs
+                                              properties:
+                                                apiURL:
+                                                  description: The SNS API URL i.e.
+                                                    https://sns.us-east-2.amazonaws.com.
+                                                    If not specified, the SNS API
+                                                    URL from the SNS SDK will be used.
+                                                  type: string
+                                                attributes:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: SNS message attributes.
+                                                  type: object
+                                                httpConfig:
+                                                  description: HTTP client configuration.
+                                                  properties:
+                                                    authorization:
+                                                      description: Authorization header
+                                                        configuration for the client.
+                                                        This is mutually exclusive
+                                                        with BasicAuth and is only
+                                                        available starting from Alertmanager
+                                                        v0.22+.
+                                                      properties:
+                                                        credentials:
+                                                          description: The secret's
+                                                            key that contains the
+                                                            credentials of the request
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type:
+                                                          description: Set the authentication
+                                                            type. Defaults to Bearer,
+                                                            Basic will cause an error
+                                                          type: string
+                                                      type: object
+                                                    basicAuth:
+                                                      description: BasicAuth for the
+                                                        client. This is mutually exclusive
+                                                        with Authorization. If both
+                                                        are defined, BasicAuth takes
+                                                        precedence.
+                                                      properties:
+                                                        password:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the password for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        username:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the username for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                    bearerTokenSecret:
+                                                      description: The secret's key
+                                                        that contains the bearer token
+                                                        to be used by the client for
+                                                        authentication. The secret
+                                                        needs to be in the same namespace
+                                                        as the AlertmanagerConfig
+                                                        object and accessible by the
+                                                        Prometheus Operator.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    followRedirects:
+                                                      description: FollowRedirects
+                                                        specifies whether the client
+                                                        should follow HTTP 3xx redirects.
+                                                      type: boolean
+                                                    oauth2:
+                                                      description: OAuth2 client credentials
+                                                        used to fetch a token for
+                                                        the targets.
+                                                      properties:
+                                                        clientId:
+                                                          description: The secret
+                                                            or configmap containing
+                                                            the OAuth2 client id
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        clientSecret:
+                                                          description: The secret
+                                                            containing the OAuth2
+                                                            client secret
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        endpointParams:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: Parameters
+                                                            to append to the token
+                                                            URL
+                                                          type: object
+                                                        scopes:
+                                                          description: OAuth2 scopes
+                                                            used for the token request
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        tokenUrl:
+                                                          description: The URL to
+                                                            fetch the token from
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                        - clientId
+                                                        - clientSecret
+                                                        - tokenUrl
+                                                      type: object
+                                                    proxyURL:
+                                                      description: Optional proxy
+                                                        URL.
+                                                      type: string
+                                                    tlsConfig:
+                                                      description: TLS configuration
+                                                        for the client.
+                                                      properties:
+                                                        ca:
+                                                          description: Certificate
+                                                            authority used when verifying
+                                                            server certificates.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        cert:
+                                                          description: Client certificate
+                                                            to present when doing
+                                                            client-authentication.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        insecureSkipVerify:
+                                                          description: Disable target
+                                                            certificate validation.
+                                                          type: boolean
+                                                        keySecret:
+                                                          description: Secret containing
+                                                            the client key file for
+                                                            the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        serverName:
+                                                          description: Used to verify
+                                                            the hostname for the targets.
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                message:
+                                                  description: The message content
+                                                    of the SNS notification.
+                                                  type: string
+                                                phoneNumber:
+                                                  description: Phone number if message
+                                                    is delivered via SMS in E.164
+                                                    format. If you don't specify this
+                                                    value, you must specify a value
+                                                    for the TopicARN or TargetARN.
+                                                  type: string
+                                                sendResolved:
+                                                  description: Whether or not to notify
+                                                    about resolved alerts.
+                                                  type: boolean
+                                                sigv4:
+                                                  description: Configures AWS's Signature
+                                                    Verification 4 signing process
+                                                    to sign requests.
+                                                  properties:
+                                                    accessKey:
+                                                      description: AccessKey is the
+                                                        AWS API key. If blank, the
+                                                        environment variable `AWS_ACCESS_KEY_ID`
+                                                        is used.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    profile:
+                                                      description: Profile is the
+                                                        named AWS profile used to
+                                                        authenticate.
+                                                      type: string
+                                                    region:
+                                                      description: Region is the AWS
+                                                        region. If blank, the region
+                                                        from the default credentials
+                                                        chain used.
+                                                      type: string
+                                                    roleArn:
+                                                      description: RoleArn is the
+                                                        named AWS profile used to
+                                                        authenticate.
+                                                      type: string
+                                                    secretKey:
+                                                      description: SecretKey is the
+                                                        AWS API secret. If blank,
+                                                        the environment variable `AWS_SECRET_ACCESS_KEY`
+                                                        is used.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                subject:
+                                                  description: Subject line when the
+                                                    message is delivered to email
+                                                    endpoints.
+                                                  type: string
+                                                targetARN:
+                                                  description: The  mobile platform
+                                                    endpoint ARN if message is delivered
+                                                    via mobile notifications. If you
+                                                    don't specify this value, you
+                                                    must specify a value for the topic_arn
+                                                    or PhoneNumber.
+                                                  type: string
+                                                topicARN:
+                                                  description: SNS topic ARN, i.e.
+                                                    arn:aws:sns:us-east-2:698519295917:My-Topic
+                                                    If you don't specify this value,
+                                                    you must specify a value for the
+                                                    PhoneNumber or TargetARN.
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          telegramConfigs:
+                                            description: List of Telegram configurations.
+                                            items:
+                                              description: TelegramConfig configures
+                                                notifications via Telegram. See https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
+                                              properties:
+                                                apiURL:
+                                                  description: The Telegram API URL
+                                                    i.e. https://api.telegram.org.
+                                                    If not specified, default API
+                                                    URL will be used.
+                                                  type: string
+                                                botToken:
+                                                  description: Telegram bot token
+                                                    The secret needs to be in the
+                                                    same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus
+                                                    Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                chatID:
+                                                  description: The Telegram chat ID.
+                                                  format: int64
+                                                  type: integer
+                                                disableNotifications:
+                                                  description: Disable telegram notifications
+                                                  type: boolean
+                                                httpConfig:
+                                                  description: HTTP client configuration.
+                                                  properties:
+                                                    authorization:
+                                                      description: Authorization header
+                                                        configuration for the client.
+                                                        This is mutually exclusive
+                                                        with BasicAuth and is only
+                                                        available starting from Alertmanager
+                                                        v0.22+.
+                                                      properties:
+                                                        credentials:
+                                                          description: The secret's
+                                                            key that contains the
+                                                            credentials of the request
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type:
+                                                          description: Set the authentication
+                                                            type. Defaults to Bearer,
+                                                            Basic will cause an error
+                                                          type: string
+                                                      type: object
+                                                    basicAuth:
+                                                      description: BasicAuth for the
+                                                        client. This is mutually exclusive
+                                                        with Authorization. If both
+                                                        are defined, BasicAuth takes
+                                                        precedence.
+                                                      properties:
+                                                        password:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the password for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        username:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the username for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                    bearerTokenSecret:
+                                                      description: The secret's key
+                                                        that contains the bearer token
+                                                        to be used by the client for
+                                                        authentication. The secret
+                                                        needs to be in the same namespace
+                                                        as the AlertmanagerConfig
+                                                        object and accessible by the
+                                                        Prometheus Operator.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    followRedirects:
+                                                      description: FollowRedirects
+                                                        specifies whether the client
+                                                        should follow HTTP 3xx redirects.
+                                                      type: boolean
+                                                    oauth2:
+                                                      description: OAuth2 client credentials
+                                                        used to fetch a token for
+                                                        the targets.
+                                                      properties:
+                                                        clientId:
+                                                          description: The secret
+                                                            or configmap containing
+                                                            the OAuth2 client id
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        clientSecret:
+                                                          description: The secret
+                                                            containing the OAuth2
+                                                            client secret
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        endpointParams:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: Parameters
+                                                            to append to the token
+                                                            URL
+                                                          type: object
+                                                        scopes:
+                                                          description: OAuth2 scopes
+                                                            used for the token request
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        tokenUrl:
+                                                          description: The URL to
+                                                            fetch the token from
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                        - clientId
+                                                        - clientSecret
+                                                        - tokenUrl
+                                                      type: object
+                                                    proxyURL:
+                                                      description: Optional proxy
+                                                        URL.
+                                                      type: string
+                                                    tlsConfig:
+                                                      description: TLS configuration
+                                                        for the client.
+                                                      properties:
+                                                        ca:
+                                                          description: Certificate
+                                                            authority used when verifying
+                                                            server certificates.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        cert:
+                                                          description: Client certificate
+                                                            to present when doing
+                                                            client-authentication.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        insecureSkipVerify:
+                                                          description: Disable target
+                                                            certificate validation.
+                                                          type: boolean
+                                                        keySecret:
+                                                          description: Secret containing
+                                                            the client key file for
+                                                            the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        serverName:
+                                                          description: Used to verify
+                                                            the hostname for the targets.
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                message:
+                                                  description: Message template
+                                                  type: string
+                                                parseMode:
+                                                  description: Parse mode for telegram
+                                                    message
+                                                  enum:
+                                                    - MarkdownV2
+                                                    - Markdown
+                                                    - HTML
+                                                  type: string
+                                                sendResolved:
+                                                  description: Whether to notify about
+                                                    resolved alerts.
+                                                  type: boolean
+                                              type: object
+                                            type: array
+                                          victoropsConfigs:
+                                            description: List of VictorOps configurations.
+                                            items:
+                                              description: VictorOpsConfig configures
+                                                notifications via VictorOps. See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
+                                              properties:
+                                                apiKey:
+                                                  description: The secret's key that
+                                                    contains the API key to use when
+                                                    talking to the VictorOps API.
+                                                    The secret needs to be in the
+                                                    same namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus
+                                                    Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                apiUrl:
+                                                  description: The VictorOps API URL.
+                                                  type: string
+                                                customFields:
+                                                  description: Additional custom fields
+                                                    for notification.
+                                                  items:
+                                                    description: KeyValue defines
+                                                      a (key, value) tuple.
+                                                    properties:
+                                                      key:
+                                                        description: Key of the tuple.
+                                                        minLength: 1
+                                                        type: string
+                                                      value:
+                                                        description: Value of the
+                                                          tuple.
+                                                        type: string
+                                                    required:
+                                                      - key
+                                                      - value
+                                                    type: object
+                                                  type: array
+                                                entityDisplayName:
+                                                  description: Contains summary of
+                                                    the alerted problem.
+                                                  type: string
+                                                httpConfig:
+                                                  description: The HTTP client's configuration.
+                                                  properties:
+                                                    authorization:
+                                                      description: Authorization header
+                                                        configuration for the client.
+                                                        This is mutually exclusive
+                                                        with BasicAuth and is only
+                                                        available starting from Alertmanager
+                                                        v0.22+.
+                                                      properties:
+                                                        credentials:
+                                                          description: The secret's
+                                                            key that contains the
+                                                            credentials of the request
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type:
+                                                          description: Set the authentication
+                                                            type. Defaults to Bearer,
+                                                            Basic will cause an error
+                                                          type: string
+                                                      type: object
+                                                    basicAuth:
+                                                      description: BasicAuth for the
+                                                        client. This is mutually exclusive
+                                                        with Authorization. If both
+                                                        are defined, BasicAuth takes
+                                                        precedence.
+                                                      properties:
+                                                        password:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the password for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        username:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the username for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                    bearerTokenSecret:
+                                                      description: The secret's key
+                                                        that contains the bearer token
+                                                        to be used by the client for
+                                                        authentication. The secret
+                                                        needs to be in the same namespace
+                                                        as the AlertmanagerConfig
+                                                        object and accessible by the
+                                                        Prometheus Operator.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    followRedirects:
+                                                      description: FollowRedirects
+                                                        specifies whether the client
+                                                        should follow HTTP 3xx redirects.
+                                                      type: boolean
+                                                    oauth2:
+                                                      description: OAuth2 client credentials
+                                                        used to fetch a token for
+                                                        the targets.
+                                                      properties:
+                                                        clientId:
+                                                          description: The secret
+                                                            or configmap containing
+                                                            the OAuth2 client id
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        clientSecret:
+                                                          description: The secret
+                                                            containing the OAuth2
+                                                            client secret
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        endpointParams:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: Parameters
+                                                            to append to the token
+                                                            URL
+                                                          type: object
+                                                        scopes:
+                                                          description: OAuth2 scopes
+                                                            used for the token request
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        tokenUrl:
+                                                          description: The URL to
+                                                            fetch the token from
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                        - clientId
+                                                        - clientSecret
+                                                        - tokenUrl
+                                                      type: object
+                                                    proxyURL:
+                                                      description: Optional proxy
+                                                        URL.
+                                                      type: string
+                                                    tlsConfig:
+                                                      description: TLS configuration
+                                                        for the client.
+                                                      properties:
+                                                        ca:
+                                                          description: Certificate
+                                                            authority used when verifying
+                                                            server certificates.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        cert:
+                                                          description: Client certificate
+                                                            to present when doing
+                                                            client-authentication.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        insecureSkipVerify:
+                                                          description: Disable target
+                                                            certificate validation.
+                                                          type: boolean
+                                                        keySecret:
+                                                          description: Secret containing
+                                                            the client key file for
+                                                            the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        serverName:
+                                                          description: Used to verify
+                                                            the hostname for the targets.
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                messageType:
+                                                  description: Describes the behavior
+                                                    of the alert (CRITICAL, WARNING,
+                                                    INFO).
+                                                  type: string
+                                                monitoringTool:
+                                                  description: The monitoring tool
+                                                    the state message is from.
+                                                  type: string
+                                                routingKey:
+                                                  description: A key used to map the
+                                                    alert to a team.
+                                                  type: string
+                                                sendResolved:
+                                                  description: Whether or not to notify
+                                                    about resolved alerts.
+                                                  type: boolean
+                                                stateMessage:
+                                                  description: Contains long explanation
+                                                    of the alerted problem.
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          webhookConfigs:
+                                            description: List of webhook configurations.
+                                            items:
+                                              description: WebhookConfig configures
+                                                notifications via a generic receiver
+                                                supporting the webhook payload. See
+                                                https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
+                                              properties:
+                                                httpConfig:
+                                                  description: HTTP client configuration.
+                                                  properties:
+                                                    authorization:
+                                                      description: Authorization header
+                                                        configuration for the client.
+                                                        This is mutually exclusive
+                                                        with BasicAuth and is only
+                                                        available starting from Alertmanager
+                                                        v0.22+.
+                                                      properties:
+                                                        credentials:
+                                                          description: The secret's
+                                                            key that contains the
+                                                            credentials of the request
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type:
+                                                          description: Set the authentication
+                                                            type. Defaults to Bearer,
+                                                            Basic will cause an error
+                                                          type: string
+                                                      type: object
+                                                    basicAuth:
+                                                      description: BasicAuth for the
+                                                        client. This is mutually exclusive
+                                                        with Authorization. If both
+                                                        are defined, BasicAuth takes
+                                                        precedence.
+                                                      properties:
+                                                        password:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the password for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        username:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the username for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                    bearerTokenSecret:
+                                                      description: The secret's key
+                                                        that contains the bearer token
+                                                        to be used by the client for
+                                                        authentication. The secret
+                                                        needs to be in the same namespace
+                                                        as the AlertmanagerConfig
+                                                        object and accessible by the
+                                                        Prometheus Operator.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    followRedirects:
+                                                      description: FollowRedirects
+                                                        specifies whether the client
+                                                        should follow HTTP 3xx redirects.
+                                                      type: boolean
+                                                    oauth2:
+                                                      description: OAuth2 client credentials
+                                                        used to fetch a token for
+                                                        the targets.
+                                                      properties:
+                                                        clientId:
+                                                          description: The secret
+                                                            or configmap containing
+                                                            the OAuth2 client id
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        clientSecret:
+                                                          description: The secret
+                                                            containing the OAuth2
+                                                            client secret
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        endpointParams:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: Parameters
+                                                            to append to the token
+                                                            URL
+                                                          type: object
+                                                        scopes:
+                                                          description: OAuth2 scopes
+                                                            used for the token request
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        tokenUrl:
+                                                          description: The URL to
+                                                            fetch the token from
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                        - clientId
+                                                        - clientSecret
+                                                        - tokenUrl
+                                                      type: object
+                                                    proxyURL:
+                                                      description: Optional proxy
+                                                        URL.
+                                                      type: string
+                                                    tlsConfig:
+                                                      description: TLS configuration
+                                                        for the client.
+                                                      properties:
+                                                        ca:
+                                                          description: Certificate
+                                                            authority used when verifying
+                                                            server certificates.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        cert:
+                                                          description: Client certificate
+                                                            to present when doing
+                                                            client-authentication.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        insecureSkipVerify:
+                                                          description: Disable target
+                                                            certificate validation.
+                                                          type: boolean
+                                                        keySecret:
+                                                          description: Secret containing
+                                                            the client key file for
+                                                            the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        serverName:
+                                                          description: Used to verify
+                                                            the hostname for the targets.
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                maxAlerts:
+                                                  description: Maximum number of alerts
+                                                    to be sent per webhook message.
+                                                    When 0, all alerts are included.
+                                                  format: int32
+                                                  minimum: 0
+                                                  type: integer
+                                                sendResolved:
+                                                  description: Whether or not to notify
+                                                    about resolved alerts.
+                                                  type: boolean
+                                                url:
+                                                  description: The URL to send HTTP
+                                                    POST requests to. `urlSecret`
+                                                    takes precedence over `url`. One
+                                                    of `urlSecret` and `url` should
+                                                    be defined.
+                                                  type: string
+                                                urlSecret:
+                                                  description: The secret's key that
+                                                    contains the webhook URL to send
+                                                    HTTP requests to. `urlSecret`
+                                                    takes precedence over `url`. One
+                                                    of `urlSecret` and `url` should
+                                                    be defined. The secret needs to
+                                                    be in the same namespace as the
+                                                    AlertmanagerConfig object and
+                                                    accessible by the Prometheus Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            type: array
+                                          wechatConfigs:
+                                            description: List of WeChat configurations.
+                                            items:
+                                              description: WeChatConfig configures
+                                                notifications via WeChat. See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
+                                              properties:
+                                                agentID:
+                                                  type: string
+                                                apiSecret:
+                                                  description: The secret's key that
+                                                    contains the WeChat API key. The
+                                                    secret needs to be in the same
+                                                    namespace as the AlertmanagerConfig
+                                                    object and accessible by the Prometheus
+                                                    Operator.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                apiURL:
+                                                  description: The WeChat API URL.
+                                                  type: string
+                                                corpID:
+                                                  description: The corp id for authentication.
+                                                  type: string
+                                                httpConfig:
+                                                  description: HTTP client configuration.
+                                                  properties:
+                                                    authorization:
+                                                      description: Authorization header
+                                                        configuration for the client.
+                                                        This is mutually exclusive
+                                                        with BasicAuth and is only
+                                                        available starting from Alertmanager
+                                                        v0.22+.
+                                                      properties:
+                                                        credentials:
+                                                          description: The secret's
+                                                            key that contains the
+                                                            credentials of the request
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type:
+                                                          description: Set the authentication
+                                                            type. Defaults to Bearer,
+                                                            Basic will cause an error
+                                                          type: string
+                                                      type: object
+                                                    basicAuth:
+                                                      description: BasicAuth for the
+                                                        client. This is mutually exclusive
+                                                        with Authorization. If both
+                                                        are defined, BasicAuth takes
+                                                        precedence.
+                                                      properties:
+                                                        password:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the password for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        username:
+                                                          description: The secret
+                                                            in the service monitor
+                                                            namespace that contains
+                                                            the username for authentication.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                    bearerTokenSecret:
+                                                      description: The secret's key
+                                                        that contains the bearer token
+                                                        to be used by the client for
+                                                        authentication. The secret
+                                                        needs to be in the same namespace
+                                                        as the AlertmanagerConfig
+                                                        object and accessible by the
+                                                        Prometheus Operator.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: 'Name of the
+                                                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful
+                                                            fields. apiVersion, kind,
+                                                            uid?'
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    followRedirects:
+                                                      description: FollowRedirects
+                                                        specifies whether the client
+                                                        should follow HTTP 3xx redirects.
+                                                      type: boolean
+                                                    oauth2:
+                                                      description: OAuth2 client credentials
+                                                        used to fetch a token for
+                                                        the targets.
+                                                      properties:
+                                                        clientId:
+                                                          description: The secret
+                                                            or configmap containing
+                                                            the OAuth2 client id
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        clientSecret:
+                                                          description: The secret
+                                                            containing the OAuth2
+                                                            client secret
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        endpointParams:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: Parameters
+                                                            to append to the token
+                                                            URL
+                                                          type: object
+                                                        scopes:
+                                                          description: OAuth2 scopes
+                                                            used for the token request
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        tokenUrl:
+                                                          description: The URL to
+                                                            fetch the token from
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                        - clientId
+                                                        - clientSecret
+                                                        - tokenUrl
+                                                      type: object
+                                                    proxyURL:
+                                                      description: Optional proxy
+                                                        URL.
+                                                      type: string
+                                                    tlsConfig:
+                                                      description: TLS configuration
+                                                        for the client.
+                                                      properties:
+                                                        ca:
+                                                          description: Certificate
+                                                            authority used when verifying
+                                                            server certificates.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        cert:
+                                                          description: Client certificate
+                                                            to present when doing
+                                                            client-authentication.
+                                                          properties:
+                                                            configMap:
+                                                              description: ConfigMap
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key to select.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the ConfigMap
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            secret:
+                                                              description: Secret
+                                                                containing data to
+                                                                use for the targets.
+                                                              properties:
+                                                                key:
+                                                                  description: The
+                                                                    key of the secret
+                                                                    to select from.  Must
+                                                                    be a valid secret
+                                                                    key.
+                                                                  type: string
+                                                                name:
+                                                                  description: 'Name
+                                                                    of the referent.
+                                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    TODO: Add other
+                                                                    useful fields.
+                                                                    apiVersion, kind,
+                                                                    uid?'
+                                                                  type: string
+                                                                optional:
+                                                                  description: Specify
+                                                                    whether the Secret
+                                                                    or its key must
+                                                                    be defined
+                                                                  type: boolean
+                                                              required:
+                                                                - key
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          type: object
+                                                        insecureSkipVerify:
+                                                          description: Disable target
+                                                            certificate validation.
+                                                          type: boolean
+                                                        keySecret:
+                                                          description: Secret containing
+                                                            the client key file for
+                                                            the targets.
+                                                          properties:
+                                                            key:
+                                                              description: The key
+                                                                of the secret to select
+                                                                from.  Must be a valid
+                                                                secret key.
+                                                              type: string
+                                                            name:
+                                                              description: 'Name of
+                                                                the referent. More
+                                                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                TODO: Add other useful
+                                                                fields. apiVersion,
+                                                                kind, uid?'
+                                                              type: string
+                                                            optional:
+                                                              description: Specify
+                                                                whether the Secret
+                                                                or its key must be
+                                                                defined
+                                                              type: boolean
+                                                          required:
+                                                            - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        serverName:
+                                                          description: Used to verify
+                                                            the hostname for the targets.
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                message:
+                                                  description: API request data as
+                                                    defined by the WeChat API.
+                                                  type: string
+                                                messageType:
+                                                  type: string
+                                                sendResolved:
+                                                  description: Whether or not to notify
+                                                    about resolved alerts.
+                                                  type: boolean
+                                                toParty:
+                                                  type: string
+                                                toTag:
+                                                  type: string
+                                                toUser:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        required:
+                                          - name
+                                        type: object
+                                      type: array
+                                    route:
+                                      description: The Alertmanager route definition
+                                        for alerts matching the resource's namespace.
+                                        If present, it will be added to the generated
+                                        Alertmanager configuration as a first-level
+                                        route.
+                                      properties:
+                                        activeTimeIntervals:
+                                          description: ActiveTimeIntervals is a list
+                                            of MuteTimeInterval names when this route
+                                            should be active.
+                                          items:
+                                            type: string
+                                          type: array
+                                        continue:
+                                          description: Boolean indicating whether
+                                            an alert should continue matching subsequent
+                                            sibling nodes. It will always be overridden
+                                            to true for the first-level route by the
+                                            Prometheus operator.
+                                          type: boolean
+                                        groupBy:
+                                          description: List of labels to group by.
+                                            Labels must not be repeated (unique list).
+                                            Special label "..." (aggregate by all
+                                            possible labels), if provided, must be
+                                            the only element in the list.
+                                          items:
+                                            type: string
+                                          type: array
+                                        groupInterval:
+                                          description: 'How long to wait before sending
+                                            an updated notification. Must match the
+                                            regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                            Example: "5m"'
+                                          type: string
+                                        groupWait:
+                                          description: 'How long to wait before sending
+                                            the initial notification. Must match the
+                                            regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                            Example: "30s"'
+                                          type: string
+                                        matchers:
+                                          description: 'List of matchers that the
+                                            alert''s labels should match. For the
+                                            first level route, the operator removes
+                                            any existing equality and regexp matcher
+                                            on the `namespace` label and adds a `namespace:
+                                            <object namespace>` matcher.'
+                                          items:
+                                            description: Matcher defines how to match
+                                              on alert's labels.
+                                            properties:
+                                              matchType:
+                                                description: Match operation available
+                                                  with AlertManager >= v0.22.0 and
+                                                  takes precedence over Regex (deprecated)
+                                                  if non-empty.
+                                                enum:
+                                                  - '!='
+                                                  - '='
+                                                  - =~
+                                                  - '!~'
+                                                type: string
+                                              name:
+                                                description: Label to match.
+                                                minLength: 1
+                                                type: string
+                                              regex:
+                                                description: Whether to match on equality
+                                                  (false) or regular-expression (true).
+                                                  Deprecated as of AlertManager >=
+                                                  v0.22.0 where a user should use
+                                                  MatchType instead.
+                                                type: boolean
+                                              value:
+                                                description: Label value to match.
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                          type: array
+                                        muteTimeIntervals:
+                                          description: 'Note: this comment applies
+                                            to the field definition above but appears
+                                            below otherwise it gets included in the
+                                            generated manifest. CRD schema doesn''t
+                                            support self-referential types for now
+                                            (see https://github.com/kubernetes/kubernetes/issues/62872).
+                                            We have to use an alternative type to
+                                            circumvent the limitation. The downside
+                                            is that the Kube API can''t validate the
+                                            data beyond the fact that it is a valid
+                                            JSON representation. MuteTimeIntervals
+                                            is a list of MuteTimeInterval names that
+                                            will mute this route when matched,'
+                                          items:
+                                            type: string
+                                          type: array
+                                        receiver:
+                                          description: Name of the receiver for this
+                                            route. If not empty, it should be listed
+                                            in the `receivers` field.
+                                          type: string
+                                        repeatInterval:
+                                          description: 'How long to wait before repeating
+                                            the last notification. Must match the
+                                            regular expression`^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$`
+                                            Example: "4h"'
+                                          type: string
+                                        routes:
+                                          description: Child routes.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                      type: object
+                                  type: object
+                                email:
+                                  description: Email necessary to send alerts via
+                                    email
+                                  type: string
+                              type: object
+                            network:
+                              description: Network contains any network related settings.
+                              properties:
+                                ipFilter:
+                                  default:
+                                    - 0.0.0.0/0
+                                  description: IPFilter is a list of allowed IPv4
+                                    CIDR ranges that can access the service. If no
+                                    IP Filter is set, you may not be able to reach
+                                    the service. A value of `0.0.0.0/0` will open
+                                    the service to all addresses on the public internet.
+                                  items:
+                                    type: string
+                                  type: array
+                                serviceType:
+                                  default: ClusterIP
+                                  description: 'ServiceType defines the type of the
+                                    service. Possible enum values: - `"ClusterIP"`
+                                    indicates that the service is only reachable from
+                                    within the cluster. - `"LoadBalancer"` indicates
+                                    that the service is reachable from the public
+                                    internet via dedicated Ipv4 address.'
+                                  enum:
+                                    - ClusterIP
+                                    - LoadBalancer
+                                  type: string
+                              type: object
+                            replication:
+                              description: "This section allows to configure Postgres\
+                                \ replication mode and HA roles groups. \n The main\
+                                \ replication group is implicit and contains the total\
+                                \ number of instances less the sum of all instances\
+                                \ in other replication groups."
+                              properties:
+                                mode:
+                                  description: "Mode defines the replication mode\
+                                    \ applied to the whole cluster. Possible values\
+                                    \ are: \"async\"(default), \"sync\", and \"strict-sync\"\
+                                    \ \n \"async\": When in asynchronous mode the\
+                                    \ cluster is allowed to lose some committed transactions.\
+                                    \ When the primary server fails or becomes unavailable\
+                                    \ for any other reason a sufficiently healthy\
+                                    \ standby will automatically be promoted to primary.\
+                                    \ Any transactions that have not been replicated\
+                                    \ to that standby remain in a \u201Cforked timeline\u201D\
+                                    \ on the primary, and are effectively unrecoverable\
+                                    \ \n \"sync\": When in synchronous mode a standby\
+                                    \ will not be promoted unless it is certain that\
+                                    \ the standby contains all transactions that may\
+                                    \ have returned a successful commit status to\
+                                    \ client. This means that the system may be unavailable\
+                                    \ for writes even though some servers are available.\
+                                    \ \n \"strict-sync\": When it is absolutely necessary\
+                                    \ to guarantee that each write is stored durably\
+                                    \ on at least two nodes, use the strict synchronous\
+                                    \ mode. This mode prevents synchronous replication\
+                                    \ to be switched off on the primary when no synchronous\
+                                    \ standby candidates are available. As a downside,\
+                                    \ the primary will not be available for writes,\
+                                    \ blocking all client write requests until at\
+                                    \ least one synchronous replica comes up. \n NOTE:\
+                                    \ We recommend to always use three intances when\
+                                    \ setting the mode to \"strict-sync\"."
+                                  enum:
+                                    - async
+                                    - sync
+                                    - strict-sync
+                                  type: string
+                              type: object
+                            restore:
+                              description: Restore contains settings to control the
+                                restore of an instance.
+                              properties:
+                                backupName:
+                                  description: BackupName is the name of the specific
+                                    backup you want to restore.
+                                  type: string
+                                claimName:
+                                  description: ClaimName specifies the name of the
+                                    instance you want to restore from. The claim has
+                                    to be in the same namespace as this new instance.
+                                  type: string
+                                recoveryTimeStamp:
+                                  description: RecoveryTimeStamp an ISO 8601 date,
+                                    that holds UTC date indicating at which point-in-time
+                                    the database has to be restored. This is optional
+                                    and if no PIT recovery is required, it can be
+                                    left empty.
+                                  pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$
+                                  type: string
+                              type: object
+                            scheduling:
+                              description: Scheduling contains settings to control
+                                the scheduling of an instance.
+                              properties:
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  description: "NodeSelector is a selector which must\
+                                    \ match a node\u2019s labels for the pod to be\
+                                    \ scheduled on that node"
+                                  type: object
+                              type: object
+                            service:
+                              description: Service contains PostgreSQL DBaaS specific
+                                properties
+                              properties:
+                                extensions:
+                                  description: Extensions allow to enable/disable
+                                    any of the supported
+                                  items:
+                                    description: VSHNDBaaSPostgresExtension contains
+                                      the name of a single extension.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the extension
+                                          to enable. For an extensive list, please
+                                          consult https://stackgres.io/doc/latest/intro/extensions/
+                                        type: string
+                                    type: object
+                                  type: array
+                                majorVersion:
+                                  default: '15'
+                                  description: MajorVersion contains supported version
+                                    of PostgreSQL. Multiple versions are supported.
+                                    The latest version "15" is the default version.
+                                  enum:
+                                    - '12'
+                                    - '13'
+                                    - '14'
+                                    - '15'
+                                  type: string
+                                pgBouncerSettings:
+                                  description: PgBouncerSettings passes additional
+                                    configuration to the pgBouncer instance.
+                                  properties:
+                                    databases:
+                                      description: "The `pgbouncer.ini` (Section [databases])\
+                                        \ parameters the configuration contains, represented\
+                                        \ as an object where the keys are valid names\
+                                        \ for the `pgbouncer.ini` configuration file\
+                                        \ parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases)\
+                                        \ for more information about supported parameters."
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    pgbouncer:
+                                      description: "The `pgbouncer.ini` (Section [pgbouncer])\
+                                        \ parameters the configuration contains, represented\
+                                        \ as an object where the keys are valid names\
+                                        \ for the `pgbouncer.ini` configuration file\
+                                        \ parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings)\
+                                        \ for more information about supported parameters"
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    users:
+                                      description: "The `pgbouncer.ini` (Section [users])\
+                                        \ parameters the configuration contains, represented\
+                                        \ as an object where the keys are valid names\
+                                        \ for the `pgbouncer.ini` configuration file\
+                                        \ parameters. \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users)\
+                                        \ for more information about supported parameters."
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                pgSettings:
+                                  description: PGSettings contains additional PostgreSQL
+                                    settings.
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                serviceLevel:
+                                  default: besteffort
+                                  description: ServiceLevel defines the service level
+                                    of this service. Either Best Effort or Guaranteed
+                                    Availability is allowed.
+                                  enum:
+                                    - besteffort
+                                    - guaranteed
+                                  type: string
+                              type: object
+                            size:
+                              description: Size contains settings to control the sizing
+                                of a service.
+                              properties:
+                                cpu:
+                                  description: CPU defines the amount of Kubernetes
+                                    CPUs for an instance.
+                                  type: string
+                                disk:
+                                  description: Disk defines the amount of disk space
+                                    for an instance.
+                                  type: string
+                                memory:
+                                  description: Memory defines the amount of memory
+                                    in units of bytes for an instance.
+                                  type: string
+                                plan:
+                                  description: Plan is the name of the resource plan
+                                    that defines the compute resources.
+                                  type: string
+                                requests:
+                                  description: Requests defines CPU and memory requests
+                                    for an instance
+                                  properties:
+                                    cpu:
+                                      description: CPU defines the amount of Kubernetes
+                                        CPUs for an instance.
+                                      type: string
+                                    memory:
+                                      description: Memory defines the amount of memory
+                                        in units of bytes for an instance.
+                                      type: string
+                                  type: object
+                              type: object
+                            updateStrategy:
+                              description: UpdateStrategy indicates when updates to
+                                the instance spec will be applied.
+                              properties:
+                                type:
+                                  default: Immediate
+                                  description: 'Type indicates the type of the UpdateStrategy.
+                                    Default is OnRestart. Possible enum values: -
+                                    `"OnRestart"` indicates that the changes to the
+                                    spec will only be applied once the instance is
+                                    restarted by other means, most likely during maintenance.
+                                    - `"Immediate"` indicates that update will be
+                                    applied to the instance as soon as the spec changes.
+                                    Please be aware that this might lead to short
+                                    downtime.'
+                                  enum:
+                                    - Immediate
+                                    - OnRestart
+                                  type: string
+                              type: object
+                          type: object
+                        relativePath:
+                          default: /
+                          description: RelativePath on which Keycloak will listen.
+                          type: string
+                        serviceLevel:
+                          default: besteffort
+                          description: ServiceLevel defines the service level of this
+                            service. Either Best Effort or Guaranteed Availability
+                            is allowed.
+                          enum:
+                            - besteffort
+                            - guaranteed
+                          type: string
+                        version:
+                          default: '23'
+                          description: Version contains supported version of keycloak.
+                            Multiple versions are supported. The latest version 22
+                            is the default version.
+                          enum:
+                            - '23'
+                          type: string
+                      type: object
+                    size:
+                      default: {}
+                      description: Size contains settings to control the sizing of
+                        a service.
+                      properties:
+                        cpu:
+                          description: CPU defines the amount of Kubernetes CPUs for
+                            an instance.
+                          type: string
+                        disk:
+                          description: Disk defines the amount of disk space for an
+                            instance.
+                          type: string
+                        memory:
+                          description: Memory defines the amount of memory in units
+                            of bytes for an instance.
+                          type: string
+                        plan:
+                          default: standard-2
+                          description: |
+                            Plan is the name of the resource plan that defines the compute resources.
+
+                            The following plans are available:
+
+                              standard-2 - CPU: 500m; Memory: 2Gi; Disk: 16Gi
+
+                              standard-4 - CPU: 1; Memory: 4Gi; Disk: 16Gi
+
+                              standard-8 - CPU: 2; Memory: 8Gi; Disk: 16Gi
+                          enum:
+                            - standard-2
+                            - standard-4
+                            - standard-8
+                          type: string
+                        requests:
+                          description: Requests defines CPU and memory requests for
+                            an instance
+                          properties:
+                            cpu:
+                              description: CPU defines the amount of Kubernetes CPUs
+                                for an instance.
+                              type: string
+                            memory:
+                              description: Memory defines the amount of memory in
+                                units of bytes for an instance.
+                              type: string
+                          type: object
+                      type: object
+                    tls:
+                      default: {}
+                      description: TLS contains settings to control tls traffic of
+                        a service.
+                      properties:
+                        authClients:
+                          default: true
+                          description: TLSAuthClients enables client authentication
+                            requirement
+                          type: boolean
+                        enabled:
+                          default: true
+                          description: TLSEnabled enables TLS traffic for the service
+                          type: boolean
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: Status reflects the observed state of a VSHNKeycloak.
+              properties:
+                caCertificateConditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about the transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if
+                          .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: Reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition.
+                        maxLength: 1024
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        enum:
+                          - 'True'
+                          - 'False'
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of condition.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    type: object
+                  type: array
+                clientCertificateConditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about the transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if
+                          .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: Reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition.
+                        maxLength: 1024
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        enum:
+                          - 'True'
+                          - 'False'
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of condition.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    type: object
+                  type: array
+                instanceNamespace:
+                  description: InstanceNamespace contains the name of the namespace
+                    where the instance resides
+                  type: string
+                localCAConditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about the transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if
+                          .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: Reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition.
+                        maxLength: 1024
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        enum:
+                          - 'True'
+                          - 'False'
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of condition.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    type: object
+                  type: array
+                namespaceConditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about the transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if
+                          .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: Reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition.
+                        maxLength: 1024
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        enum:
+                          - 'True'
+                          - 'False'
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of condition.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    type: object
+                  type: array
+                schedules:
+                  description: Schedules keeps track of random generated schedules,
+                    is overwriten by schedules set in the service's spec.
+                  properties:
+                    backup:
+                      description: Backup keeps track of the backup schedule.
+                      type: string
+                    maintenance:
+                      description: Maintenance keeps track of the maintenance schedule.
+                      properties:
+                        dayOfWeek:
+                          description: DayOfWeek specifies at which weekday the maintenance
+                            is held place. Allowed values are [monday, tuesday, wednesday,
+                            thursday, friday, saturday, sunday]
+                          enum:
+                            - monday
+                            - tuesday
+                            - wednesday
+                            - thursday
+                            - friday
+                            - saturday
+                            - sunday
+                          type: string
+                        timeOfDay:
+                          description: 'TimeOfDay for installing updates in UTC. Format:
+                            "hh:mm:ss".'
+                          pattern: ^([0-1]?[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$
+                          type: string
+                      type: object
+                  type: object
+                selfSignedIssuerConditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about the transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if
+                          .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: Reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition.
+                        maxLength: 1024
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        enum:
+                          - 'True'
+                          - 'False'
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of condition.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    type: object
+                  type: array
+                serverCertificateConditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about the transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if
+                          .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: Reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition.
+                        maxLength: 1024
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        enum:
+                          - 'True'
+                          - 'False'
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of condition.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          required:
+            - spec
+          type: object
+      served: true

--- a/component/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -5156,6 +5156,38 @@ spec:
                             - '14'
                             - '15'
                           type: string
+                        pgBouncerSettings:
+                          description: PgBouncerSettings passes additional configuration
+                            to the pgBouncer instance.
+                          properties:
+                            databases:
+                              description: "The `pgbouncer.ini` (Section [databases])\
+                                \ parameters the configuration contains, represented\
+                                \ as an object where the keys are valid names for\
+                                \ the `pgbouncer.ini` configuration file parameters.\
+                                \ \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-databases)\
+                                \ for more information about supported parameters."
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            pgbouncer:
+                              description: "The `pgbouncer.ini` (Section [pgbouncer])\
+                                \ parameters the configuration contains, represented\
+                                \ as an object where the keys are valid names for\
+                                \ the `pgbouncer.ini` configuration file parameters.\
+                                \ \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#generic-settings)\
+                                \ for more information about supported parameters"
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            users:
+                              description: "The `pgbouncer.ini` (Section [users])\
+                                \ parameters the configuration contains, represented\
+                                \ as an object where the keys are valid names for\
+                                \ the `pgbouncer.ini` configuration file parameters.\
+                                \ \n Check [pgbouncer configuration](https://www.pgbouncer.org/config.html#section-users)\
+                                \ for more information about supported parameters."
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
                         pgSettings:
                           description: PGSettings contains additional PostgreSQL settings.
                           type: object

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '10'
+    metadata.appcat.vshn.io/description: keycloak instances by VSHN
+    metadata.appcat.vshn.io/displayname: keycloak by VSHN
+    metadata.appcat.vshn.io/end-user-docs-url: https://vs.hn/vshn-keycloak
+    metadata.appcat.vshn.io/flavor: standalone
+    metadata.appcat.vshn.io/plans: '{"standard-2":{"size":{"cpu":"500m","disk":"16Gi","enabled":true,"memory":"2Gi"}},"standard-4":{"size":{"cpu":"1","disk":"16Gi","enabled":true,"memory":"4Gi"}},"standard-8":{"size":{"cpu":"2","disk":"16Gi","enabled":true,"memory":"8Gi"}}}'
+    metadata.appcat.vshn.io/product-description: https://products.docs.vshn.ch/products/appcat/keycloak.html
+    metadata.appcat.vshn.io/zone: rma1
+  labels:
+    metadata.appcat.vshn.io/offered: 'true'
+    metadata.appcat.vshn.io/serviceID: vshn-keycloak
+    name: vshnkeycloak.vshn.appcat.vshn.io
+  name: vshnkeycloak.vshn.appcat.vshn.io
+spec:
+  compositeTypeRef:
+    apiVersion: vshn.appcat.vshn.io/v1
+    kind: XVSHNKeycloak
+  mode: Pipeline
+  pipeline:
+    - functionRef:
+        name: function-appcat
+      input:
+        apiVersion: v1
+        data:
+          bucketRegion: lpg
+          chartRepository: https://charts.bitnami.com/bitnami
+          chartVersion: 18.3.0
+          controlNamespace: syn-appcat-control
+          imageTag: v4.53.0
+          isOpenshift: 'false'
+          maintenanceSA: helm-based-service-maintenance
+          plans: '{"standard-2": {"size": {"cpu": "500m", "disk": "16Gi", "enabled":
+            true, "memory": "2Gi"}}, "standard-4": {"size": {"cpu": "1", "disk": "16Gi",
+            "enabled": true, "memory": "4Gi"}}, "standard-8": {"size": {"cpu": "2",
+            "disk": "16Gi", "enabled": true, "memory": "8Gi"}}}'
+          quotasEnabled: 'false'
+          restoreSA: mariadbrestoreserviceaccount
+          serviceName: keycloak
+        kind: ConfigMap
+        metadata:
+          labels:
+            name: xfn-config
+          name: xfn-config
+      step: keycloak-func
+  writeConnectionSecretsToNamespace: syn-crossplane

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -31,7 +31,7 @@ spec:
           chartRepository: https://charts.bitnami.com/bitnami
           chartVersion: 10.1.3
           controlNamespace: syn-appcat-control
-          imageTag: v4.52.0
+          imageTag: v4.53.0
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           plans: '{"standard-1": {"size": {"cpu": "250m", "disk": "16Gi", "enabled":

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -52,7 +52,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.localCAConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -60,10 +60,10 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -111,7 +111,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.certificateConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -119,13 +119,13 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.issuerRef.name
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -133,6 +133,24 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s.vshn-postgresql-%s.svc.cluster.local'
+                  variables:
+                    - fromFieldPath: metadata.name
+                    - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.spec.dnsNames[0]
+                type: CombineFromComposite
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s.vshn-postgresql-%s.svc'
+                  variables:
+                    - fromFieldPath: metadata.name
+                    - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.spec.dnsNames[1]
+                type: CombineFromComposite
           - base:
               apiVersion: kubernetes.crossplane.io/v1alpha1
               kind: Object
@@ -244,7 +262,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.profileConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -252,7 +270,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -260,7 +278,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 type: FromCompositeFieldPath
               - fromFieldPath: spec.parameters.size.plan
@@ -315,7 +333,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.pgconfigConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -323,7 +341,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -331,7 +349,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 type: FromCompositeFieldPath
               - fromFieldPath: spec.parameters.service.majorVersion
@@ -385,7 +403,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.pgclusterConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -393,7 +411,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -401,7 +419,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 type: FromCompositeFieldPath
               - fromFieldPath: spec.parameters.size.plan
@@ -435,13 +453,13 @@ spec:
               - fromFieldPath: spec.parameters.service.majorVersion
                 toFieldPath: spec.forProvider.manifest.spec.postgres.version
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.sgInstanceProfile
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.configurations.sgPostgresConfig
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.configurations.backups[0].sgObjectStorage
                 transforms:
                   - string:
@@ -468,13 +486,13 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.objectBackupConfigConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.parameters.bucketName
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.writeConnectionSecretToRef.namespace
                 transforms:
                   - string:
@@ -482,7 +500,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.writeConnectionSecretToRef.name
                 transforms:
                   - string:
@@ -524,7 +542,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.objectBucketConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -532,7 +550,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 transforms:
                   - string:
@@ -540,7 +558,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -548,10 +566,10 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.s3Compatible.bucket
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.s3Compatible.awsCredentials.secretKeySelectors.accessKeyId.name
                 transforms:
                   - string:
@@ -559,7 +577,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.s3Compatible.awsCredentials.secretKeySelectors.secretAccessKey.name
                 transforms:
                   - string:
@@ -593,7 +611,7 @@ spec:
                   name: kubernetes
             name: podmonitor
             patches:
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -601,7 +619,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -609,10 +627,10 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.selector.matchLabels[stackgres.io/cluster-name]
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.namespaceSelector.matchNames[0]
                 transforms:
                   - string:
@@ -762,7 +780,7 @@ spec:
                   name: kubernetes
             name: prometheusrule
             patches:
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -770,7 +788,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -807,7 +825,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.networkPolicyConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -815,7 +833,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -823,7 +841,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 transforms:
                   - string:
@@ -847,7 +865,8 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.52.0
+          imageTag: v4.53.0
+          proxyEndpoint: host.docker.internal:9443
           quotasEnabled: 'false'
           serviceName: postgresql
           sgNamespace: stackgres

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -52,7 +52,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.localCAConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -60,10 +60,10 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -111,7 +111,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.certificateConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -119,13 +119,13 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.issuerRef.name
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -133,6 +133,24 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s.vshn-postgresql-%s.svc.cluster.local'
+                  variables:
+                    - fromFieldPath: metadata.name
+                    - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.spec.dnsNames[0]
+                type: CombineFromComposite
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s.vshn-postgresql-%s.svc'
+                  variables:
+                    - fromFieldPath: metadata.name
+                    - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.spec.dnsNames[1]
+                type: CombineFromComposite
           - base:
               apiVersion: kubernetes.crossplane.io/v1alpha1
               kind: Object
@@ -181,7 +199,7 @@ spec:
                   name: kubernetes
             name: copy-job
             patches:
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -189,7 +207,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 transforms:
                   - string:
@@ -206,7 +224,7 @@ spec:
               - fromFieldPath: spec.parameters.restore.backupName
                 toFieldPath: spec.forProvider.manifest.spec.template.spec.containers[0].env[2].value
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.template.spec.containers[0].env[3].value
                 transforms:
                   - string:
@@ -325,7 +343,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.profileConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -333,7 +351,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -341,7 +359,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 type: FromCompositeFieldPath
               - fromFieldPath: spec.parameters.size.plan
@@ -396,7 +414,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.pgconfigConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -404,7 +422,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -412,7 +430,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 type: FromCompositeFieldPath
               - fromFieldPath: spec.parameters.service.majorVersion
@@ -470,7 +488,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.pgclusterConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -478,7 +496,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -486,7 +504,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 type: FromCompositeFieldPath
               - fromFieldPath: spec.parameters.size.plan
@@ -520,13 +538,13 @@ spec:
               - fromFieldPath: spec.parameters.service.majorVersion
                 toFieldPath: spec.forProvider.manifest.spec.postgres.version
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.sgInstanceProfile
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.configurations.sgPostgresConfig
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.configurations.backups[0].sgObjectStorage
                 transforms:
                   - string:
@@ -543,7 +561,7 @@ spec:
               - fromFieldPath: spec.parameters.restore.recoveryTimeStamp
                 toFieldPath: spec.forProvider.manifest.spec.initialData.restore.fromBackup.pointInTimeRecovery.restoreToTimestamp
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.references[0].dependsOn.namespace
                 transforms:
                   - string:
@@ -570,13 +588,13 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.objectBackupConfigConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.parameters.bucketName
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.writeConnectionSecretToRef.namespace
                 transforms:
                   - string:
@@ -584,7 +602,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.writeConnectionSecretToRef.name
                 transforms:
                   - string:
@@ -626,7 +644,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.objectBucketConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -634,7 +652,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 transforms:
                   - string:
@@ -642,7 +660,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -650,10 +668,10 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.s3Compatible.bucket
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.s3Compatible.awsCredentials.secretKeySelectors.accessKeyId.name
                 transforms:
                   - string:
@@ -661,7 +679,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.s3Compatible.awsCredentials.secretKeySelectors.secretAccessKey.name
                 transforms:
                   - string:
@@ -695,7 +713,7 @@ spec:
                   name: kubernetes
             name: podmonitor
             patches:
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -703,7 +721,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -711,10 +729,10 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.selector.matchLabels[stackgres.io/cluster-name]
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.namespaceSelector.matchNames[0]
                 transforms:
                   - string:
@@ -864,7 +882,7 @@ spec:
                   name: kubernetes
             name: prometheusrule
             patches:
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -872,7 +890,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -909,7 +927,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.networkPolicyConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -917,7 +935,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -925,7 +943,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 transforms:
                   - string:
@@ -949,7 +967,8 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.52.0
+          imageTag: v4.53.0
+          proxyEndpoint: host.docker.internal:9443
           quotasEnabled: 'false'
           serviceName: postgresql
           sgNamespace: stackgres

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -114,7 +114,7 @@ spec:
                   name: kubernetes
             name: prometheusrule
             patches:
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -122,7 +122,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -152,7 +152,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.selfSignedIssuerConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -160,7 +160,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 transforms:
                   - string:
@@ -168,7 +168,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -198,7 +198,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.localCAConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -206,7 +206,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 transforms:
                   - string:
@@ -214,7 +214,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -258,7 +258,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.caCertificateConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -266,7 +266,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 transforms:
                   - string:
@@ -274,7 +274,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.issuerRef.name
                 transforms:
                   - string:
@@ -282,7 +282,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -295,7 +295,7 @@ spec:
                   string:
                     fmt: redis-headless.vshn-redis-%s.svc.cluster.local
                   variables:
-                    - fromFieldPath: metadata.labels[crossplane.io/composite]
+                    - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.dnsNames[0]
                 type: CombineFromComposite
               - combine:
@@ -303,7 +303,7 @@ spec:
                   string:
                     fmt: redis-headless.vshn-redis-%s.svc
                   variables:
-                    - fromFieldPath: metadata.labels[crossplane.io/composite]
+                    - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.dnsNames[1]
                 type: CombineFromComposite
           - base:
@@ -345,7 +345,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.serverCertificateConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -353,7 +353,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 transforms:
                   - string:
@@ -361,7 +361,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.issuerRef.name
                 transforms:
                   - string:
@@ -369,7 +369,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -382,7 +382,7 @@ spec:
                   string:
                     fmt: redis-headless.vshn-redis-%s.svc.cluster.local
                   variables:
-                    - fromFieldPath: metadata.labels[crossplane.io/composite]
+                    - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.dnsNames[0]
                 type: CombineFromComposite
               - combine:
@@ -390,7 +390,7 @@ spec:
                   string:
                     fmt: redis-headless.vshn-redis-%s.svc
                   variables:
-                    - fromFieldPath: metadata.labels[crossplane.io/composite]
+                    - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.dnsNames[1]
                 type: CombineFromComposite
           - base:
@@ -431,7 +431,7 @@ spec:
               - fromFieldPath: status.conditions
                 toFieldPath: status.clientCertificateConditions
                 type: ToCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 transforms:
                   - string:
@@ -439,7 +439,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 transforms:
                   - string:
@@ -447,7 +447,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.issuerRef.name
                 transforms:
                   - string:
@@ -455,7 +455,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -468,7 +468,7 @@ spec:
                   string:
                     fmt: redis-headless.vshn-redis-%s.svc.cluster.local
                   variables:
-                    - fromFieldPath: metadata.labels[crossplane.io/composite]
+                    - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.dnsNames[0]
                 type: CombineFromComposite
               - combine:
@@ -476,7 +476,7 @@ spec:
                   string:
                     fmt: redis-headless.vshn-redis-%s.svc
                   variables:
-                    - fromFieldPath: metadata.labels[crossplane.io/composite]
+                    - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.spec.dnsNames[1]
                 type: CombineFromComposite
           - base:
@@ -544,10 +544,10 @@ spec:
                   name: helm
             name: release
             patches:
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: metadata.name
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.namespace
                 transforms:
                   - string:
@@ -555,7 +555,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - string:
@@ -563,7 +563,7 @@ spec:
                       type: Format
                     type: string
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
                 type: FromCompositeFieldPath
               - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
@@ -660,7 +660,7 @@ spec:
               - fromFieldPath: spec.parameters.tls.authClients
                 toFieldPath: spec.forProvider.values.tls.authClients
                 type: FromCompositeFieldPath
-              - fromFieldPath: metadata.labels[crossplane.io/composite]
+              - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.values.metrics.serviceMonitor.namespace
                 transforms:
                   - string:
@@ -706,7 +706,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.52.0
+          imageTag: v4.53.0
           maintenanceSA: helm-based-service-maintenance
           quotasEnabled: 'false'
           restoreSA: redisrestoreserviceaccount

--- a/component/tests/golden/vshn/appcat/appcat/22_prom_rule_sla_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/22_prom_rule_sla_keycloak.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: vshn-vshnkeycloak-sla
+  name: vshn-vshnkeycloak-sla
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-vshnkeycloak-sla-target
+      rules:
+        - expr: vector(99.25)
+          labels:
+            service: VSHNKeycloak
+          record: sla:objective:ratio

--- a/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.52.0
+          image: ghcr.io/vshn/appcat:v4.53.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.52.0
+              image: ghcr.io/vshn/appcat:v4.53.0
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak.yaml
@@ -1,0 +1,206 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: vshn-keycloak
+  name: vshn-keycloak
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: sloth-slo-sli-recordings-appcat-vshn-keycloak-uptime
+      rules:
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="false", maintenance="false"}[5m]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[5m])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="false"}[5m])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+            sloth_window: 5m
+          record: slo:sli_error:ratio_rate5m
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="false", maintenance="false"}[30m]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[30m])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="false"}[30m])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+            sloth_window: 30m
+          record: slo:sli_error:ratio_rate30m
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="false", maintenance="false"}[1h]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[1h])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="false"}[1h])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+            sloth_window: 1h
+          record: slo:sli_error:ratio_rate1h
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="false", maintenance="false"}[2h]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[2h])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="false"}[2h])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+            sloth_window: 2h
+          record: slo:sli_error:ratio_rate2h
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="false", maintenance="false"}[6h]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[6h])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="false"}[6h])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+            sloth_window: 6h
+          record: slo:sli_error:ratio_rate6h
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="false", maintenance="false"}[1d]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[1d])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="false"}[1d])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+            sloth_window: 1d
+          record: slo:sli_error:ratio_rate1d
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="false", maintenance="false"}[3d]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[3d])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="false"}[3d])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+            sloth_window: 3d
+          record: slo:sli_error:ratio_rate3d
+        - expr: |
+            sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"}[30d])
+            / ignoring (sloth_window)
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"}[30d])
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+            sloth_window: 30d
+          record: slo:sli_error:ratio_rate30d
+    - name: sloth-slo-meta-recordings-appcat-vshn-keycloak-uptime
+      rules:
+        - expr: vector(0.9990000000000001)
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+          record: slo:objective:ratio
+        - expr: vector(1-0.9990000000000001)
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+          record: slo:error_budget:ratio
+        - expr: vector(30)
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+          record: slo:time_period:days
+        - expr: |
+            slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"}
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+            slo:error_budget:ratio{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"}
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+          record: slo:current_burn_rate:ratio
+        - expr: |
+            slo:sli_error:ratio_rate30d{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"}
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+            slo:error_budget:ratio{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"}
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+          record: slo:period_burn_rate:ratio
+        - expr: 1 - slo:period_burn_rate:ratio{sloth_id="appcat-vshn-keycloak-uptime",
+            sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"}
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+          record: slo:period_error_budget_remaining:ratio
+        - expr: vector(1)
+          labels:
+            sloth_id: appcat-vshn-keycloak-uptime
+            sloth_mode: cli-gen-prom
+            sloth_objective: '99.9'
+            sloth_service: appcat-vshn-keycloak
+            sloth_slo: uptime
+            sloth_spec: prometheus/v1
+            sloth_version: v0.11.0
+          record: sloth_slo_info
+    - name: sloth-slo-alerts-appcat-vshn-keycloak-uptime
+      rules:
+        - alert: SLO_AppCat_VSHNKeycloakUptime
+          annotations:
+            for: 6m
+            summary: Probes to Keycloak by VSHN instance fail
+            title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1h{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate30m{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"} > (6 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate6h{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"} > (6 * 0.0009999999999999432)) without (sloth_window)
+            )
+          for: 6m
+          labels:
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
+            service: VSHNKeycloak
+            severity: critical
+            slo: 'true'
+            sloth_severity: page
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar
+        - alert: SLO_AppCat_VSHNKeycloakUptime
+          annotations:
+            runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-keycloak.html#uptime
+            summary: Probes to Keycloak by VSHN instance fail
+            title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate2h{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"} > (3 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1d{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"} > (3 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate6h{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
+            )
+          labels:
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
+            service: VSHNKeycloak
+            severity: warning
+            slo: 'true'
+            sloth_severity: ticket
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar

--- a/component/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak_ha.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak_ha.yaml
@@ -1,0 +1,206 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: vshn-keycloak-ha
+  name: vshn-keycloak-ha
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: sloth-slo-sli-recordings-appcat-vshn-keycloak-ha-uptime
+      rules:
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="true"}[5m]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[5m])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="true"}[5m])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+            sloth_window: 5m
+          record: slo:sli_error:ratio_rate5m
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="true"}[30m]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[30m])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="true"}[30m])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+            sloth_window: 30m
+          record: slo:sli_error:ratio_rate30m
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="true"}[1h]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[1h])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="true"}[1h])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+            sloth_window: 1h
+          record: slo:sli_error:ratio_rate1h
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="true"}[2h]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[2h])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="true"}[2h])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+            sloth_window: 2h
+          record: slo:sli_error:ratio_rate2h
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="true"}[6h]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[6h])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="true"}[6h])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+            sloth_window: 6h
+          record: slo:sli_error:ratio_rate6h
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="true"}[1d]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[1d])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="true"}[1d])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+            sloth_window: 1d
+          record: slo:sli_error:ratio_rate1d
+        - expr: |
+            (sum(rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak", ha="true"}[3d]) or 0*rate(appcat_probes_seconds_count{service="VSHNKeycloak"}[3d])) by (service, namespace, name, organization, sla))
+            /
+            (sum(rate(appcat_probes_seconds_count{service="VSHNKeycloak", ha="true"}[3d])) by (service, namespace, name, organization, sla))
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+            sloth_window: 3d
+          record: slo:sli_error:ratio_rate3d
+        - expr: |
+            sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"}[30d])
+            / ignoring (sloth_window)
+            count_over_time(slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"}[30d])
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+            sloth_window: 30d
+          record: slo:sli_error:ratio_rate30d
+    - name: sloth-slo-meta-recordings-appcat-vshn-keycloak-ha-uptime
+      rules:
+        - expr: vector(0.9990000000000001)
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+          record: slo:objective:ratio
+        - expr: vector(1-0.9990000000000001)
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+          record: slo:error_budget:ratio
+        - expr: vector(30)
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+          record: slo:time_period:days
+        - expr: |
+            slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"}
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+            slo:error_budget:ratio{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"}
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+          record: slo:current_burn_rate:ratio
+        - expr: |
+            slo:sli_error:ratio_rate30d{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"}
+            / on(sloth_id, sloth_slo, sloth_service) group_left
+            slo:error_budget:ratio{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"}
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+          record: slo:period_burn_rate:ratio
+        - expr: 1 - slo:period_burn_rate:ratio{sloth_id="appcat-vshn-keycloak-ha-uptime",
+            sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"}
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+          record: slo:period_error_budget_remaining:ratio
+        - expr: vector(1)
+          labels:
+            sloth_id: appcat-vshn-keycloak-ha-uptime
+            sloth_mode: cli-gen-prom
+            sloth_objective: '99.9'
+            sloth_service: appcat-vshn-keycloak-ha
+            sloth_slo: uptime
+            sloth_spec: prometheus/v1
+            sloth_version: v0.11.0
+          record: sloth_slo_info
+    - name: sloth-slo-alerts-appcat-vshn-keycloak-ha-uptime
+      rules:
+        - alert: SLO_AppCat_HAVSHNKeycloakUptime
+          annotations:
+            for: 6m
+            summary: Probes to HA Keycloak by VSHN instance fail
+            title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate5m{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1h{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate30m{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"} > (6 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate6h{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"} > (6 * 0.0009999999999999432)) without (sloth_window)
+            )
+          for: 6m
+          labels:
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
+            service: VSHNKeycloak
+            severity: critical
+            slo: 'true'
+            sloth_severity: page
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar
+        - alert: SLO_AppCat_HAVSHNKeycloakUptime
+          annotations:
+            runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-keycloak.html#uptime
+            summary: Probes to HA Keycloak by VSHN instance fail
+            title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error
+              budget burn rate is too fast.
+          expr: |
+            (
+                max(slo:sli_error:ratio_rate2h{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"} > (3 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate1d{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"} > (3 * 0.0009999999999999432)) without (sloth_window)
+            )
+            or
+            (
+                max(slo:sli_error:ratio_rate6h{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
+                and
+                max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
+            )
+          labels:
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
+            service: VSHNKeycloak
+            severity: warning
+            slo: 'true'
+            sloth_severity: ticket
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar

--- a/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -29,8 +29,8 @@ spec:
         - name: APPCAT_SLI_VSHNREDIS
           value: "true"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
-          value: "true"
-        image: ghcr.io/vshn/appcat:v4.52.0
+          value: "false"
+        image: ghcr.io/vshn/appcat:v4.53.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/vshn.yml
+++ b/component/tests/vshn.yml
@@ -39,7 +39,7 @@ parameters:
       enabled: true
       alertsEnabled: true
       sli_exporter:
-        enableMaintenceObserver: true
+        enableMaintenceObserver: false
       sla_reporter:
         enabled: true
         slo_mimir_svc: kube-prometheus-kube-prome-prometheus
@@ -77,14 +77,17 @@ parameters:
         emailAlerting:
           enabled: true
           smtpPassword: "whatever"
-        services:
-          mariadb:
-            enabled: true
-            # grpcEndpoint: host.docker.internal:9443
-            # proxyFunction: true
-        postgres:
+        mariadb:
+          enabled: true
           # grpcEndpoint: host.docker.internal:9443
           # proxyFunction: true
+        keycloak:
+          enabled: true
+          # grpcEndpoint: host.docker.internal:9443
+          # proxyFunction: true
+        postgres:
+          grpcEndpoint: host.docker.internal:9443
+          proxyFunction: true
           sgNamespace: stackgres
           bucket_region: 'us-east-1'
           bucket_endpoint: 'http://minio-server.minio:9000'
@@ -163,6 +166,3 @@ parameters:
               enabled: true
               # grpcEndpoint: host.docker.internal:9443
               # proxyFunction: true
-
-  openshift4_operators:
-    defaultSourceNamespace: openshift-marketplace

--- a/package/main.yaml
+++ b/package/main.yaml
@@ -7,7 +7,7 @@ parameters:
     image:
       registry: ghcr.io
       repository: vshn/appcat
-      tag: v4.52.0
+      tag: v4.53.0
   components:
     appcat:
       url: https://github.com/vshn/component-appcat.git


### PR DESCRIPTION
Various cleanups and fixes for nested services:

* Moved MariaDB hash up
  * With the previous identation it was not picked up by the billing job generator
* Added more filter functions to common for the service hash
  * These can come in handy if we need to get a list of services with a specific parameter enabled
* Fix broken PG certificates
  * They were hardcoded to wrong hostnames
* Add Keycloak composition
* Replace `crossplane.io/composite]` with `metadata.name`
  * This is necessary for nesting to work.
  * If you just deploy one single instance of something, then indeed it doesn't matter which one of those you use. But if you nest PostgreSQL within Keycloak, then things start to fall apart. Because crossplane.io/composite] will contain Keycloak's composite and NOT PostgreSQL's composite. However, when using metadata.name it will always point to the right one.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
