### PR TITLE
Pass through loadbalancer annotations

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -428,6 +428,9 @@ parameters:
           # bucket_endpoint: 'https://objects.lpg.cloudscale.ch' || 'https://sos-ch-gva-2.exo.io'
           bucket_endpoint: ""
           enabled: true
+          additionalInputs:
+            # Depending on the cluster, this needs to be set
+            loadbalancerAnnotations: ""
           grpcEndpoint: ${appcat:grpcEndpoint}
           proxyFunction: ${appcat:proxyFunction}
           enableNetworkPolicy: true

--- a/component/component/vshn_postgres.jsonnet
+++ b/component/component/vshn_postgres.jsonnet
@@ -913,7 +913,8 @@ local composition(restore=false) =
                       ownerVersion: xrd.spec.versions[0].name,
                       bucketRegion: pgParams.bucket_region,
                       isOpenshift: std.toString(isOpenshift),
-                    } + common.EmailAlerting(params.services.vshn.emailAlerting)
+                    } + std.get(pgParams, 'additionalInputs', default={}, inc_hidden=true)
+                    + common.EmailAlerting(params.services.vshn.emailAlerting)
                     + if pgParams.proxyFunction then {
                       proxyEndpoint: pgParams.grpcEndpoint,
                     } else {},

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -711,6 +711,8 @@ spec:
           externalDatabaseConnectionsEnabled: 'true'
           imageTag: v4.66.2
           isOpenshift: 'false'
+          loadbalancerAnnotations: |
+            foo: bar
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNPostgreSQL
           ownerVersion: v1

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgresrestore.yaml
@@ -813,6 +813,8 @@ spec:
           externalDatabaseConnectionsEnabled: 'true'
           imageTag: v4.66.2
           isOpenshift: 'false'
+          loadbalancerAnnotations: |
+            foo: bar
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNPostgreSQL
           ownerVersion: v1

--- a/component/tests/vshn.yml
+++ b/component/tests/vshn.yml
@@ -96,6 +96,9 @@ parameters:
           sgNamespace: stackgres
           bucket_region: 'us-east-1'
           bucket_endpoint: 'http://minio-server.minio:9000'
+          additionalInputs:
+            loadbalancerAnnotations: |
+                foo: bar
           plans:
             standard-8:
               enabled: false

--- a/docs/modules/ROOT/pages/references/services-vshn.adoc
+++ b/docs/modules/ROOT/pages/references/services-vshn.adoc
@@ -157,6 +157,20 @@ default:: `standard-2`
 
 The default plan used for PostgreSQL by VSHN, if the service user doesn't specify a plan.
 
+=== `postgres.additionalInputs.loadbalancerAnnotations`
+type:: string
+default:: `""`
+
+Additional loadbalancer annotations. They need to be specified as yaml maps.
+
+.Examples
+[source,yaml]
+----
+loadbalancerAnnotations: |
+  foo: bar
+  important: label
+----
+
 == `redis`
 [horizontal]
 type:: dict


### PR DESCRIPTION
Add ability to pass through annotations for the `primary-service` in PostgreSQL instances. Necessary for APPUiO managed instances.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
