### PR TITLE
Add label selectors to webhooks

### DIFF
--- a/component/component/appcat_controller.jsonnet
+++ b/component/component/appcat_controller.jsonnet
@@ -143,6 +143,23 @@ local webhookCertificate = {
   },
 };
 
+local clientConfig = {
+  clientConfig+: {
+    service+: {
+      namespace: controllersParams.namespace,
+    },
+  },
+};
+
+local selector = {
+  matchExpressions: [
+    {
+      key: 'appcat.vshn.io/ownerkind',
+      operator: 'Exists',
+    },
+  ],
+};
+
 local webhook = loadManifest('webhooks.yaml') {
   metadata+: {
     name: 'appcat-validation',
@@ -151,13 +168,10 @@ local webhook = loadManifest('webhooks.yaml') {
     },
   },
   webhooks: [
-    w {
-      clientConfig+: {
-        service+: {
-          namespace: controllersParams.namespace,
-        },
-      },
-    }
+    if w.name == 'pvc.vshn.appcat.vshn.io' then w { namespaceSelector: selector } + clientConfig else
+      if w.name == 'namespace.vshn.appcat.vshn.io' then w { objectSelector: selector } + clientConfig else
+        if w.name == 'xobjectbuckets.vshn.appcat.vshn.io' then w { objectSelector: selector } + clientConfig
+        else w + clientConfig
     for w in super.webhooks
   ],
 };

--- a/component/tests/golden/controllers/appcat/appcat/controllers/appcat/10_webhooks.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/controllers/appcat/10_webhooks.yaml
@@ -14,6 +14,10 @@ webhooks:
         path: /validate--v1-namespace
     failurePolicy: Fail
     name: namespace.vshn.appcat.vshn.io
+    objectSelector:
+      matchExpressions:
+        - key: appcat.vshn.io/ownerkind
+          operator: Exists
     rules:
       - apiGroups:
           - ''
@@ -54,6 +58,10 @@ webhooks:
         path: /validate--v1-persistentvolumeclaim
     failurePolicy: Fail
     name: pvc.vshn.appcat.vshn.io
+    namespaceSelector:
+      matchExpressions:
+        - key: appcat.vshn.io/ownerkind
+          operator: Exists
     rules:
       - apiGroups:
           - ''
@@ -92,6 +100,10 @@ webhooks:
         path: /validate-appcat-vshn-io-v1-xobjectbucket
     failurePolicy: Fail
     name: xobjectbuckets.vshn.appcat.vshn.io
+    objectSelector:
+      matchExpressions:
+        - key: appcat.vshn.io/ownerkind
+          operator: Exists
     rules:
       - apiGroups:
           - appcat.vshn.io

--- a/component/tests/golden/minio/appcat/appcat/controllers/appcat/10_webhooks.yaml
+++ b/component/tests/golden/minio/appcat/appcat/controllers/appcat/10_webhooks.yaml
@@ -14,6 +14,10 @@ webhooks:
         path: /validate--v1-namespace
     failurePolicy: Fail
     name: namespace.vshn.appcat.vshn.io
+    objectSelector:
+      matchExpressions:
+        - key: appcat.vshn.io/ownerkind
+          operator: Exists
     rules:
       - apiGroups:
           - ''
@@ -54,6 +58,10 @@ webhooks:
         path: /validate--v1-persistentvolumeclaim
     failurePolicy: Fail
     name: pvc.vshn.appcat.vshn.io
+    namespaceSelector:
+      matchExpressions:
+        - key: appcat.vshn.io/ownerkind
+          operator: Exists
     rules:
       - apiGroups:
           - ''
@@ -92,6 +100,10 @@ webhooks:
         path: /validate-appcat-vshn-io-v1-xobjectbucket
     failurePolicy: Fail
     name: xobjectbuckets.vshn.appcat.vshn.io
+    objectSelector:
+      matchExpressions:
+        - key: appcat.vshn.io/ownerkind
+          operator: Exists
     rules:
       - apiGroups:
           - appcat.vshn.io

--- a/component/tests/golden/vshn/appcat/appcat/controllers/appcat/10_webhooks.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/controllers/appcat/10_webhooks.yaml
@@ -14,6 +14,10 @@ webhooks:
         path: /validate--v1-namespace
     failurePolicy: Fail
     name: namespace.vshn.appcat.vshn.io
+    objectSelector:
+      matchExpressions:
+        - key: appcat.vshn.io/ownerkind
+          operator: Exists
     rules:
       - apiGroups:
           - ''
@@ -54,6 +58,10 @@ webhooks:
         path: /validate--v1-persistentvolumeclaim
     failurePolicy: Fail
     name: pvc.vshn.appcat.vshn.io
+    namespaceSelector:
+      matchExpressions:
+        - key: appcat.vshn.io/ownerkind
+          operator: Exists
     rules:
       - apiGroups:
           - ''
@@ -92,6 +100,10 @@ webhooks:
         path: /validate-appcat-vshn-io-v1-xobjectbucket
     failurePolicy: Fail
     name: xobjectbuckets.vshn.appcat.vshn.io
+    objectSelector:
+      matchExpressions:
+        - key: appcat.vshn.io/ownerkind
+          operator: Exists
     rules:
       - apiGroups:
           - appcat.vshn.io


### PR DESCRIPTION
This limits when the webhooks are triggered. Thus reducing the fallout if for some reason the webhooks are not available.

For PVCs: it will only trigger if the PVC resides in an instance namespace.

For namespaces and XObjectBuckets: it will only trigger, if they contain the AppCat mandatory `appcat.vshn.io/ownerkind` label.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
