### PR TITLE
Add ability to add Keycloak specific ingress annotations

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -45,7 +45,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.61.0
+        tag: keycloak/staging_le
       apiserver:
         registry: ghcr.io
         repository: vshn/appcat-apiserver
@@ -696,6 +696,7 @@ parameters:
           additionalInputs:
             registry_username: "?{vaultkv:__shared__/__shared__/appcat/inventage_registry_username}"
             registry_password: "?{vaultkv:__shared__/__shared__/appcat/inventage_registry_password}"
+            issuer_name: letsencrypt-production
           openshiftTemplate:
             serviceName: keycloakbyvshn
             description: "Keycloak is an open source identity and access management solution."

--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -45,7 +45,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: keycloak/staging_le
+        tag: v4.62.0
       apiserver:
         registry: ghcr.io
         repository: vshn/appcat-apiserver

--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -688,6 +688,7 @@ parameters:
             - KEYCLOAK_PASSWORD
             - KEYCLOAK_URL
             - KEYCLOAK_USERNAME
+            - ca.crt
           mode: standalone
           offered: true
           enabled: false
@@ -696,7 +697,8 @@ parameters:
           additionalInputs:
             registry_username: "?{vaultkv:__shared__/__shared__/appcat/inventage_registry_username}"
             registry_password: "?{vaultkv:__shared__/__shared__/appcat/inventage_registry_password}"
-            issuer_name: letsencrypt-production
+            ingress_annotations: |
+              cert-manager.io/cluster-issuer: letsencrypt-production
           openshiftTemplate:
             serviceName: keycloakbyvshn
             description: "Keycloak is an open source identity and access management solution."

--- a/component/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -32,7 +32,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMINIO
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.61.0
+        image: ghcr.io/vshn/appcat:v4.62.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -32,7 +32,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMINIO
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.61.0
+        image: ghcr.io/vshn/appcat:v4.62.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.61.0
+          image: ghcr.io/vshn/appcat:v4.62.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -32,7 +32,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMINIO
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.61.0
+        image: ghcr.io/vshn/appcat:v4.62.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -32,7 +32,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMINIO
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.61.0
+        image: ghcr.io/vshn/appcat:v4.62.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -32,7 +32,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMINIO
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.61.0
+        image: ghcr.io/vshn/appcat:v4.62.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
@@ -28,7 +28,7 @@ spec:
         data:
           controlNamespace: syn-appcat-control
           defaultPlan: standard-1
-          imageTag: v4.61.0
+          imageTag: v4.62.0
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io
           minioChartVersion: 5.0.13

--- a/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.61.0
+          image: ghcr.io/vshn/appcat:v4.62.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.61.0
+              image: ghcr.io/vshn/appcat:v4.62.0
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -32,7 +32,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMINIO
           value: "true"
-        image: ghcr.io/vshn/appcat:v4.61.0
+        image: ghcr.io/vshn/appcat:v4.62.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -32,7 +32,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMINIO
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.61.0
+        image: ghcr.io/vshn/appcat:v4.62.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:keycloak_staging_le-func
+  package: ghcr.io/vshn/appcat:v4.62.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.61.0-func
+  package: ghcr.io/vshn/appcat:keycloak_staging_le-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/vshn/appcat/appcat/20_xrd_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/20_xrd_vshn_keycloak.yaml
@@ -16,6 +16,7 @@ spec:
     - KEYCLOAK_PASSWORD
     - KEYCLOAK_URL
     - KEYCLOAK_USERNAME
+    - ca.crt
   defaultCompositionRef:
     name: vshnkeycloak.vshn.appcat.vshn.io
   group: vshn.appcat.vshn.io

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_objectstorage_minio.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_objectstorage_minio.yaml
@@ -26,6 +26,7 @@ spec:
         apiVersion: v1
         data:
           providerConfig: minio
+          proxyEndpoint: host.docker.internal:9443
           serviceName: miniobucket
         kind: ConfigMap
         metadata:
@@ -63,6 +64,7 @@ spec:
         apiVersion: v1
         data:
           providerConfig: minio-cluster
+          proxyEndpoint: host.docker.internal:9443
           serviceName: miniobucket
         kind: ConfigMap
         metadata:

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_objectstorage_minio.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_objectstorage_minio.yaml
@@ -26,7 +26,6 @@ spec:
         apiVersion: v1
         data:
           providerConfig: minio
-          proxyEndpoint: host.docker.internal:9443
           serviceName: miniobucket
         kind: ConfigMap
         metadata:
@@ -64,7 +63,6 @@ spec:
         apiVersion: v1
         data:
           providerConfig: minio-cluster
-          proxyEndpoint: host.docker.internal:9443
           serviceName: miniobucket
         kind: ConfigMap
         metadata:

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -31,7 +31,7 @@ spec:
           chartRepository: https://codecentric.github.io/helm-charts
           chartVersion: 2.3.0
           controlNamespace: syn-appcat-control
-          imageTag: keycloak_staging_le
+          imageTag: v4.62.0
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging
@@ -41,7 +41,6 @@ spec:
             true, "memory": "2Gi"}}, "standard-4": {"size": {"cpu": "1", "disk": "16Gi",
             "enabled": true, "memory": "4Gi"}}, "standard-8": {"size": {"cpu": "2",
             "disk": "16Gi", "enabled": true, "memory": "8Gi"}}}'
-          proxyEndpoint: host.docker.internal:9443
           quotasEnabled: 'false'
           registry_password: ''
           registry_username: ''

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -33,6 +33,7 @@ spec:
           controlNamespace: syn-appcat-control
           imageTag: v4.61.0
           isOpenshift: 'false'
+          issuer_name: letsencrypt-staging
           maintenanceSA: helm-based-service-maintenance
           plans: '{"standard-2": {"size": {"cpu": "500m", "disk": "16Gi", "enabled":
             true, "memory": "2Gi"}}, "standard-4": {"size": {"cpu": "1", "disk": "16Gi",

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -31,14 +31,17 @@ spec:
           chartRepository: https://codecentric.github.io/helm-charts
           chartVersion: 2.3.0
           controlNamespace: syn-appcat-control
-          imageTag: v4.61.0
+          imageTag: keycloak_staging_le
+          ingress_annotations: |
+            nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+            cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'false'
-          issuer_name: letsencrypt-staging
           maintenanceSA: helm-based-service-maintenance
           plans: '{"standard-2": {"size": {"cpu": "500m", "disk": "16Gi", "enabled":
             true, "memory": "2Gi"}}, "standard-4": {"size": {"cpu": "1", "disk": "16Gi",
             "enabled": true, "memory": "4Gi"}}, "standard-8": {"size": {"cpu": "2",
             "disk": "16Gi", "enabled": true, "memory": "8Gi"}}}'
+          proxyEndpoint: host.docker.internal:9443
           quotasEnabled: 'false'
           registry_password: ''
           registry_username: ''

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -31,7 +31,7 @@ spec:
           chartRepository: https://charts.bitnami.com/bitnami
           chartVersion: 11.6.2
           controlNamespace: syn-appcat-control
-          imageTag: keycloak_staging_le
+          imageTag: v4.62.0
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           plans: '{"standard-1": {"size": {"cpu": "250m", "disk": "16Gi", "enabled":
@@ -41,7 +41,6 @@ spec:
             {"size": {"cpu": "125m", "disk": "16Gi", "enabled": true, "memory": "512Mi"}},
             "standard-8": {"size": {"cpu": "2", "disk": "16Gi", "enabled": true, "memory":
             "8Gi"}}}'
-          proxyEndpoint: host.docker.internal:9443
           quotasEnabled: 'false'
           restoreSA: mariadbrestoreserviceaccount
           serviceName: mariadb

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -31,7 +31,7 @@ spec:
           chartRepository: https://charts.bitnami.com/bitnami
           chartVersion: 11.6.2
           controlNamespace: syn-appcat-control
-          imageTag: v4.61.0
+          imageTag: keycloak_staging_le
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           plans: '{"standard-1": {"size": {"cpu": "250m", "disk": "16Gi", "enabled":
@@ -41,6 +41,7 @@ spec:
             {"size": {"cpu": "125m", "disk": "16Gi", "enabled": true, "memory": "512Mi"}},
             "standard-8": {"size": {"cpu": "2", "disk": "16Gi", "enabled": true, "memory":
             "8Gi"}}}'
+          proxyEndpoint: host.docker.internal:9443
           quotasEnabled: 'false'
           restoreSA: mariadbrestoreserviceaccount
           serviceName: mariadb

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -708,8 +708,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: keycloak_staging_le
-          proxyEndpoint: host.docker.internal:9443
+          imageTag: v4.62.0
           quotasEnabled: 'false'
           serviceName: postgresql
           sgNamespace: stackgres

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -708,7 +708,8 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.61.0
+          imageTag: keycloak_staging_le
+          proxyEndpoint: host.docker.internal:9443
           quotasEnabled: 'false'
           serviceName: postgresql
           sgNamespace: stackgres

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -810,7 +810,8 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.61.0
+          imageTag: keycloak_staging_le
+          proxyEndpoint: host.docker.internal:9443
           quotasEnabled: 'false'
           serviceName: postgresql
           sgNamespace: stackgres

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -810,8 +810,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: keycloak_staging_le
-          proxyEndpoint: host.docker.internal:9443
+          imageTag: v4.62.0
           quotasEnabled: 'false'
           serviceName: postgresql
           sgNamespace: stackgres

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -608,9 +608,8 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: keycloak_staging_le
+          imageTag: v4.62.0
           maintenanceSA: helm-based-service-maintenance
-          proxyEndpoint: host.docker.internal:9443
           quotasEnabled: 'false'
           restoreSA: redisrestoreserviceaccount
           serviceName: redis

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -608,8 +608,9 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.61.0
+          imageTag: keycloak_staging_le
           maintenanceSA: helm-based-service-maintenance
+          proxyEndpoint: host.docker.internal:9443
           quotasEnabled: 'false'
           restoreSA: redisrestoreserviceaccount
           serviceName: redis

--- a/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.61.0
+          image: ghcr.io/vshn/appcat:keycloak_staging_le
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:keycloak_staging_le
+          image: ghcr.io/vshn/appcat:v4.62.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:keycloak_staging_le
+              image: ghcr.io/vshn/appcat:v4.62.0
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.61.0
+              image: ghcr.io/vshn/appcat:keycloak_staging_le
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -32,7 +32,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMINIO
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.61.0
+        image: ghcr.io/vshn/appcat:keycloak_staging_le
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -32,7 +32,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMINIO
           value: "false"
-        image: ghcr.io/vshn/appcat:keycloak_staging_le
+        image: ghcr.io/vshn/appcat:v4.62.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/vshn.yml
+++ b/component/tests/vshn.yml
@@ -89,6 +89,7 @@ parameters:
             # https://vault-prod.syn.vshn.net/ui/vault/secrets/clusters%2Fkv/kv/__shared__%2F__shared__%2Fappcat/details?version=1
             registry_username: ""
             registry_password: ""
+            issuer_name: letsencrypt-staging
         postgres:
           sgNamespace: stackgres
           bucket_region: 'us-east-1'

--- a/component/tests/vshn.yml
+++ b/component/tests/vshn.yml
@@ -21,7 +21,7 @@ parameters:
   appcat:
 
     grpcEndpoint: host.docker.internal:9443
-    proxyFunction: true
+    proxyFunction: false
 
     quotasEnabled: false
     appuioManaged: false

--- a/component/tests/vshn.yml
+++ b/component/tests/vshn.yml
@@ -21,7 +21,7 @@ parameters:
   appcat:
 
     grpcEndpoint: host.docker.internal:9443
-    proxyFunction: false
+    proxyFunction: true
 
     quotasEnabled: false
     appuioManaged: false
@@ -89,7 +89,9 @@ parameters:
             # https://vault-prod.syn.vshn.net/ui/vault/secrets/clusters%2Fkv/kv/__shared__%2F__shared__%2Fappcat/details?version=1
             registry_username: ""
             registry_password: ""
-            issuer_name: letsencrypt-staging
+            ingress_annotations: |
+              nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+              cert-manager.io/cluster-issuer: letsencrypt-staging
         postgres:
           sgNamespace: stackgres
           bucket_region: 'us-east-1'

--- a/package/main.yaml
+++ b/package/main.yaml
@@ -7,7 +7,7 @@ parameters:
     image:
       registry: ghcr.io
       repository: vshn/appcat
-      tag: keycloak/staging_le
+      tag: v4.62.0
   components:
     appcat:
       url: https://github.com/vshn/component-appcat.git

--- a/package/main.yaml
+++ b/package/main.yaml
@@ -7,7 +7,7 @@ parameters:
     image:
       registry: ghcr.io
       repository: vshn/appcat
-      tag: v4.61.0
+      tag: keycloak/staging_le
   components:
     appcat:
       url: https://github.com/vshn/component-appcat.git

--- a/tests/e2e/keycloak/00-assert.yaml
+++ b/tests/e2e/keycloak/00-assert.yaml
@@ -17,10 +17,6 @@ spec:
     backup: {}
     service:
       postgreSQLParameters:
-        backup:
-          deletionProtection: false
-          deletionRetention: 7
-          retention: 6
         instances: 1
       relativePath: /
       serviceLevel: besteffort

--- a/tests/e2e/keycloak/01-connect.yaml
+++ b/tests/e2e/keycloak/01-connect.yaml
@@ -3,13 +3,18 @@ kind: Job
 metadata:
   name: connect-keycloak-e2e
 spec:
-  backoffLimit: 20
+  backoffLimit: 1
   template:
     metadata:
       labels:
         e2e-test: keycloak-e2e
     spec:
       restartPolicy: Never
+      activeDeadlineSeconds: 180
+      volumes:
+        - name: certs
+          secret:
+            secretName: keycloak-e2e
       containers:
         - name: connect
           image: curlimages/curl:8.6.0
@@ -18,7 +23,16 @@ spec:
             - /bin/sh
           args:
             - -c
-            - echo "Testing health...\n" && sleep 30 && curl -kivv https://$KEYCLOAK_HOST:8443/health
+            - |
+              echo "Testing health..."
+              while ! curl --cacert /certs/ca.crt -ivv https://$KEYCLOAK_HOST:8443/health
+              do
+                sleep 1
+                echo "not ready"
+              done
           envFrom:
             - secretRef:
                 name: keycloak-e2e
+          volumeMounts:
+            - name: certs
+              mountPath: /certs

--- a/tests/e2e/keycloak/01-install.yaml
+++ b/tests/e2e/keycloak/01-install.yaml
@@ -6,5 +6,8 @@ spec:
   parameters:
     service:
       fqdn: keycloak-e2e.example.com
+      postgreSQLParameters:
+        backup:
+          deletionProtection: false
   writeConnectionSecretToRef:
     name: keycloak-e2e

--- a/tests/e2e/mariadb/01-connect.yaml
+++ b/tests/e2e/mariadb/01-connect.yaml
@@ -3,13 +3,14 @@ kind: Job
 metadata:
   name: connect-mariadb
 spec:
-  backoffLimit: 20
+  backoffLimit: 1
   template:
     metadata:
       labels:
         e2e-test: mariadb
     spec:
       restartPolicy: Never
+      activeDeadlineSeconds: 180
       containers:
         - name: connect
           image: dockerhub.vshn.net/bitnami/mariadb:latest
@@ -18,7 +19,13 @@ spec:
             - bash
           args:
             - -c
-            - echo "Testing Select...\n" && mariadb -h $MARIADB_HOST -u $MARIADB_USERNAME --password="$MARIADB_PASSWORD" -P $MARIADB_PORT --ssl-verify-server-cert --ssl-ca=/etc/mariadb-tls/ca.crt -e "select 1;"
+            - |
+              echo "Testing Select..."
+              until mariadb -h $MARIADB_HOST -u $MARIADB_USERNAME --password="$MARIADB_PASSWORD" -P $MARIADB_PORT --ssl-verify-server-cert --ssl-ca=/etc/mariadb-tls/ca.crt -e "select 1;"
+              do
+                sleep 1
+                echo "not ready"
+              done
           envFrom:
             - secretRef:
                 name: mariadb-creds

--- a/tests/e2e/postgresql/00-assert.yaml
+++ b/tests/e2e/postgresql/00-assert.yaml
@@ -15,7 +15,7 @@ spec:
   compositionUpdatePolicy: Automatic
   parameters:
     backup:
-        deletionProtection: false
+        deletionProtection: true
         deletionRetention: 7
         retention: 6
     instances: 1

--- a/tests/e2e/postgresql/01-connect.yaml
+++ b/tests/e2e/postgresql/01-connect.yaml
@@ -3,13 +3,14 @@ kind: Job
 metadata:
   name: connect-postgresql
 spec:
-  backoffLimit: 10
+  backoffLimit: 1
   template:
     metadata:
       labels:
         e2e-test: postgresql
     spec:
       restartPolicy: Never
+      activeDeadlineSeconds: 180
       containers:
         - name: connect
           image: dockerhub.vshn.net/library/postgres:15
@@ -18,7 +19,12 @@ spec:
             - bash
           args:
             - -c
-            - PGPASSWORD=$POSTGRESQL_PASSWORD psql "sslmode=verify-ca sslrootcert=/etc/postgresql-tls/ca.crt host=$POSTGRESQL_HOST port=$POSTGRESQL_PORT dbname=$POSTGRESQL_DB" -U $POSTGRESQL_USER -c "select 1;"
+            - |
+              until PGPASSWORD=$POSTGRESQL_PASSWORD psql "sslmode=verify-full sslrootcert=/etc/postgresql-tls/ca.crt host=$POSTGRESQL_HOST port=$POSTGRESQL_PORT dbname=$POSTGRESQL_DB" -U $POSTGRESQL_USER -c "select 1;"
+              do
+                sleep 1
+                echo "not ready"
+              done
           envFrom:
             - secretRef:
                 name: postgresql-e2e-test-creds

--- a/tests/e2e/postgresql/01-install.yaml
+++ b/tests/e2e/postgresql/01-install.yaml
@@ -4,6 +4,10 @@ metadata:
   name: postgresql-e2e-test
 spec:
   parameters:
+    backup:
+      deletionProtection: false
+      deletionRetention: 7
+      retention: 6
     size:
       plan: standard-2
   writeConnectionSecretToRef:

--- a/tests/e2e/redis/01-connect.yaml
+++ b/tests/e2e/redis/01-connect.yaml
@@ -3,13 +3,14 @@ kind: Job
 metadata:
   name: connect-redis
 spec:
-  backoffLimit: 10
+  backoffLimit: 1
   template:
     metadata:
       labels:
-        e2e-test: postgresql
+        e2e-test: redis
     spec:
       restartPolicy: Never
+      activeDeadlineSeconds: 180
       containers:
         - name: connect
           image: dockerhub.vshn.net/library/redis:7
@@ -18,7 +19,12 @@ spec:
             - bash
           args:
             - -c
-            - redis-cli -u rediss://$REDIS_USERNAME:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT --tls --cert /etc/redis-tls/tls.crt --key /etc/redis-tls/tls.key --cacert /etc/redis-tls/ca.crt PING
+            - |
+              until redis-cli -u rediss://$REDIS_USERNAME:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT --tls --cert /etc/redis-tls/tls.crt --key /etc/redis-tls/tls.key --cacert /etc/redis-tls/ca.crt PING
+              do
+                sleep 1
+                echo "not ready"
+              done
           envFrom:
             - secretRef:
                 name: redis-e2e-test-creds


### PR DESCRIPTION
With this it's possible to set arbitrary annotations on the ingress objects for Keycloak.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
