### PR TITLE
Remove LPG e2e test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,25 +28,3 @@ jobs:
           job_name: 'E2E tests for lab environement'
           icon_emoji: ':fire:'
           url: ${{ secrets.ROCKETCHAT_WEBHOOK }}
-  test-e2e-prod-lpg:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Get KUBECONFIG
-        shell: bash
-        env:
-          LPG_KUBECONFIG: ${{ secrets.LPG_KUBECONFIG }}
-        run: |
-          echo "$LPG_KUBECONFIG" > kubeconfig
-      - name: Run tests
-        run: make e2e-test
-        env:
-          KUBECONFIG: kubeconfig
-      - name: Rocket.Chat Notification
-        uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
-        if: failure()
-        with:
-          type: ${{ job.status }}
-          job_name: 'E2E tests for LPG environement'
-          icon_emoji: ':fire:'
-          url: ${{ secrets.ROCKETCHAT_WEBHOOK }}


### PR DESCRIPTION
Due to performance issues with provider-kubernetes, the e2e tests on LPG can sometimes timeout.

So we temporarily remove them from the actions. Once provider-kubernetes has been migrated, we can re-enable them.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
