### PR TITLE
Sane Opsgenie alerting

### DIFF
--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -86,7 +86,7 @@ local generateSlothInput(name, uptime) =
           },
           labels+: {
             service: 'VSHN' + name,
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end }}',
+            OnCall: false,
           },
         },
       },
@@ -104,7 +104,7 @@ local generateSlothInput(name, uptime) =
           },
           labels+: {
             service: 'VSHN' + name,
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end }}',
+            OnCall: false,
           },
         },
       },

--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -86,7 +86,6 @@ local generateSlothInput(name, uptime) =
           },
           labels+: {
             service: 'VSHN' + name,
-            OnCall: false,
           },
         },
       },
@@ -104,7 +103,6 @@ local generateSlothInput(name, uptime) =
           },
           labels+: {
             service: 'VSHN' + name,
-            OnCall: false,
           },
         },
       },

--- a/component/slos.libsonnet
+++ b/component/slos.libsonnet
@@ -17,7 +17,6 @@ local newSLO(name, group, sloParams) =
     name: name,
     objective: sloParams.objective,
     alerting: {
-      labels: params.slos.alerting.labels,
       page_alert: {
         labels: params.slos.alerting.page_labels,
         annotations: {

--- a/component/vshn_alerting.jsonnet
+++ b/component/vshn_alerting.jsonnet
@@ -27,12 +27,13 @@ local genGenericAlertingRule(serviceName) = {
             // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 45 seconds
             expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[1m]) > 0.75',
             labels: {
+              OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end }}',
+              runbook: 'https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html',
               service: serviceName,
               severity: 'critical',
               syn: 'true',
               syn_team: 'schedar',
               syn_component: 'appcat',
-              OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end }}',
             },
           },
           {
@@ -41,12 +42,13 @@ local genGenericAlertingRule(serviceName) = {
             // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 45 seconds
             expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true"}[1m]) > 0.75',
             labels: {
+              OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end }}',
+              runbook: 'https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html',
               service: serviceName,
               severity: 'critical',
               syn: 'true',
               syn_team: 'schedar',
               syn_component: 'appcat',
-              OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end }}',
             },
           },
         ],

--- a/component/vshn_alerting.jsonnet
+++ b/component/vshn_alerting.jsonnet
@@ -10,6 +10,10 @@ local genGenericAlertingRule(serviceName) = {
   metadata: {
     name: 'vshn-' + std.asciiLower(serviceName) + '-opsgenie',
     namespace: params.slos.namespace,
+    labels: {
+      syn_team: 'schedar',
+      syn_component: 'appcat',
+    },
   },
   spec: {
     groups: [

--- a/component/vshn_alerting.jsonnet
+++ b/component/vshn_alerting.jsonnet
@@ -8,11 +8,12 @@ local genGenericAlertingRule(serviceName) = {
   apiVersion: 'monitoring.coreos.com/v1',
   kind: 'PrometheusRule',
   metadata: {
-    name: 'vshn-' + std.asciiLower(serviceName) + '-opsgenie',
+    name: 'vshn-' + std.asciiLower(serviceName) + '-sla',
     namespace: params.slos.namespace,
     labels: {
       syn_team: 'schedar',
       syn_component: 'appcat',
+      syn: 'true',
     },
   },
   spec: {
@@ -21,24 +22,30 @@ local genGenericAlertingRule(serviceName) = {
         name: 'appcat-' + std.asciiLower(serviceName) + '-sla-target',
         rules: [
           {
-            alert: 'vshn-' + std.asciiLower(serviceName) + '-opsgenie',
+            alert: 'vshn-' + std.asciiLower(serviceName) + '-sla',
             // this query can be read as: if the rate of probes that are not successful is higher than 0.2 in the last 5 minutes and in the last minute, then alert
             // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 45 seconds
             expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[1m]) > 0.75',
             labels: {
               service: serviceName,
-              severity: 'warning',
+              severity: 'critical',
+              syn: 'true',
+              syn_team: 'schedar',
+              syn_component: 'appcat',
               OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end }}',
             },
           },
           {
-            alert: 'vshn-' + std.asciiLower(serviceName) + '-opsgenie-ha',
+            alert: 'vshn-' + std.asciiLower(serviceName) + '-sla-ha',
             // this query can be read as: if the rate of probes that are not successful is higher than 0.2 in the last 5 minutes and in the last minute, then alert
             // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 45 seconds
             expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true"}[1m]) > 0.75',
             labels: {
               service: serviceName,
-              severity: 'warning',
+              severity: 'critical',
+              syn: 'true',
+              syn_team: 'schedar',
+              syn_component: 'appcat',
               OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end }}',
             },
           },

--- a/component/vshn_alerting.jsonnet
+++ b/component/vshn_alerting.jsonnet
@@ -24,7 +24,7 @@ local genGenericAlertingRule(serviceName) = {
             labels: {
               service: serviceName,
               severity: 'warning',
-              OnCall: 'true',
+              OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end }}',
             },
           },
           {

--- a/component/vshn_alerting.jsonnet
+++ b/component/vshn_alerting.jsonnet
@@ -1,0 +1,50 @@
+local kap = import 'lib/kapitan.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.appcat;
+
+
+local genGenericAlertingRule(serviceName) = {
+  apiVersion: 'monitoring.coreos.com/v1',
+  kind: 'PrometheusRule',
+  metadata: {
+    name: 'vshn-' + std.asciiLower(serviceName) + '-opsgenie',
+    namespace: params.slos.namespace,
+  },
+  spec: {
+    groups: [
+      {
+        name: 'appcat-' + std.asciiLower(serviceName) + '-sla-target',
+        rules: [
+          {
+            alert: 'vshn-' + std.asciiLower(serviceName) + '-opsgenie',
+            // this query can be read as: if the rate of probes that are not successful is higher than 0.2 in the last 5 minutes and in the last minute, then alert
+            // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 12 seconds
+            expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[1m]) > 0.2',
+            labels: {
+              service: serviceName,
+              severity: 'warning',
+              OnCall: 'true',
+            },
+          },
+          {
+            alert: 'vshn-' + std.asciiLower(serviceName) + '-opsgenie-ha',
+            // this query can be read as: if the rate of probes that are not successful is higher than 0.2 in the last 5 minutes and in the last minute, then alert
+            // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 12 seconds
+            expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true", maintenance="false"}[1m]) > 0.2',
+            labels: {
+              service: serviceName,
+              severity: 'warning',
+              OnCall: 'true',
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+
+
+{
+  GenGenericAlertingRule: genGenericAlertingRule,
+}

--- a/component/vshn_alerting.jsonnet
+++ b/component/vshn_alerting.jsonnet
@@ -35,7 +35,7 @@ local genGenericAlertingRule(serviceName) = {
             labels: {
               service: serviceName,
               severity: 'warning',
-              OnCall: 'true',
+              OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end }}',
             },
           },
         ],

--- a/component/vshn_alerting.jsonnet
+++ b/component/vshn_alerting.jsonnet
@@ -19,8 +19,8 @@ local genGenericAlertingRule(serviceName) = {
           {
             alert: 'vshn-' + std.asciiLower(serviceName) + '-opsgenie',
             // this query can be read as: if the rate of probes that are not successful is higher than 0.2 in the last 5 minutes and in the last minute, then alert
-            // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 12 seconds
-            expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[1m]) > 0.2',
+            // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 45 seconds
+            expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[1m]) > 0.75',
             labels: {
               service: serviceName,
               severity: 'warning',
@@ -30,8 +30,8 @@ local genGenericAlertingRule(serviceName) = {
           {
             alert: 'vshn-' + std.asciiLower(serviceName) + '-opsgenie-ha',
             // this query can be read as: if the rate of probes that are not successful is higher than 0.2 in the last 5 minutes and in the last minute, then alert
-            // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 12 seconds
-            expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true", maintenance="false"}[1m]) > 0.2',
+            // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 45 seconds
+            expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true"}[1m]) > 0.75',
             labels: {
               service: serviceName,
               severity: 'warning',

--- a/component/vshn_appcat_services.jsonnet
+++ b/component/vshn_appcat_services.jsonnet
@@ -10,6 +10,8 @@ local prom = import 'prometheus.libsonnet';
 local xrds = import 'xrds.libsonnet';
 
 local slos = import 'slos.libsonnet';
+local opsgenieRules = import 'vshn_alerting.jsonnet';
+
 
 local inv = kap.inventory();
 local params = inv.parameters.appcat;
@@ -188,6 +190,8 @@ local vshn_appcat_service(name, serviceParams) =
     [if isOpenshift && std.objectHas(serviceParams, 'openshiftTemplate') then '21_openshift_template_%s_vshn' % name]: osTemplate,
     [if params.services.vshn.enabled && serviceParams.enabled then 'sli_exporter/90_slo_vshn_%s' % name]: slos.Get('vshn-' + name),
     [if params.services.vshn.enabled && serviceParams.enabled then 'sli_exporter/90_slo_vshn_%s_ha' % name]: slos.Get('vshn-' + name + '-ha'),
+    ['sli_exporter/90_%s_Opsgenie' % name]: opsgenieRules.GenGenericAlertingRule(name),
+
   } else {}
 ;
 

--- a/component/vshn_minio.jsonnet
+++ b/component/vshn_minio.jsonnet
@@ -7,7 +7,7 @@ local common = import 'common.libsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local minioParams = params.services.vshn.minio;
-
+local opsgenieRules = import 'vshn_alerting.jsonnet';
 
 local instances = [
   kube._Object('vshn.appcat.vshn.io/v1', 'VSHNMinio', instance.name) +
@@ -29,4 +29,6 @@ local instances = [
 
 if params.services.vshn.enabled && minioParams.enabled && std.length(instances) != 0 then {
   '22_minio_instances': instances,
+  'sli_exporter/90_VSHNMinio_Opsgenie': opsgenieRules.GenGenericAlertingRule('VSHNMinio'),
+
 } else {}

--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -12,6 +12,7 @@ local xrds = import 'xrds.libsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local pgParams = params.services.vshn.postgres;
+local opsgenieRules = import 'vshn_alerting.jsonnet';
 
 local defaultDB = 'postgres';
 local defaultUser = 'postgres';
@@ -307,4 +308,6 @@ if params.services.vshn.enabled && pgParams.enabled then
     [if isOpenshift then '12_stackgres_openshift_operator_netpol']: stackgresNetworkPolicy,
     [if params.slos.enabled && params.services.vshn.enabled && params.services.vshn.postgres.enabled then 'sli_exporter/90_slo_vshn_postgresql']: slos.Get('vshn-postgresql'),
     [if params.slos.enabled && params.services.vshn.enabled && params.services.vshn.postgres.enabled then 'sli_exporter/90_slo_vshn_postgresql_ha']: slos.Get('vshn-postgresql-ha'),
+    [if params.services.vshn.enabled && params.services.vshn.postgres.enabled then 'sli_exporter/90_VSHNPostgreSQL_Opsgenie']: opsgenieRules.GenGenericAlertingRule('VSHNPostgreSQL'),
+
   } else {}

--- a/component/vshn_redis.jsonnet
+++ b/component/vshn_redis.jsonnet
@@ -13,6 +13,7 @@ local xrds = import 'xrds.libsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local redisParams = params.services.vshn.redis;
+local opsgenieRules = import 'vshn_alerting.jsonnet';
 
 local defaultUser = 'default';
 local defaultPort = '6379';
@@ -566,4 +567,5 @@ if params.services.vshn.enabled && redisParams.enabled then {
   [if isOpenshift then '21_openshift_template_redis_vshn']: osTemplate,
   [if params.services.vshn.enabled && params.services.vshn.redis.enabled then 'sli_exporter/90_slo_vshn_redis']: slos.Get('vshn-redis'),
   [if params.services.vshn.enabled && params.services.vshn.redis.enabled then 'sli_exporter/90_slo_vshn_redis_ha']: slos.Get('vshn-redis-ha'),
+  [if params.services.vshn.enabled && params.services.vshn.redis.enabled then 'sli_exporter/90_VSHNRedis_Opsgenie']: opsgenieRules.GenGenericAlertingRule('VSHNRedis'),
 } else {}

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
@@ -12,7 +12,8 @@ spec:
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="minio", ha="false", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: minio
             severity: warning
         - alert: vshn-minio-opsgenie-ha
@@ -20,6 +21,7 @@ spec:
             ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="minio", ha="true", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: minio
             severity: warning

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vshn-minio-opsgenie
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-minio-sla-target
+      rules:
+        - alert: vshn-minio-opsgenie
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="minio",
+            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="minio", ha="false", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: minio
+            severity: warning
+        - alert: vshn-minio-opsgenie-ha
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="minio",
+            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="minio", ha="true", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: minio
+            severity: warning

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
@@ -18,6 +18,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: minio
             severity: critical
             syn: 'true'
@@ -30,6 +31,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: minio
             severity: critical
             syn: 'true'

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
@@ -10,7 +10,7 @@ spec:
         - alert: vshn-minio-opsgenie
           expr: rate(appcat_probes_seconds_count{reason!="success", service="minio",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="minio", ha="false", maintenance="false"}[1m]) > 0.2
+            service="minio", ha="false", maintenance="false"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -18,8 +18,8 @@ spec:
             severity: warning
         - alert: vshn-minio-opsgenie-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="minio",
-            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="minio", ha="true", maintenance="false"}[1m]) > 0.2
+            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="minio", ha="true"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
@@ -2,15 +2,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    syn: 'true'
     syn_component: appcat
     syn_team: schedar
-  name: vshn-minio-opsgenie
+  name: vshn-minio-sla
   namespace: appcat-slos
 spec:
   groups:
     - name: appcat-minio-sla-target
       rules:
-        - alert: vshn-minio-opsgenie
+        - alert: vshn-minio-sla
           expr: rate(appcat_probes_seconds_count{reason!="success", service="minio",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="minio", ha="false", maintenance="false"}[1m]) > 0.75
@@ -18,8 +19,11 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: minio
-            severity: warning
-        - alert: vshn-minio-opsgenie-ha
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar
+        - alert: vshn-minio-sla-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="minio",
             ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="minio", ha="true"}[1m]) > 0.75
@@ -27,4 +31,7 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: minio
-            severity: warning
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_minio_Opsgenie.yaml
@@ -1,6 +1,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  labels:
+    syn_component: appcat
+    syn_team: schedar
   name: vshn-minio-opsgenie
   namespace: appcat-slos
 spec:

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNMinio
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-minio-uptime", sloth_service="appcat-vshn-minio", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNMinio
             severity: warning
             slo: 'true'

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNMinio
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-minio-uptime", sloth_service="appcat-vshn-minio", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNMinio
             severity: warning
             slo: 'true'

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNMinio
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_VSHNMinioUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-minio.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNMinio
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio_ha.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio_ha.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNMinio
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-minio-ha-uptime", sloth_service="appcat-vshn-minio-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNMinio
             severity: warning
             slo: 'true'

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio_ha.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio_ha.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNMinio
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-minio-ha-uptime", sloth_service="appcat-vshn-minio-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNMinio
             severity: warning
             slo: 'true'

--- a/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio_ha.yaml
+++ b/tests/golden/minio/appcat/appcat/sli_exporter/90_slo_vshn_minio_ha.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNMinio
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_HAVSHNMinioUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-minio.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNMinio
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -10,7 +10,7 @@ spec:
         - alert: vshn-vshnpostgresql-opsgenie
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.2
+            service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -18,8 +18,8 @@ spec:
             severity: warning
         - alert: vshn-vshnpostgresql-opsgenie-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
-            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="true", maintenance="false"}[1m]) > 0.2
+            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNPostgreSQL", ha="true"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -12,7 +12,8 @@ spec:
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: VSHNPostgreSQL
             severity: warning
         - alert: vshn-vshnpostgresql-opsgenie-ha
@@ -20,6 +21,7 @@ spec:
             ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNPostgreSQL", ha="true", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: VSHNPostgreSQL
             severity: warning

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -2,15 +2,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    syn: 'true'
     syn_component: appcat
     syn_team: schedar
-  name: vshn-vshnpostgresql-opsgenie
+  name: vshn-vshnpostgresql-sla
   namespace: appcat-slos
 spec:
   groups:
     - name: appcat-vshnpostgresql-sla-target
       rules:
-        - alert: vshn-vshnpostgresql-opsgenie
+        - alert: vshn-vshnpostgresql-sla
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.75
@@ -18,8 +19,11 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: VSHNPostgreSQL
-            severity: warning
-        - alert: vshn-vshnpostgresql-opsgenie-ha
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar
+        - alert: vshn-vshnpostgresql-sla-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
             ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNPostgreSQL", ha="true"}[1m]) > 0.75
@@ -27,4 +31,7 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: VSHNPostgreSQL
-            severity: warning
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vshn-vshnpostgresql-opsgenie
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-vshnpostgresql-sla-target
+      rules:
+        - alert: vshn-vshnpostgresql-opsgenie
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
+            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: VSHNPostgreSQL
+            severity: warning
+        - alert: vshn-vshnpostgresql-opsgenie-ha
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
+            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNPostgreSQL", ha="true", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: VSHNPostgreSQL
+            severity: warning

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -18,6 +18,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: VSHNPostgreSQL
             severity: critical
             syn: 'true'
@@ -30,6 +31,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: VSHNPostgreSQL
             severity: critical
             syn: 'true'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -1,6 +1,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  labels:
+    syn_component: appcat
+    syn_team: schedar
   name: vshn-vshnpostgresql-opsgenie
   namespace: appcat-slos
 spec:

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -2,15 +2,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    syn: 'true'
     syn_component: appcat
     syn_team: schedar
-  name: vshn-vshnredis-opsgenie
+  name: vshn-vshnredis-sla
   namespace: appcat-slos
 spec:
   groups:
     - name: appcat-vshnredis-sla-target
       rules:
-        - alert: vshn-vshnredis-opsgenie
+        - alert: vshn-vshnredis-sla
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.75
@@ -18,8 +19,11 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: VSHNRedis
-            severity: warning
-        - alert: vshn-vshnredis-opsgenie-ha
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar
+        - alert: vshn-vshnredis-sla-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
             ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNRedis", ha="true"}[1m]) > 0.75
@@ -27,4 +31,7 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: VSHNRedis
-            severity: warning
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vshn-vshnredis-opsgenie
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-vshnredis-sla-target
+      rules:
+        - alert: vshn-vshnredis-opsgenie
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
+            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: VSHNRedis
+            severity: warning
+        - alert: vshn-vshnredis-opsgenie-ha
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
+            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNRedis", ha="true", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: VSHNRedis
+            severity: warning

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -12,7 +12,8 @@ spec:
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: VSHNRedis
             severity: warning
         - alert: vshn-vshnredis-opsgenie-ha
@@ -20,6 +21,7 @@ spec:
             ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNRedis", ha="true", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: VSHNRedis
             severity: warning

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -10,7 +10,7 @@ spec:
         - alert: vshn-vshnredis-opsgenie
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.2
+            service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -18,8 +18,8 @@ spec:
             severity: warning
         - alert: vshn-vshnredis-opsgenie-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
-            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="true", maintenance="false"}[1m]) > 0.2
+            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNRedis", ha="true"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -1,6 +1,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  labels:
+    syn_component: appcat
+    syn_team: schedar
   name: vshn-vshnredis-opsgenie
   namespace: appcat-slos
 spec:

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -18,6 +18,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: VSHNRedis
             severity: critical
             syn: 'true'
@@ -30,6 +31,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: VSHNRedis
             severity: critical
             syn: 'true'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: warning
             slo: 'true'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: warning
             slo: 'true'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNPostgreSQL
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_VSHNPostgreSQLUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-postgresql.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNPostgreSQL
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-postgresql-ha-uptime", sloth_service="appcat-vshn-postgresql-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: warning
             slo: 'true'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-postgresql-ha-uptime", sloth_service="appcat-vshn-postgresql-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: warning
             slo: 'true'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNPostgreSQL
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_HAVSHNPostgreSQLUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-postgresql.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNPostgreSQL
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNRedis
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-redis-uptime", sloth_service="appcat-vshn-redis", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNRedis
             severity: warning
             slo: 'true'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNRedis
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_VSHNRedisUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-redis.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNRedis
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNRedis
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-redis-uptime", sloth_service="appcat-vshn-redis", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNRedis
             severity: warning
             slo: 'true'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNRedis
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-redis-ha-uptime", sloth_service="appcat-vshn-redis-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNRedis
             severity: warning
             slo: 'true'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNRedis
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-redis-ha-uptime", sloth_service="appcat-vshn-redis-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNRedis
             severity: warning
             slo: 'true'

--- a/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
+++ b/tests/golden/openshift/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNRedis
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_HAVSHNRedisUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-redis.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNRedis
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -10,7 +10,7 @@ spec:
         - alert: vshn-vshnpostgresql-opsgenie
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.2
+            service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -18,8 +18,8 @@ spec:
             severity: warning
         - alert: vshn-vshnpostgresql-opsgenie-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
-            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="true", maintenance="false"}[1m]) > 0.2
+            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNPostgreSQL", ha="true"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -12,7 +12,8 @@ spec:
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: VSHNPostgreSQL
             severity: warning
         - alert: vshn-vshnpostgresql-opsgenie-ha
@@ -20,6 +21,7 @@ spec:
             ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNPostgreSQL", ha="true", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: VSHNPostgreSQL
             severity: warning

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -2,15 +2,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    syn: 'true'
     syn_component: appcat
     syn_team: schedar
-  name: vshn-vshnpostgresql-opsgenie
+  name: vshn-vshnpostgresql-sla
   namespace: appcat-slos
 spec:
   groups:
     - name: appcat-vshnpostgresql-sla-target
       rules:
-        - alert: vshn-vshnpostgresql-opsgenie
+        - alert: vshn-vshnpostgresql-sla
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.75
@@ -18,8 +19,11 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: VSHNPostgreSQL
-            severity: warning
-        - alert: vshn-vshnpostgresql-opsgenie-ha
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar
+        - alert: vshn-vshnpostgresql-sla-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
             ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNPostgreSQL", ha="true"}[1m]) > 0.75
@@ -27,4 +31,7 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: VSHNPostgreSQL
-            severity: warning
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vshn-vshnpostgresql-opsgenie
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-vshnpostgresql-sla-target
+      rules:
+        - alert: vshn-vshnpostgresql-opsgenie
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
+            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: VSHNPostgreSQL
+            severity: warning
+        - alert: vshn-vshnpostgresql-opsgenie-ha
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
+            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNPostgreSQL", ha="true", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: VSHNPostgreSQL
+            severity: warning

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -18,6 +18,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: VSHNPostgreSQL
             severity: critical
             syn: 'true'
@@ -30,6 +31,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: VSHNPostgreSQL
             severity: critical
             syn: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -1,6 +1,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  labels:
+    syn_component: appcat
+    syn_team: schedar
   name: vshn-vshnpostgresql-opsgenie
   namespace: appcat-slos
 spec:

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -2,15 +2,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    syn: 'true'
     syn_component: appcat
     syn_team: schedar
-  name: vshn-vshnredis-opsgenie
+  name: vshn-vshnredis-sla
   namespace: appcat-slos
 spec:
   groups:
     - name: appcat-vshnredis-sla-target
       rules:
-        - alert: vshn-vshnredis-opsgenie
+        - alert: vshn-vshnredis-sla
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.75
@@ -18,8 +19,11 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: VSHNRedis
-            severity: warning
-        - alert: vshn-vshnredis-opsgenie-ha
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar
+        - alert: vshn-vshnredis-sla-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
             ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNRedis", ha="true"}[1m]) > 0.75
@@ -27,4 +31,7 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: VSHNRedis
-            severity: warning
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vshn-vshnredis-opsgenie
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-vshnredis-sla-target
+      rules:
+        - alert: vshn-vshnredis-opsgenie
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
+            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: VSHNRedis
+            severity: warning
+        - alert: vshn-vshnredis-opsgenie-ha
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
+            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNRedis", ha="true", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: VSHNRedis
+            severity: warning

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -12,7 +12,8 @@ spec:
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: VSHNRedis
             severity: warning
         - alert: vshn-vshnredis-opsgenie-ha
@@ -20,6 +21,7 @@ spec:
             ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="VSHNRedis", ha="true", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: VSHNRedis
             severity: warning

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -10,7 +10,7 @@ spec:
         - alert: vshn-vshnredis-opsgenie
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.2
+            service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -18,8 +18,8 @@ spec:
             severity: warning
         - alert: vshn-vshnredis-opsgenie-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
-            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="true", maintenance="false"}[1m]) > 0.2
+            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="VSHNRedis", ha="true"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -1,6 +1,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  labels:
+    syn_component: appcat
+    syn_team: schedar
   name: vshn-vshnredis-opsgenie
   namespace: appcat-slos
 spec:

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -18,6 +18,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: VSHNRedis
             severity: critical
             syn: 'true'
@@ -30,6 +31,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: VSHNRedis
             severity: critical
             syn: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
@@ -10,7 +10,7 @@ spec:
         - alert: vshn-keycloak-opsgenie
           expr: rate(appcat_probes_seconds_count{reason!="success", service="keycloak",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="keycloak", ha="false", maintenance="false"}[1m]) > 0.2
+            service="keycloak", ha="false", maintenance="false"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -18,8 +18,8 @@ spec:
             severity: warning
         - alert: vshn-keycloak-opsgenie-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="keycloak",
-            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="keycloak", ha="true", maintenance="false"}[1m]) > 0.2
+            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="keycloak", ha="true"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
@@ -18,6 +18,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: keycloak
             severity: critical
             syn: 'true'
@@ -30,6 +31,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: keycloak
             severity: critical
             syn: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
@@ -12,7 +12,8 @@ spec:
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="keycloak", ha="false", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: keycloak
             severity: warning
         - alert: vshn-keycloak-opsgenie-ha
@@ -20,6 +21,7 @@ spec:
             ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="keycloak", ha="true", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: keycloak
             severity: warning

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
@@ -1,6 +1,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  labels:
+    syn_component: appcat
+    syn_team: schedar
   name: vshn-keycloak-opsgenie
   namespace: appcat-slos
 spec:

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
@@ -2,15 +2,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    syn: 'true'
     syn_component: appcat
     syn_team: schedar
-  name: vshn-keycloak-opsgenie
+  name: vshn-keycloak-sla
   namespace: appcat-slos
 spec:
   groups:
     - name: appcat-keycloak-sla-target
       rules:
-        - alert: vshn-keycloak-opsgenie
+        - alert: vshn-keycloak-sla
           expr: rate(appcat_probes_seconds_count{reason!="success", service="keycloak",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="keycloak", ha="false", maintenance="false"}[1m]) > 0.75
@@ -18,8 +19,11 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: keycloak
-            severity: warning
-        - alert: vshn-keycloak-opsgenie-ha
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar
+        - alert: vshn-keycloak-sla-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="keycloak",
             ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="keycloak", ha="true"}[1m]) > 0.75
@@ -27,4 +31,7 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: keycloak
-            severity: warning
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_keycloak_Opsgenie.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vshn-keycloak-opsgenie
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-keycloak-sla-target
+      rules:
+        - alert: vshn-keycloak-opsgenie
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="keycloak",
+            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="keycloak", ha="false", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: keycloak
+            severity: warning
+        - alert: vshn-keycloak-opsgenie-ha
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="keycloak",
+            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="keycloak", ha="true", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: keycloak
+            severity: warning

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vshn-mariadb-opsgenie
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-mariadb-sla-target
+      rules:
+        - alert: vshn-mariadb-opsgenie
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="mariadb",
+            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="mariadb", ha="false", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: mariadb
+            severity: warning
+        - alert: vshn-mariadb-opsgenie-ha
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="mariadb",
+            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="mariadb", ha="true", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: mariadb
+            severity: warning

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
@@ -10,7 +10,7 @@ spec:
         - alert: vshn-mariadb-opsgenie
           expr: rate(appcat_probes_seconds_count{reason!="success", service="mariadb",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="mariadb", ha="false", maintenance="false"}[1m]) > 0.2
+            service="mariadb", ha="false", maintenance="false"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -18,8 +18,8 @@ spec:
             severity: warning
         - alert: vshn-mariadb-opsgenie-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="mariadb",
-            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="mariadb", ha="true", maintenance="false"}[1m]) > 0.2
+            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="mariadb", ha="true"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
@@ -18,6 +18,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: mariadb
             severity: critical
             syn: 'true'
@@ -30,6 +31,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: mariadb
             severity: critical
             syn: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
@@ -12,7 +12,8 @@ spec:
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="mariadb", ha="false", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: mariadb
             severity: warning
         - alert: vshn-mariadb-opsgenie-ha
@@ -20,6 +21,7 @@ spec:
             ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="mariadb", ha="true", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: mariadb
             severity: warning

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
@@ -1,6 +1,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  labels:
+    syn_component: appcat
+    syn_team: schedar
   name: vshn-mariadb-opsgenie
   namespace: appcat-slos
 spec:

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_mariadb_Opsgenie.yaml
@@ -2,15 +2,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    syn: 'true'
     syn_component: appcat
     syn_team: schedar
-  name: vshn-mariadb-opsgenie
+  name: vshn-mariadb-sla
   namespace: appcat-slos
 spec:
   groups:
     - name: appcat-mariadb-sla-target
       rules:
-        - alert: vshn-mariadb-opsgenie
+        - alert: vshn-mariadb-sla
           expr: rate(appcat_probes_seconds_count{reason!="success", service="mariadb",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="mariadb", ha="false", maintenance="false"}[1m]) > 0.75
@@ -18,8 +19,11 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: mariadb
-            severity: warning
-        - alert: vshn-mariadb-opsgenie-ha
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar
+        - alert: vshn-mariadb-sla-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="mariadb",
             ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="mariadb", ha="true"}[1m]) > 0.75
@@ -27,4 +31,7 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: mariadb
-            severity: warning
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
@@ -2,15 +2,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    syn: 'true'
     syn_component: appcat
     syn_team: schedar
-  name: vshn-nextcloud-opsgenie
+  name: vshn-nextcloud-sla
   namespace: appcat-slos
 spec:
   groups:
     - name: appcat-nextcloud-sla-target
       rules:
-        - alert: vshn-nextcloud-opsgenie
+        - alert: vshn-nextcloud-sla
           expr: rate(appcat_probes_seconds_count{reason!="success", service="nextcloud",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="nextcloud", ha="false", maintenance="false"}[1m]) > 0.75
@@ -18,8 +19,11 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: nextcloud
-            severity: warning
-        - alert: vshn-nextcloud-opsgenie-ha
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar
+        - alert: vshn-nextcloud-sla-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="nextcloud",
             ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="nextcloud", ha="true"}[1m]) > 0.75
@@ -27,4 +31,7 @@ spec:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
             service: nextcloud
-            severity: warning
+            severity: critical
+            syn: 'true'
+            syn_component: appcat
+            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
@@ -18,6 +18,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: nextcloud
             severity: critical
             syn: 'true'
@@ -30,6 +31,7 @@ spec:
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
+            runbook: https://kb.vshn.ch/app-catalog/how-tos/appcat/GuaranteedUptimeTarget.html
             service: nextcloud
             severity: critical
             syn: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vshn-nextcloud-opsgenie
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-nextcloud-sla-target
+      rules:
+        - alert: vshn-nextcloud-opsgenie
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="nextcloud",
+            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="nextcloud", ha="false", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: nextcloud
+            severity: warning
+        - alert: vshn-nextcloud-opsgenie-ha
+          expr: rate(appcat_probes_seconds_count{reason!="success", service="nextcloud",
+            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="nextcloud", ha="true", maintenance="false"}[1m]) > 0.2
+          labels:
+            OnCall: 'true'
+            service: nextcloud
+            severity: warning

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
@@ -1,6 +1,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  labels:
+    syn_component: appcat
+    syn_team: schedar
   name: vshn-nextcloud-opsgenie
   namespace: appcat-slos
 spec:

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
@@ -12,7 +12,8 @@ spec:
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="nextcloud", ha="false", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: nextcloud
             severity: warning
         - alert: vshn-nextcloud-opsgenie-ha
@@ -20,6 +21,7 @@ spec:
             ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
             service="nextcloud", ha="true", maintenance="false"}[1m]) > 0.2
           labels:
-            OnCall: 'true'
+            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
+              }}'
             service: nextcloud
             severity: warning

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_nextcloud_Opsgenie.yaml
@@ -10,7 +10,7 @@ spec:
         - alert: vshn-nextcloud-opsgenie
           expr: rate(appcat_probes_seconds_count{reason!="success", service="nextcloud",
             ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="nextcloud", ha="false", maintenance="false"}[1m]) > 0.2
+            service="nextcloud", ha="false", maintenance="false"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -18,8 +18,8 @@ spec:
             severity: warning
         - alert: vshn-nextcloud-opsgenie-ha
           expr: rate(appcat_probes_seconds_count{reason!="success", service="nextcloud",
-            ha="true", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="nextcloud", ha="true", maintenance="false"}[1m]) > 0.2
+            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
+            service="nextcloud", ha="true"}[1m]) > 0.75
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNKeycloak
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNKeycloak
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNKeycloak
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_VSHNKeycloakUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-keycloak.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNKeycloak
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNKeycloak
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-keycloak-uptime", sloth_service="appcat-vshn-keycloak", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNKeycloak
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak_ha.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNKeycloak
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNKeycloak
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak_ha.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNKeycloak
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_HAVSHNKeycloakUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-keycloak.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNKeycloak
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_keycloak_ha.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNKeycloak
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-keycloak-ha-uptime", sloth_service="appcat-vshn-keycloak-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNKeycloak
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNMariaDB
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-mariadb-uptime", sloth_service="appcat-vshn-mariadb", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNMariaDB
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNMariaDB
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-mariadb-uptime", sloth_service="appcat-vshn-mariadb", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNMariaDB
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNMariaDB
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_VSHNMariaDBUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-mariadb.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNMariaDB
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb_ha.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNMariaDB
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-mariadb-ha-uptime", sloth_service="appcat-vshn-mariadb-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNMariaDB
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb_ha.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNMariaDB
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_HAVSHNMariaDBUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-mariadb.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNMariaDB
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_mariadb_ha.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNMariaDB
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-mariadb-ha-uptime", sloth_service="appcat-vshn-mariadb-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNMariaDB
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNNextcloud
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-nextcloud-uptime", sloth_service="appcat-vshn-nextcloud", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNNextcloud
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNNextcloud
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_VSHNNextcloudUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-nextcloud.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNNextcloud
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNNextcloud
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-nextcloud-uptime", sloth_service="appcat-vshn-nextcloud", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNNextcloud
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud_ha.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNNextcloud
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_HAVSHNNextcloudUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-nextcloud.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNNextcloud
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud_ha.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNNextcloud
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-nextcloud-ha-uptime", sloth_service="appcat-vshn-nextcloud-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNNextcloud
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_nextcloud_ha.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNNextcloud
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-nextcloud-ha-uptime", sloth_service="appcat-vshn-nextcloud-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNNextcloud
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-postgresql-uptime", sloth_service="appcat-vshn-postgresql", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNPostgreSQL
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_VSHNPostgreSQLUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-postgresql.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNPostgreSQL
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-postgresql-ha-uptime", sloth_service="appcat-vshn-postgresql-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-postgresql-ha-uptime", sloth_service="appcat-vshn-postgresql-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNPostgreSQL
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_postgresql_ha.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNPostgreSQL
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_HAVSHNPostgreSQLUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-postgresql.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNPostgreSQL
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNRedis
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-redis-uptime", sloth_service="appcat-vshn-redis", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNRedis
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNRedis
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_VSHNRedisUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-redis.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNRedis
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNRedis
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-redis-uptime", sloth_service="appcat-vshn-redis", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNRedis
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
@@ -166,8 +166,7 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNRedis
             severity: critical
             slo: 'true'
@@ -194,8 +193,7 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-redis-ha-uptime", sloth_service="appcat-vshn-redis-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
-              }}'
+            OnCall: 'false'
             service: VSHNRedis
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
@@ -166,7 +166,6 @@ spec:
             )
           for: 6m
           labels:
-            OnCall: 'false'
             service: VSHNRedis
             severity: critical
             slo: 'true'
@@ -193,7 +192,6 @@ spec:
                 max(slo:sli_error:ratio_rate3d{sloth_id="appcat-vshn-redis-ha-uptime", sloth_service="appcat-vshn-redis-ha", sloth_slo="uptime"} > (1 * 0.0009999999999999432)) without (sloth_window)
             )
           labels:
-            OnCall: 'false'
             service: VSHNRedis
             severity: warning
             slo: 'true'

--- a/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
+++ b/tests/golden/vshn/appcat/appcat/sli_exporter/90_slo_vshn_redis_ha.yaml
@@ -168,11 +168,7 @@ spec:
           labels:
             service: VSHNRedis
             severity: critical
-            slo: 'true'
             sloth_severity: page
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar
         - alert: SLO_AppCat_HAVSHNRedisUptime
           annotations:
             runbook_url: https://hub.syn.tools/appcat/runbooks/vshn-redis.html#uptime
@@ -194,8 +190,4 @@ spec:
           labels:
             service: VSHNRedis
             severity: warning
-            slo: 'true'
             sloth_severity: ticket
-            syn: 'true'
-            syn_component: appcat
-            syn_team: schedar


### PR DESCRIPTION
PR ensures we have new Opsgenie alerts that self resolve depending on time window, so we keep our Responsible Ops sane. It leaves old logic generated by Sloth tool, but disables forwarding alerts to Opsgenie. 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
