### PR TITLE
Add support for PostgreSQL 15 and 16 on Exoscale

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -52,7 +52,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.88.0
+        tag: v4.89.0
       functionAppcat:
         registry: ${appcat:images:appcat:registry}
         repository: ${appcat:images:appcat:repository}

--- a/component/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
+++ b/component/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.88.0
+          image: ghcr.io/vshn/appcat:v4.89.0
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.88.0
+        image: ghcr.io/vshn/appcat:v4.89.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.88.0
+        image: ghcr.io/vshn/appcat:v4.89.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.88.0
+          image: ghcr.io/vshn/appcat:v4.89.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.88.0
+        image: ghcr.io/vshn/appcat:v4.89.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.88.0
+        image: ghcr.io/vshn/appcat:v4.89.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.88.0
+        image: ghcr.io/vshn/appcat:v4.89.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/exoscale/appcat/appcat/20_xrd_exoscale_postgres.yaml
+++ b/component/tests/golden/exoscale/appcat/appcat/20_xrd_exoscale_postgres.yaml
@@ -108,12 +108,14 @@ spec:
                         properties
                       properties:
                         majorVersion:
-                          default: '14'
+                          default: '16'
                           description: |-
                             MajorVersion contains the major version for PostgreSQL.
-                            Currently only "14" is supported. Leave it empty to always get the latest supported version.
+                            Leave it empty to always get the latest supported version.
                           enum:
                             - '14'
+                            - '15'
+                            - '16'
                           type: string
                         pgSettings:
                           description: PGSettings contains additional PostgreSQL settings.

--- a/component/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/component/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
@@ -38,7 +38,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.88.0
+          imageTag: v4.89.0
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io

--- a/component/tests/golden/minio/appcat/appcat/apiserver/30_deployment.yaml
+++ b/component/tests/golden/minio/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.88.0
+          image: ghcr.io/vshn/appcat:v4.89.0
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.88.0
+          image: ghcr.io/vshn/appcat:v4.89.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.88.0
+              image: ghcr.io/vshn/appcat:v4.89.0
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.88.0
+        image: ghcr.io/vshn/appcat:v4.89.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/openshift/appcat/appcat/20_xrd_exoscale_postgres.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/20_xrd_exoscale_postgres.yaml
@@ -108,12 +108,14 @@ spec:
                         properties
                       properties:
                         majorVersion:
-                          default: '14'
+                          default: '16'
                           description: |-
                             MajorVersion contains the major version for PostgreSQL.
-                            Currently only "14" is supported. Leave it empty to always get the latest supported version.
+                            Leave it empty to always get the latest supported version.
                           enum:
                             - '14'
+                            - '15'
+                            - '16'
                           type: string
                         pgSettings:
                           description: PGSettings contains additional PostgreSQL settings.

--- a/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.88.0
+        image: ghcr.io/vshn/appcat:v4.89.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.88.0-func
+  package: ghcr.io/vshn/appcat:v4.89.0-func
   runtimeConfigRef:
     name: function-appcat

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -38,7 +38,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.88.0
+          imageTag: v4.89.0
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -38,7 +38,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.88.0
+          imageTag: v4.89.0
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -38,7 +38,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.88.0
+          imageTag: v4.89.0
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
             nginx.ingress.kubernetes.io/enable-cors: "true"

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.88.0
+          imageTag: v4.89.0
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -595,7 +595,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.88.0
+          imageTag: v4.89.0
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/component/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.88.0
+          image: ghcr.io/vshn/appcat:v4.89.0
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.88.0
+          image: ghcr.io/vshn/appcat:v4.89.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.88.0
+              image: ghcr.io/vshn/appcat:v4.89.0
               name: sla-reporter
               resources:
                 limits:

--- a/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/component/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "true"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "true"
-        image: ghcr.io/vshn/appcat:v4.88.0
+        image: ghcr.io/vshn/appcat:v4.89.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/package/main.yaml
+++ b/package/main.yaml
@@ -7,7 +7,7 @@ parameters:
     image:
       registry: ghcr.io
       repository: vshn/appcat
-      tag: v4.88.0
+      tag: v4.89.0
   components:
     appcat:
       url: https://github.com/vshn/component-appcat.git


### PR DESCRIPTION
This PR adds support for PostgreSQL 15 and 16 on Exoscale.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
