### PR TITLE
Bump appcat version

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -52,7 +52,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.79.2
+        tag: v4.79.3
       apiserver:
         registry: ghcr.io
         repository: vshn/appcat-apiserver

--- a/component/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.79.2
+        image: ghcr.io/vshn/appcat:v4.79.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.79.2
+        image: ghcr.io/vshn/appcat:v4.79.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.79.2
+          image: ghcr.io/vshn/appcat:v4.79.3
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.79.2
+        image: ghcr.io/vshn/appcat:v4.79.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.79.2
+        image: ghcr.io/vshn/appcat:v4.79.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.79.2
+        image: ghcr.io/vshn/appcat:v4.79.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
@@ -34,7 +34,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.79.2
+          imageTag: v4.79.3
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io

--- a/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.79.2
+          image: ghcr.io/vshn/appcat:v4.79.3
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.79.2
+              image: ghcr.io/vshn/appcat:v4.79.3
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.79.2
+        image: ghcr.io/vshn/appcat:v4.79.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.79.2
+        image: ghcr.io/vshn/appcat:v4.79.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.79.2-func
+  package: ghcr.io/vshn/appcat:v4.79.3-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/vshn/appcat/appcat/20_xrd_vshn_nextcloud.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/20_xrd_vshn_nextcloud.yaml
@@ -10562,6 +10562,7 @@ spec:
                             - guaranteed
                           type: string
                         useExternalPostgreSQL:
+                          default: true
                           description: |-
                             UseExternalPostgreSQL defines if the VSHNPostgreSQL database backend should be used. Defaults to true. If set to false,
                             the build-in SQLite database is being used.

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -37,7 +37,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.79.2
+          imageTag: v4.79.3
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -37,7 +37,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.79.2
+          imageTag: v4.79.3
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -37,7 +37,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.79.2
+          imageTag: v4.79.3
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
             nginx.ingress.kubernetes.io/enable-cors: "true"

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.79.2
+          imageTag: v4.79.3
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -595,7 +595,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.79.2
+          imageTag: v4.79.3
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.79.2
+          image: ghcr.io/vshn/appcat:v4.79.3
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.79.2
+              image: ghcr.io/vshn/appcat:v4.79.3
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "true"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "true"
-        image: ghcr.io/vshn/appcat:v4.79.2
+        image: ghcr.io/vshn/appcat:v4.79.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/package/main.yaml
+++ b/package/main.yaml
@@ -7,7 +7,7 @@ parameters:
     image:
       registry: ghcr.io
       repository: vshn/appcat
-      tag: v4.79.2
+      tag: v4.79.3
   components:
     appcat:
       url: https://github.com/vshn/component-appcat.git


### PR DESCRIPTION
This fixes another bug in the kubebuilder instructions to set the default value for the `useExternalPostgreSQL` parameter

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
