### PR TITLE
Add very rudimentary backup monitoring

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -438,8 +438,6 @@ parameters:
           smtpFromAddress: myuser@example.com
           secretNamespace: syn-appcat
           secretName: mailgun-smtp-credentials
-        stsResizer:
-          enabled: true
         postgres:
           billing: true
           # bucket_region: 'lpg' || 'ch-gva-2'

--- a/component/tests/golden/apiserver/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/apiserver/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(|postgresql|redis)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(|postgresql|redis)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(|postgresql|redis)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar

--- a/component/tests/golden/cloudscale/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/cloudscale/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(|postgresql|redis)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar

--- a/component/tests/golden/controllers/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(|postgresql|redis)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar

--- a/component/tests/golden/defaults/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(|postgresql|redis)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(|postgresql|redis)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(|postgresql|redis)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar

--- a/component/tests/golden/exoscale/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(|postgresql|redis)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar

--- a/component/tests/golden/minio/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/minio/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(||minio)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar

--- a/component/tests/golden/openshift/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(|postgresql|redis)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar

--- a/component/tests/golden/vshn/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: appcat-backup
+  namespace: syn-appcat
+spec:
+  groups:
+    - name: appcat-backup
+      rules:
+        - alert: AppCatBackupJobError
+          annotations:
+            description: The backup job {{ $labels.job_name }} in namespace {{ $labels.namespace
+              }} has failed.
+            runbook_url: https://kb.vshn.ch/app-catalog/how-tos/appcat/AppCatBackupJobError.html
+            summary: AppCat service backup failed.
+          expr: kube_job_failed{job_name=~".*backup.*", namespace=~"vshn-(||keycloak|mariadb|nextcloud|postgresql|redis)-.*"}
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn_team: schedar


### PR DESCRIPTION
This adds a backup monitoring via jobs. It alerts if there's a job that has failed in any of the AppCat namespaces.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
