### PR TITLE
Rename Keycloak's restore service account

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -710,7 +710,7 @@ parameters:
           mode: standalone
           offered: true
           enabled: false
-          restoreSA: mariadbrestoreserviceaccount
+          restoreSA: keycloakserviceaccount
           restoreRoleRules: ${appcat:defaultRestoreRoleRules}
           additionalInputs:
             registry_username: "?{vaultkv:__shared__/__shared__/appcat/inventage_registry_username}"

--- a/component/tests/golden/vshn/appcat/appcat/20_role_vshn_keycloak_restore.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/20_role_vshn_keycloak_restore.yaml
@@ -59,8 +59,8 @@ kind: ServiceAccount
 metadata:
   annotations: {}
   labels:
-    name: mariadbrestoreserviceaccount
-  name: mariadbrestoreserviceaccount
+    name: keycloakserviceaccount
+  name: keycloakserviceaccount
   namespace: syn-appcat-control
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -76,5 +76,5 @@ roleRef:
   name: crossplane:appcat:job:keycloak:restorejob
 subjects:
   - kind: ServiceAccount
-    name: mariadbrestoreserviceaccount
+    name: keycloakserviceaccount
     namespace: syn-appcat-control

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -53,7 +53,7 @@ spec:
           quotasEnabled: 'false'
           registry_password: ''
           registry_username: ''
-          restoreSA: mariadbrestoreserviceaccount
+          restoreSA: keycloakserviceaccount
           serviceName: keycloak
           sliNamespace: appcat-slos
         kind: ConfigMap


### PR DESCRIPTION
Previously it had the same name as MariaDB's restore account, which lead to duplicated resources in ArgoCD.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
