### PR TITLE
Add stackgres operator to component

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -42,7 +42,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.51.1
+        tag: v4.52.0
       apiserver:
         registry: ghcr.io
         repository: vshn/appcat-apiserver
@@ -237,6 +237,11 @@ parameters:
           cpu: 200m
           memory: 200Mi
 
+    stackgres:
+      namespace: syn-stackgres-operator
+      operator:
+        channel: stable
+        installPlanApproval: Manual
     stsResizer:
       resources:
         requests:

--- a/component/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.51.1
+        image: ghcr.io/vshn/appcat:v4.52.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.51.1
+        image: ghcr.io/vshn/appcat:v4.52.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.51.1
+          image: ghcr.io/vshn/appcat:v4.52.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.51.1
+        image: ghcr.io/vshn/appcat:v4.52.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.51.1
+        image: ghcr.io/vshn/appcat:v4.52.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.51.1
+        image: ghcr.io/vshn/appcat:v4.52.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
@@ -28,7 +28,7 @@ spec:
         data:
           controlNamespace: syn-appcat-control
           defaultPlan: standard-1
-          imageTag: v4.51.1
+          imageTag: v4.52.0
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io
           minioChartVersion: 5.0.13

--- a/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.51.1
+          image: ghcr.io/vshn/appcat:v4.52.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.51.1
+              image: ghcr.io/vshn/appcat:v4.52.0
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.51.1
+        image: ghcr.io/vshn/appcat:v4.52.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.51.1
+        image: ghcr.io/vshn/appcat:v4.52.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.51.1-func
+  package: ghcr.io/vshn/appcat:v4.52.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -31,7 +31,7 @@ spec:
           chartRepository: https://charts.bitnami.com/bitnami
           chartVersion: 10.1.3
           controlNamespace: syn-appcat-control
-          imageTag: v4.51.1
+          imageTag: v4.52.0
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           plans: '{"standard-1": {"size": {"cpu": "250m", "disk": "16Gi", "enabled":

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -847,7 +847,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.51.1
+          imageTag: v4.52.0
           quotasEnabled: 'false'
           serviceName: postgresql
           sgNamespace: stackgres

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -949,7 +949,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.51.1
+          imageTag: v4.52.0
           quotasEnabled: 'false'
           serviceName: postgresql
           sgNamespace: stackgres

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -706,7 +706,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.51.1
+          imageTag: v4.52.0
           maintenanceSA: helm-based-service-maintenance
           quotasEnabled: 'false'
           restoreSA: redisrestoreserviceaccount

--- a/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.51.1
+          image: ghcr.io/vshn/appcat:v4.52.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.51.1
+              image: ghcr.io/vshn/appcat:v4.52.0
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -30,7 +30,7 @@ spec:
           value: "true"
         - name: APPCAT_SLI_TRACK_OC_MAINTENANCE_STATUS
           value: "true"
-        image: ghcr.io/vshn/appcat:v4.51.1
+        image: ghcr.io/vshn/appcat:v4.52.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/vshn.yml
+++ b/component/tests/vshn.yml
@@ -4,6 +4,9 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-crossplane/v2.3.0/lib/crossplane.libsonnet
         output_path: vendor/lib/crossplane.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-operators/v1.4.0/lib/openshift4-operators.libsonnet
+        output_path: vendor/lib/openshift4-operators.libsonnet
 
   facts:
     cloud: cloudscale
@@ -160,3 +163,6 @@ parameters:
               enabled: true
               # grpcEndpoint: host.docker.internal:9443
               # proxyFunction: true
+
+  openshift4_operators:
+    defaultSourceNamespace: openshift-marketplace

--- a/package/main.yaml
+++ b/package/main.yaml
@@ -7,7 +7,7 @@ parameters:
     image:
       registry: ghcr.io
       repository: vshn/appcat
-      tag: v4.51.1
+      tag: v4.52.0
   components:
     appcat:
       url: https://github.com/vshn/component-appcat.git
@@ -16,6 +16,10 @@ parameters:
     crossplane:
       url: https://github.com/projectsyn/component-crossplane.git
       version: v3.4.0
+    openshift4-operators:
+      url: https://github.com/appuio/component-openshift4-operators
+      version: v1.4.0
+
   appcat:
     images:
       appcat:


### PR DESCRIPTION
This PR adds the stackgres Operator via the Openshift OLM, instead of installing stackgres via it's own operator using the helm chart.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
