### PR TITLE
Remove netpol from postgres status

### DIFF
--- a/tests/e2e/postgresql/00-assert.yaml
+++ b/tests/e2e/postgresql/00-assert.yaml
@@ -39,9 +39,6 @@ status:
   localCAConditions:
     - status: "True"
     - status: "True"
-  networkPolicyConditions:
-    - status: "True"
-    - status: "True"
   objectBackupConfigConditions:
     - status: "True"
     - status: "True"

--- a/tests/tests.mk
+++ b/tests/tests.mk
@@ -20,7 +20,7 @@ e2e-test: $(kuttl_bin) ## Run e2e tests
 # kuttl leaves kubeconfig garbage: https://github.com/kudobuilder/kuttl/issues/297
 
 .PHONY: .run-single-e2e
-run-single-e2e:
+run-single-e2e: $(kuttl_bin)
 	@kubectl create namespace appcat-e2e || true
 	GOBIN=$(go_bin) $(kuttl_bin) test ./tests/e2e --config ./tests/e2e/kuttl-test.yaml --suppress-log=Events --test $(test)
 	@rm -f kubeconfig


### PR DESCRIPTION
E2E tests are complaining of the missing netpol status. Removing it from the test itself.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
