### PR TITLE
Enable mail configuration by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -501,11 +501,11 @@ parameters:
       controlNamespace: "syn-appcat-control"
       # Works only for VSHN services for now
       emailAlerting:
-        enabled: false
+        enabled: true
         smtpHost: "smtp.eu.mailgun.org:465"
-        smtpUsername: myuser@example.com
+        smtpUsername: appcat@appuio.cloud
         smtpPassword: "?{vaultkv:__shared__/__shared__/mailgun/smtp_password}"
-        smtpFromAddress: myuser@example.com
+        smtpFromAddress: appcat@appuio.cloud
         secretNamespace: syn-appcat
         secretName: mailgun-smtp-credentials
       vshn:

--- a/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/tests/golden/minio/appcat/appcat/21_composition_vshn_minio.yaml
@@ -36,9 +36,9 @@ spec:
           emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials
           emailAlertingSecretNamespace: syn-appcat
-          emailAlertingSmtpFromAddress: myuser@example.com
+          emailAlertingSmtpFromAddress: appcat@appuio.cloud
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
-          emailAlertingSmtpUsername: myuser@example.com
+          emailAlertingSmtpUsername: appcat@appuio.cloud
           imageTag: v4.102.1
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance

--- a/tests/golden/openshift/appcat/appcat/10_mailgun_secret.yaml
+++ b/tests/golden/openshift/appcat/appcat/10_mailgun_secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: mailgun-smtp-credentials
+  name: mailgun-smtp-credentials
+  namespace: syn-appcat
+stringData:
+  password: __shared__/__shared__/mailgun/smtp_password
+type: Opaque

--- a/tests/golden/openshift/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -33,12 +33,12 @@ spec:
           bucketRegion: ch-gva-2
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
-          emailAlertingEnabled: 'false'
+          emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials
           emailAlertingSecretNamespace: syn-appcat
-          emailAlertingSmtpFromAddress: myuser@example.com
+          emailAlertingSmtpFromAddress: appcat@appuio.cloud
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
-          emailAlertingSmtpUsername: myuser@example.com
+          emailAlertingSmtpUsername: appcat@appuio.cloud
           externalDatabaseConnectionsEnabled: 'false'
           imageTag: v4.102.1
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",

--- a/tests/golden/openshift/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/openshift/appcat/appcat/21_composition_vshn_redis.yaml
@@ -564,12 +564,12 @@ spec:
           bucketRegion: lpg
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
-          emailAlertingEnabled: 'false'
+          emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials
           emailAlertingSecretNamespace: syn-appcat
-          emailAlertingSmtpFromAddress: myuser@example.com
+          emailAlertingSmtpFromAddress: appcat@appuio.cloud
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
-          emailAlertingSmtpUsername: myuser@example.com
+          emailAlertingSmtpUsername: appcat@appuio.cloud
           imageTag: v4.102.1
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -36,9 +36,9 @@ spec:
           emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials
           emailAlertingSecretNamespace: syn-appcat
-          emailAlertingSmtpFromAddress: myuser@example.com
+          emailAlertingSmtpFromAddress: appcat@appuio.cloud
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
-          emailAlertingSmtpUsername: myuser@example.com
+          emailAlertingSmtpUsername: appcat@appuio.cloud
           imageTag: v4.102.1
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -36,9 +36,9 @@ spec:
           emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials
           emailAlertingSecretNamespace: syn-appcat
-          emailAlertingSmtpFromAddress: myuser@example.com
+          emailAlertingSmtpFromAddress: appcat@appuio.cloud
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
-          emailAlertingSmtpUsername: myuser@example.com
+          emailAlertingSmtpUsername: appcat@appuio.cloud
           imageTag: v4.102.1
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -36,9 +36,9 @@ spec:
           emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials
           emailAlertingSecretNamespace: syn-appcat
-          emailAlertingSmtpFromAddress: myuser@example.com
+          emailAlertingSmtpFromAddress: appcat@appuio.cloud
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
-          emailAlertingSmtpUsername: myuser@example.com
+          emailAlertingSmtpUsername: appcat@appuio.cloud
           imageTag: v4.102.1
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -36,9 +36,9 @@ spec:
           emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials
           emailAlertingSecretNamespace: syn-appcat
-          emailAlertingSmtpFromAddress: myuser@example.com
+          emailAlertingSmtpFromAddress: appcat@appuio.cloud
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
-          emailAlertingSmtpUsername: myuser@example.com
+          emailAlertingSmtpUsername: appcat@appuio.cloud
           externalDatabaseConnectionsEnabled: 'true'
           imageTag: v4.102.1
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",

--- a/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn/appcat/appcat/21_composition_vshn_redis.yaml
@@ -593,9 +593,9 @@ spec:
           emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials
           emailAlertingSecretNamespace: syn-appcat
-          emailAlertingSmtpFromAddress: myuser@example.com
+          emailAlertingSmtpFromAddress: appcat@appuio.cloud
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
-          emailAlertingSmtpUsername: myuser@example.com
+          emailAlertingSmtpUsername: appcat@appuio.cloud
           imageTag: v4.102.1
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance


### PR DESCRIPTION
The settings are adjusted to match APPUiO Cloud. According to internal docs our mailgun currently only supports the `appuio.cloud` domain.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
