### PR TITLE
Add necessary labels to backup alert

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -222,6 +222,8 @@ local backupPrometheusRule = {
             labels: {
               severity: 'warning',
               syn_team: 'schedar',
+              syn: 'true',
+              syn_component: 'appcat',
             },
           },
         ],

--- a/tests/golden/apiserver/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/apiserver/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/billing/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/billing/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/cloudscale-metrics-collector-cloud/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/cloudscale-metrics-collector-managed/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/cloudscale/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/cloudscale/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/controllers/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/controllers/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/defaults/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/exoscale-metrics-collector-cloud/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/exoscale-metrics-collector-managed/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/exoscale/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/exoscale/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/minio/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/minio/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/openshift/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar

--- a/tests/golden/vshn/appcat/appcat/10_appcat_backup_monitoring.yaml
+++ b/tests/golden/vshn/appcat/appcat/10_appcat_backup_monitoring.yaml
@@ -18,4 +18,6 @@ spec:
           for: 1m
           labels:
             severity: warning
+            syn: 'true'
+            syn_component: appcat
             syn_team: schedar


### PR DESCRIPTION
The backup alerts don't actually alert, because the `syn: true` label is missing.
## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
