### PR TITLE
Adjust PostgreSQL sidecar limits

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -584,14 +584,14 @@ parameters:
                 cpu: "32m"
                 memory: "64Mi"
               limits:
-                cpu: "64m"
+                cpu: "500m"
                 memory: "64Mi"
             pgbouncer:
               requests:
                 cpu: "16m"
                 memory: "4Mi"
               limits:
-                cpu: "32m"
+                cpu: "500m"
                 memory: "20Mi"
             postgresUtil:
               requests:

--- a/tests/golden/openshift/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/tests/golden/openshift/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -11,8 +11,8 @@ data:
   sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"}, "requests":
     {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu": "400m",
     "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy": {"limits":
-    {"cpu": "64m", "memory": "64Mi"}, "requests": {"cpu": "32m", "memory": "64Mi"}},
-    "pgbouncer": {"limits": {"cpu": "32m", "memory": "20Mi"}, "requests": {"cpu":
+    {"cpu": "500m", "memory": "64Mi"}, "requests": {"cpu": "32m", "memory": "64Mi"}},
+    "pgbouncer": {"limits": {"cpu": "500m", "memory": "20Mi"}, "requests": {"cpu":
     "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
     "20Mi"}, "requests": {"cpu": "10m", "memory": "4Mi"}}, "prometheusPostgresExporter":
     {"limits": {"cpu": "150m", "memory": "256Mi"}, "requests": {"cpu": "10m", "memory":

--- a/tests/golden/openshift/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -84,8 +84,8 @@ spec:
           sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"},
             "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
-            "64Mi"}}, "envoy": {"limits": {"cpu": "64m", "memory": "64Mi"}, "requests":
-            {"cpu": "32m", "memory": "64Mi"}}, "pgbouncer": {"limits": {"cpu": "32m",
+            "64Mi"}}, "envoy": {"limits": {"cpu": "500m", "memory": "64Mi"}, "requests":
+            {"cpu": "32m", "memory": "64Mi"}}, "pgbouncer": {"limits": {"cpu": "500m",
             "memory": "20Mi"}, "requests": {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil":
             {"limits": {"cpu": "20m", "memory": "20Mi"}, "requests": {"cpu": "10m",
             "memory": "4Mi"}}, "prometheusPostgresExporter": {"limits": {"cpu": "150m",

--- a/tests/golden/vshn/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/tests/golden/vshn/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -11,8 +11,8 @@ data:
   sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"}, "requests":
     {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu": "400m",
     "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy": {"limits":
-    {"cpu": "64m", "memory": "64Mi"}, "requests": {"cpu": "32m", "memory": "64Mi"}},
-    "pgbouncer": {"limits": {"cpu": "32m", "memory": "20Mi"}, "requests": {"cpu":
+    {"cpu": "500m", "memory": "64Mi"}, "requests": {"cpu": "32m", "memory": "64Mi"}},
+    "pgbouncer": {"limits": {"cpu": "500m", "memory": "20Mi"}, "requests": {"cpu":
     "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
     "20Mi"}, "requests": {"cpu": "10m", "memory": "4Mi"}}, "prometheusPostgresExporter":
     {"limits": {"cpu": "150m", "memory": "256Mi"}, "requests": {"cpu": "10m", "memory":

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -84,8 +84,8 @@ spec:
           sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"},
             "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
-            "64Mi"}}, "envoy": {"limits": {"cpu": "64m", "memory": "64Mi"}, "requests":
-            {"cpu": "32m", "memory": "64Mi"}}, "pgbouncer": {"limits": {"cpu": "32m",
+            "64Mi"}}, "envoy": {"limits": {"cpu": "500m", "memory": "64Mi"}, "requests":
+            {"cpu": "32m", "memory": "64Mi"}}, "pgbouncer": {"limits": {"cpu": "500m",
             "memory": "20Mi"}, "requests": {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil":
             {"limits": {"cpu": "20m", "memory": "20Mi"}, "requests": {"cpu": "10m",
             "memory": "4Mi"}}, "prometheusPostgresExporter": {"limits": {"cpu": "150m",


### PR DESCRIPTION
The limits for `envoy` and `pgbouncer` are evidently too low.

This change will increase the limit, so that we ensure that `pgbouncer` and `envoy` aren't the bottleneck.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
