### PR TITLE
Fix missing restAPI when using stackgres with OLM

### DIFF
--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -40,6 +40,84 @@ local stackgresOperatorNs = kube.Namespace(params.stackgres.namespace) {
   },
 };
 
+local sa = kube.ServiceAccount('stackgres-sgconfig-restapi-patcher') {
+  metadata+: {
+    namespace: params.stackgres.namespace,
+  },
+};
+
+local role = kube.Role('stackgres-sgconfig-restapi-patcher') {
+  metadata+: {
+    namespace: params.stackgres.namespace,
+  },
+  rules: [
+    {
+      apiGroups: [
+        'stackgres.io',
+      ],
+      resources: [
+        'sgconfigs',
+      ],
+      verbs: [
+        'get',
+        'list',
+        'watch',
+        'patch',
+      ],
+    },
+  ],
+};
+
+local rolebinding = kube.RoleBinding('stackgres-sgconfig-restapi-patcher') {
+  metadata+: {
+    namespace: params.stackgres.namespace,
+  },
+  roleRef: {
+    apiGroup: 'rbac.authorization.k8s.io',
+    kind: 'Role',
+    name: 'stackgres-sgconfig-restapi-patcher',
+  },
+  subjects: [
+    {
+      kind: 'ServiceAccount',
+      name: 'stackgres-sgconfig-restapi-patcher',
+    },
+  ],
+};
+
+local stackgresOperatorConfigPatch = kube.Job('stackgres-sgconfig-restapi-patcher') {
+  metadata+: {
+    namespace: params.stackgres.namespace,
+  },
+  spec+: {
+    template+: {
+      spec+: {
+        restartPolicy: 'Never',
+        serviceAccountName: 'stackgres-sgconfig-restapi-patcher',
+        containers: [
+          {
+            name: 'patch-restapi',
+            image: params.images.kubectl.registry + '/' + params.images.kubectl.image + ':' + params.images.kubectl.tag,
+            command: [
+              'sh',
+              '-c',
+            ],
+            args: [
+              'cat <<EOF | kubectl -n ${TARGET_NAMESPACE} patch sgconfig stackgres-operator --type merge -p "$(cat)"\nspec:\n  restapi:\n    image:\n      name: stackgres/restapi\n      pullPolicy: IfNotPresent\n    name: stackgres-restapi\nEOF',
+            ],
+            env: [
+              {
+                name: 'TARGET_NAMESPACE',
+                value: params.stackgres.namespace,
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+};
+
 local stackgresNetworkPolicy = kube.NetworkPolicy('allow-stackgres-api') + {
   metadata+: {
     namespace: params.stackgres.namespace,
@@ -311,6 +389,7 @@ if params.services.vshn.enabled && pgParams.enabled && vars.isSingleOrControlPla
     [if isOpenshift then '10_stackgres_openshift_operator_ns']: stackgresOperatorNs,
     [if isOpenshift then '11_stackgres_openshift_operator']: std.prune(stackgresOperator),
     [if isOpenshift then '12_stackgres_openshift_operator_netpol']: stackgresNetworkPolicy,
+    [if isOpenshift then '13_stackgres_openshift_operator_restapi']: [ sa, role, rolebinding, stackgresOperatorConfigPatch ],
     [if params.slos.enabled && params.services.vshn.enabled && params.services.vshn.postgres.enabled then 'sli_exporter/90_slo_vshn_postgresql']: slos.Get('vshn-postgresql'),
     [if params.slos.enabled && params.services.vshn.enabled && params.services.vshn.postgres.enabled then 'sli_exporter/90_slo_vshn_postgresql_ha']: slos.Get('vshn-postgresql-ha'),
     [if params.services.vshn.enabled && params.services.vshn.postgres.enabled then 'sli_exporter/90_VSHNPostgreSQL_Opsgenie']: opsgenieRules.GenGenericAlertingRule('VSHNPostgreSQL'),

--- a/tests/golden/vshn-cloud/appcat/appcat/13_stackgres_openshift_operator_restapi.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/13_stackgres_openshift_operator_restapi.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+rules:
+  - apiGroups:
+      - stackgres.io
+    resources:
+      - sgconfigs
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: stackgres-sgconfig-restapi-patcher
+subjects:
+  - kind: ServiceAccount
+    name: stackgres-sgconfig-restapi-patcher
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations: {}
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        name: stackgres-sgconfig-restapi-patcher
+    spec:
+      containers:
+        - args:
+            - |-
+              cat <<EOF | kubectl -n ${TARGET_NAMESPACE} patch sgconfig stackgres-operator --type merge -p "$(cat)"
+              spec:
+                restapi:
+                  image:
+                    name: stackgres/restapi
+                    pullPolicy: IfNotPresent
+                  name: stackgres-restapi
+              EOF
+          command:
+            - sh
+            - -c
+          env:
+            - name: TARGET_NAMESPACE
+              value: syn-stackgres-operator
+          image: docker.io/bitnami/kubectl:1.25.15
+          name: patch-restapi
+      imagePullSecrets: []
+      initContainers: []
+      restartPolicy: Never
+      serviceAccountName: stackgres-sgconfig-restapi-patcher
+      terminationGracePeriodSeconds: 30
+      volumes: []

--- a/tests/golden/vshn-managed/appcat/appcat/13_stackgres_openshift_operator_restapi.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/13_stackgres_openshift_operator_restapi.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+rules:
+  - apiGroups:
+      - stackgres.io
+    resources:
+      - sgconfigs
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: stackgres-sgconfig-restapi-patcher
+subjects:
+  - kind: ServiceAccount
+    name: stackgres-sgconfig-restapi-patcher
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations: {}
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        name: stackgres-sgconfig-restapi-patcher
+    spec:
+      containers:
+        - args:
+            - |-
+              cat <<EOF | kubectl -n ${TARGET_NAMESPACE} patch sgconfig stackgres-operator --type merge -p "$(cat)"
+              spec:
+                restapi:
+                  image:
+                    name: stackgres/restapi
+                    pullPolicy: IfNotPresent
+                  name: stackgres-restapi
+              EOF
+          command:
+            - sh
+            - -c
+          env:
+            - name: TARGET_NAMESPACE
+              value: syn-stackgres-operator
+          image: docker.io/bitnami/kubectl:1.25.15
+          name: patch-restapi
+      imagePullSecrets: []
+      initContainers: []
+      restartPolicy: Never
+      serviceAccountName: stackgres-sgconfig-restapi-patcher
+      terminationGracePeriodSeconds: 30
+      volumes: []


### PR DESCRIPTION
We need the Stackgres RestAPI for our maintenance. Without the RestAPI we won't be able to find the latest minor versions available.

Unfortunately the RestAPI is not installed by default when using OLM and needs to be manually patched in the SGConfig.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
