### PR TITLE
Fix pointer leaks by using generics

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -55,7 +55,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.92.0
+        tag: v4.92.2
       functionAppcat:
         registry: ${appcat:images:appcat:registry}
         repository: ${appcat:images:appcat:repository}

--- a/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/apiserver/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/apiserver/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.92.0
+        image: ghcr.io/vshn/appcat:v4.92.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.92.0
+        image: ghcr.io/vshn/appcat:v4.92.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/cloudscale/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/controllers/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/controllers/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/controllers/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/controllers/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/defaults/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.92.0
+        image: ghcr.io/vshn/appcat:v4.92.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.92.0
+        image: ghcr.io/vshn/appcat:v4.92.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.92.0
+        image: ghcr.io/vshn/appcat:v4.92.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/exoscale/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/exoscale/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/minio/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
@@ -38,7 +38,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.92.0
+          imageTag: v4.92.2
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io

--- a/tests/golden/minio/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/minio/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/minio/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/minio/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.92.0
+              image: ghcr.io/vshn/appcat:v4.92.2
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.92.0
+        image: ghcr.io/vshn/appcat:v4.92.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/openshift/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'false'
-          imageTag: v4.92.0
+          imageTag: v4.92.2
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/tests/golden/openshift/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_vshn_redis.yaml
@@ -569,7 +569,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.92.0
+          imageTag: v4.92.2
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/tests/golden/openshift/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/openshift/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "false"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "false"
-        image: ghcr.io/vshn/appcat:v4.92.0
+        image: ghcr.io/vshn/appcat:v4.92.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_function_appcat.yaml
@@ -3,6 +3,6 @@ kind: Function
 metadata:
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.92.0-func
+  package: ghcr.io/vshn/appcat:v4.92.2-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -38,7 +38,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.92.0
+          imageTag: v4.92.2
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -38,7 +38,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.92.0
+          imageTag: v4.92.2
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -38,7 +38,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.92.0
+          imageTag: v4.92.2
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
             nginx.ingress.kubernetes.io/enable-cors: "true"

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
           externalDatabaseConnectionsEnabled: 'true'
-          imageTag: v4.92.0
+          imageTag: v4.92.2
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -595,7 +595,7 @@ spec:
           emailAlertingSmtpFromAddress: myuser@example.com
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: myuser@example.com
-          imageTag: v4.92.0
+          imageTag: v4.92.2
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.92.0
+          image: ghcr.io/vshn/appcat:v4.92.2
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/vshn/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.92.0
+              image: ghcr.io/vshn/appcat:v4.92.2
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
           value: "true"
         - name: APPCAT_SLI_VSHNMARIADB
           value: "true"
-        image: ghcr.io/vshn/appcat:v4.92.0
+        image: ghcr.io/vshn/appcat:v4.92.2
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
We re-used the same pointer for every single reconcile of any given
service type. This could lead to leaking settings between the instances.
Resulting in instances enabling features that aren't actually enabled in
the claim belonging to the instance.
    
This change gets rid of the pointer by leveraging generics and reflect.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
