### PR TITLE
Explicitly specify readiness checks

### DIFF
--- a/component/component/common.libsonnet
+++ b/component/component/common.libsonnet
@@ -164,7 +164,13 @@ local defaultReadinessCheck() = {
         status: 'True',
         type: 'Ready',
       },
-
+      type: 'MatchCondition',
+    },
+    {
+      matchCondition: {
+        status: 'True',
+        type: 'Ready',
+      },
       type: 'MatchCondition',
     },
   ],

--- a/component/component/exoscale_kafka.jsonnet
+++ b/component/component/exoscale_kafka.jsonnet
@@ -93,7 +93,7 @@ local composition =
             comp.ToCompositeFieldPath('status.atProvider.version', 'status.version'),
             comp.FromCompositeFieldPath('spec.parameters.service.zone', 'metadata.annotations[appcat.vshn.io/cloudzone]'),
           ],
-        },
+        } + common.DefaultReadinessCheck(),
       ],
     },
   };

--- a/component/component/exoscale_mysql.jsonnet
+++ b/component/component/exoscale_mysql.jsonnet
@@ -96,7 +96,7 @@ local composition =
             comp.FromCompositeFieldPath('spec.parameters.backup.timeOfDay', 'spec.forProvider.backup.timeOfDay'),
             comp.FromCompositeFieldPath('spec.parameters.service.zone', 'metadata.annotations[appcat.vshn.io/cloudzone]'),
           ],
-        },
+        } + common.DefaultReadinessCheck(),
       ],
     },
   };

--- a/component/component/exoscale_opensearch.jsonnet
+++ b/component/component/exoscale_opensearch.jsonnet
@@ -95,7 +95,7 @@ local composition =
             comp.FromCompositeFieldPath('spec.parameters.backup.timeOfDay', 'spec.forProvider.backup.timeOfDay'),
             comp.FromCompositeFieldPath('spec.parameters.service.zone', 'metadata.annotations[appcat.vshn.io/cloudzone]'),
           ],
-        },
+        } + common.DefaultReadinessCheck(),
       ],
     },
   };

--- a/component/component/exoscale_postgres.jsonnet
+++ b/component/component/exoscale_postgres.jsonnet
@@ -96,7 +96,7 @@ local composition =
             comp.FromCompositeFieldPath('spec.parameters.backup.timeOfDay', 'spec.forProvider.backup.timeOfDay'),
             comp.FromCompositeFieldPath('spec.parameters.service.zone', 'metadata.annotations[appcat.vshn.io/cloudzone]'),
           ],
-        },
+        } + common.DefaultReadinessCheck(),
       ],
     },
   };

--- a/component/component/exoscale_redis.jsonnet
+++ b/component/component/exoscale_redis.jsonnet
@@ -88,7 +88,7 @@ local composition =
             comp.FromCompositeFieldPath('spec.parameters.maintenance.timeOfDay', 'spec.forProvider.maintenance.timeOfDay'),
             comp.FromCompositeFieldPath('spec.parameters.service.zone', 'metadata.annotations[appcat.vshn.io/cloudzone]'),
           ],
-        },
+        } + common.DefaultReadinessCheck(),
       ],
     },
   };

--- a/component/tests/golden/cloudscale/appcat/appcat/21_composition_objectstorage_cloudscale.yaml
+++ b/component/tests/golden/cloudscale/appcat/appcat/21_composition_objectstorage_cloudscale.yaml
@@ -76,6 +76,10 @@ spec:
             status: 'True'
             type: Ready
           type: MatchCondition
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
     - base:
         apiVersion: cloudscale.crossplane.io/v1
         kind: Bucket
@@ -138,6 +142,10 @@ spec:
               type: map
           type: FromCompositeFieldPath
       readinessChecks:
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
         - matchCondition:
             status: 'True'
             type: Ready

--- a/component/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_kafka.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_kafka.yaml
@@ -99,4 +99,13 @@ spec:
         - fromFieldPath: spec.parameters.service.zone
           toFieldPath: metadata.annotations[appcat.vshn.io/cloudzone]
           type: FromCompositeFieldPath
+      readinessChecks:
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
   writeConnectionSecretsToNamespace: crossplane-system

--- a/component/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_mysql.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_mysql.yaml
@@ -101,4 +101,13 @@ spec:
         - fromFieldPath: spec.parameters.service.zone
           toFieldPath: metadata.annotations[appcat.vshn.io/cloudzone]
           type: FromCompositeFieldPath
+      readinessChecks:
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
   writeConnectionSecretsToNamespace: crossplane-system

--- a/component/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_opensearch.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_opensearch.yaml
@@ -98,4 +98,13 @@ spec:
         - fromFieldPath: spec.parameters.service.zone
           toFieldPath: metadata.annotations[appcat.vshn.io/cloudzone]
           type: FromCompositeFieldPath
+      readinessChecks:
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
   writeConnectionSecretsToNamespace: crossplane-system

--- a/component/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_postgres.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_postgres.yaml
@@ -101,4 +101,13 @@ spec:
         - fromFieldPath: spec.parameters.service.zone
           toFieldPath: metadata.annotations[appcat.vshn.io/cloudzone]
           type: FromCompositeFieldPath
+      readinessChecks:
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
   writeConnectionSecretsToNamespace: crossplane-system

--- a/component/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_redis.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/21_composition_exoscale_redis.yaml
@@ -86,4 +86,13 @@ spec:
         - fromFieldPath: spec.parameters.service.zone
           toFieldPath: metadata.annotations[appcat.vshn.io/cloudzone]
           type: FromCompositeFieldPath
+      readinessChecks:
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
   writeConnectionSecretsToNamespace: crossplane-system

--- a/component/tests/golden/openshift/appcat/appcat/21_composition_exoscale_kafka.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/21_composition_exoscale_kafka.yaml
@@ -99,4 +99,13 @@ spec:
         - fromFieldPath: spec.parameters.service.zone
           toFieldPath: metadata.annotations[appcat.vshn.io/cloudzone]
           type: FromCompositeFieldPath
+      readinessChecks:
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
   writeConnectionSecretsToNamespace: syn-crossplane

--- a/component/tests/golden/openshift/appcat/appcat/21_composition_exoscale_mysql.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/21_composition_exoscale_mysql.yaml
@@ -101,4 +101,13 @@ spec:
         - fromFieldPath: spec.parameters.service.zone
           toFieldPath: metadata.annotations[appcat.vshn.io/cloudzone]
           type: FromCompositeFieldPath
+      readinessChecks:
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
   writeConnectionSecretsToNamespace: syn-crossplane

--- a/component/tests/golden/openshift/appcat/appcat/21_composition_exoscale_opensearch.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/21_composition_exoscale_opensearch.yaml
@@ -98,4 +98,13 @@ spec:
         - fromFieldPath: spec.parameters.service.zone
           toFieldPath: metadata.annotations[appcat.vshn.io/cloudzone]
           type: FromCompositeFieldPath
+      readinessChecks:
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
   writeConnectionSecretsToNamespace: syn-crossplane

--- a/component/tests/golden/openshift/appcat/appcat/21_composition_exoscale_postgres.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/21_composition_exoscale_postgres.yaml
@@ -101,4 +101,13 @@ spec:
         - fromFieldPath: spec.parameters.service.zone
           toFieldPath: metadata.annotations[appcat.vshn.io/cloudzone]
           type: FromCompositeFieldPath
+      readinessChecks:
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
   writeConnectionSecretsToNamespace: syn-crossplane

--- a/component/tests/golden/openshift/appcat/appcat/21_composition_exoscale_redis.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/21_composition_exoscale_redis.yaml
@@ -86,4 +86,13 @@ spec:
         - fromFieldPath: spec.parameters.service.zone
           toFieldPath: metadata.annotations[appcat.vshn.io/cloudzone]
           type: FromCompositeFieldPath
+      readinessChecks:
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
+        - matchCondition:
+            status: 'True'
+            type: Ready
+          type: MatchCondition
   writeConnectionSecretsToNamespace: syn-crossplane


### PR DESCRIPTION
On some clusters we have issues with the default readiness check, which checks for the `Ready` condition on managed resources. However this seems bugged on at least one of our clusters, as Crossplane claims the check is invalid.

By explicitly adding it with an additional check, the check is accepted again. Even though we add the exact same check twice.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
