### PR TITLE
Optimize MariaDB e2e test

### DIFF
--- a/tests/e2e/mariadb/00-assert.yaml
+++ b/tests/e2e/mariadb/00-assert.yaml
@@ -18,8 +18,6 @@ spec:
     security:
       deletionProtection: true
     service:
-      access:
-        - user: e2e-test
       serviceLevel: besteffort
       version: "11.2"
     size:

--- a/tests/e2e/mariadb/02-assert.yaml
+++ b/tests/e2e/mariadb/02-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+---
 apiVersion: vshn.appcat.vshn.io/v1
 kind: VSHNMariaDB
 metadata:
@@ -5,7 +9,13 @@ metadata:
 spec:
   parameters:
     service:
+      access:
+        - user: e2e-test
     size:
       plan: standard-2
   writeConnectionSecretToRef:
     name: mariadb-creds
+status:
+  conditions:
+    - status: "True"
+    - status: "True"

--- a/tests/e2e/mariadb/02-install.yaml
+++ b/tests/e2e/mariadb/02-install.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   parameters:
     service:
+      access:
+        - user: e2e-test
     size:
       plan: standard-2
   writeConnectionSecretToRef:


### PR DESCRIPTION
The previous version of the MariaDB e2e could easily take longer than the configured timeout until it's ready. This is partially due to MariaDB's 2 minute startup delay, as well as reconcile delays of various other CRs.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
