### PR TITLE
treat OKE like Openshift4

### DIFF
--- a/component/component/appcat_sli_exporter.jsonnet
+++ b/component/component/appcat_sli_exporter.jsonnet
@@ -8,8 +8,7 @@ local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local sli_exporter_params = params.slos.sli_exporter;
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
-
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift') || inv.parameters.facts.distribution == 'oke';
 local deployment_patch = kube._Object('apps/v1', 'Deployment', 'controller-manager') {
   metadata+: {
     namespace: 'system',

--- a/component/component/exoscale_kafka.jsonnet
+++ b/component/component/exoscale_kafka.jsonnet
@@ -12,7 +12,7 @@ local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local kafkaParams = params.services.exoscale.kafka;
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift') || inv.parameters.facts.distribution == 'oke';
 
 local connectionSecretKeys = [
   'KAFKA_URI',

--- a/component/component/exoscale_mysql.jsonnet
+++ b/component/component/exoscale_mysql.jsonnet
@@ -12,8 +12,7 @@ local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local mysqlParams = params.services.exoscale.mysql;
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
-
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift') || inv.parameters.facts.distribution == 'oke';
 local connectionSecretKeys = [
   'MYSQL_URL',
   'MYSQL_DB',

--- a/component/component/exoscale_opensearch.jsonnet
+++ b/component/component/exoscale_opensearch.jsonnet
@@ -12,8 +12,7 @@ local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local osParams = params.services.exoscale.opensearch;
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
-
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift') || inv.parameters.facts.distribution == 'oke';
 local connectionSecretKeys = [
   'OPENSEARCH_USER',
   'OPENSEARCH_PASSWORD',

--- a/component/component/exoscale_postgres.jsonnet
+++ b/component/component/exoscale_postgres.jsonnet
@@ -12,8 +12,7 @@ local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local pgParams = params.services.exoscale.postgres;
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
-
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift') || inv.parameters.facts.distribution == 'oke';
 local connectionSecretKeys = [
   'POSTGRESQL_URL',
   'POSTGRESQL_DB',

--- a/component/component/exoscale_redis.jsonnet
+++ b/component/component/exoscale_redis.jsonnet
@@ -12,8 +12,7 @@ local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local redisParams = params.services.exoscale.redis;
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
-
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift') || inv.parameters.facts.distribution == 'oke';
 local connectionSecretKeys = [
   'REDIS_HOST',
   'REDIS_PORT',

--- a/component/component/main.jsonnet
+++ b/component/component/main.jsonnet
@@ -31,7 +31,7 @@ local xrdBrowseRole = kube.ClusterRole('appcat:browse') + {
 };
 
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift') || inv.parameters.facts.distribution == 'oke';
 local finalizerRole = kube.ClusterRole('crossplane:appcat:finalizer') {
   metadata+: {
     labels: {

--- a/component/component/vshn_appcat_services.jsonnet
+++ b/component/component/vshn_appcat_services.jsonnet
@@ -25,7 +25,7 @@ local getServiceNamePlural(serviceName) =
     serviceNameLower + 's';
 
 local vshn_appcat_service(name, serviceParams) =
-  local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+  local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift') || inv.parameters.facts.distribution == 'oke';
 
   local connectionSecretKeys = serviceParams.connectionSecretKeys;
   local promRuleSLA = prom.PromRuleSLA(serviceParams.sla, serviceParams.serviceName);

--- a/component/component/vshn_minio.jsonnet
+++ b/component/component/vshn_minio.jsonnet
@@ -14,8 +14,7 @@ local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local minioParams = params.services.vshn.minio;
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
-
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift') || inv.parameters.facts.distribution == 'oke';
 local serviceNameLabelKey = 'appcat.vshn.io/servicename';
 local serviceNamespaceLabelKey = 'appcat.vshn.io/claim-namespace';
 

--- a/component/component/vshn_postgres.jsonnet
+++ b/component/component/vshn_postgres.jsonnet
@@ -19,7 +19,7 @@ local defaultPort = '5432';
 
 local certificateSecretName = 'tls-certificate';
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift') || inv.parameters.facts.distribution == 'oke';
 local operatorlib = import 'lib/openshift4-operators.libsonnet';
 
 local stackgresOperatorNs = kube.Namespace(params.stackgres.namespace) {

--- a/component/component/vshn_redis.jsonnet
+++ b/component/component/vshn_redis.jsonnet
@@ -36,7 +36,7 @@ local connectionSecretKeys = [
   'REDIS_URL',
 ];
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift') || inv.parameters.facts.distribution == 'oke';
 local securityContext = if isOpenshift then false else true;
 
 local redisPlans = common.FilterDisabledParams(redisParams.plans);

--- a/package/main.yaml
+++ b/package/main.yaml
@@ -15,7 +15,7 @@ parameters:
       path: component
     crossplane:
       url: https://github.com/projectsyn/component-crossplane.git
-      version: v3.4.0
+      version: v3.5.0
     openshift4-operators:
       url: https://github.com/appuio/component-openshift4-operators
       version: v1.4.0


### PR DESCRIPTION
Idea is to treat OKE like Openshift4 so all necessary abstracts will be installed on cluster

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
