### PR TITLE
Update e2e.yaml

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
   schedule:
     # daily midnight
-    - cron: '0 0 * * *'
+    - cron: '27 3 * * *'
 jobs:
   test-e2e-lab:
     runs-on: ubuntu-latest


### PR DESCRIPTION
it might be possible that everyone run some jobs at 00:00 and our e2e test times out because of that. I suggest change of time to see if that's the issue
