### PR TITLE
Remove the org label from the syn-appcat namespace

### DIFF
--- a/component/component/main.jsonnet
+++ b/component/component/main.jsonnet
@@ -84,7 +84,6 @@ local ns = kube.Namespace(params.namespace) {
   metadata+: {
     labels+: {
       'openshift.io/cluster-monitoring': 'true',
-      'appuio.io/organization': 'vshn',
     } + params.namespaceLabels,
     annotations+: params.namespaceAnnotations,
   },

--- a/component/tests/golden/apiserver/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/apiserver/appcat/appcat/10_appcat_namespace.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    appuio.io/organization: vshn
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_appcat_namespace.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    appuio.io/organization: vshn
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_appcat_namespace.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    appuio.io/organization: vshn
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/component/tests/golden/cloudscale/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/cloudscale/appcat/appcat/10_appcat_namespace.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    appuio.io/organization: vshn
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/component/tests/golden/controllers/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/10_appcat_namespace.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    appuio.io/organization: vshn
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/component/tests/golden/defaults/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/10_appcat_namespace.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    appuio.io/organization: vshn
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_appcat_namespace.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    appuio.io/organization: vshn
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_appcat_namespace.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    appuio.io/organization: vshn
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/component/tests/golden/exoscale/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/10_appcat_namespace.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    appuio.io/organization: vshn
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/component/tests/golden/minio/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/minio/appcat/appcat/10_appcat_namespace.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    appuio.io/organization: vshn
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'
   name: syn-appcat

--- a/component/tests/golden/openshift/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/10_appcat_namespace.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     openshift.io/node-selector: node-role.kubernetes.io/infra=
   labels:
-    appuio.io/organization: vshn
     foo: bar
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'

--- a/component/tests/golden/vshn/appcat/appcat/10_appcat_namespace.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/10_appcat_namespace.yaml
@@ -3,7 +3,6 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
-    appuio.io/organization: vshn
     name: syn-appcat
     openshift.io/cluster-monitoring: 'true'
   name: syn-appcat


### PR DESCRIPTION
The organization label causes all pods in that namespace to have the node selector set to a compute node (eg. flex).
However, we also have a node selector on the namespace level set to the infra nodes.
This causes all pods to have two node selectors that are mutually exclusive and results in unschedulable pods




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
