### PR TITLE
Reduce provider-kubernetes' API load

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -470,6 +470,17 @@ parameters:
           serviceAccountName: provider-kubernetes
         defaultProviderConfig: {}
         additionalProviderConfigs: []
+        additionalRuntimeConfig:
+          spec:
+            deploymentTemplate:
+              spec:
+                template:
+                  spec:
+                    containers:
+                    - name: package-runtime
+                      securityContext: {}
+                      args:
+                        - --max-reconcile-rate=10
 
       helm:
         enabled: false

--- a/component/provider.jsonnet
+++ b/component/provider.jsonnet
@@ -265,7 +265,9 @@ local provider(name, provider) =
     },
   };
 
-  local runtimeConf = common.DefaultRuntimeConfigWithSaName(sa.metadata.name);
+  local runtimeConf = std.mergePatch(common.DefaultRuntimeConfigWithSaName(sa.metadata.name),
+                                     if std.objectHas(provider, 'additionalRuntimeConfig') && provider.additionalRuntimeConfig != null then
+                                       provider.additionalRuntimeConfig else {});
 
   local providerManifest = crossplane.Provider('provider-' + name) {
     spec+: escapePackage(provider.spec) + runtimeConfigRef(sa.metadata.name),

--- a/tests/golden/control-plane/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_provider_kubernetes.yaml
@@ -26,7 +26,9 @@ spec:
       template:
         spec:
           containers:
-            - name: package-runtime
+            - args:
+                - --max-reconcile-rate=10
+              name: package-runtime
               securityContext: {}
           securityContext: {}
           serviceAccountName: provider-kubernetes

--- a/tests/golden/dev/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/dev/appcat/appcat/10_provider_kubernetes.yaml
@@ -26,7 +26,9 @@ spec:
       template:
         spec:
           containers:
-            - name: package-runtime
+            - args:
+                - --max-reconcile-rate=10
+              name: package-runtime
               securityContext: {}
           securityContext: {}
           serviceAccountName: provider-kubernetes

--- a/tests/golden/vshn-cloud/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_provider_kubernetes.yaml
@@ -26,7 +26,9 @@ spec:
       template:
         spec:
           containers:
-            - name: package-runtime
+            - args:
+                - --max-reconcile-rate=10
+              name: package-runtime
               securityContext: {}
           securityContext: {}
           serviceAccountName: provider-kubernetes

--- a/tests/golden/vshn-managed/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_provider_kubernetes.yaml
@@ -26,7 +26,9 @@ spec:
       template:
         spec:
           containers:
-            - name: package-runtime
+            - args:
+                - --max-reconcile-rate=10
+              name: package-runtime
               securityContext: {}
           securityContext: {}
           serviceAccountName: provider-kubernetes


### PR DESCRIPTION
we've observed if many instances are created at the same time, the objects might need manual intervention due to the `create-pending` annotation.

This change will reduce the API load on the apiservers to reduce the chances of this actually happening.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
