### PR TITLE
Add possibility to disable TLS in VSHNPostgreSQL

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -55,7 +55,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.108.0
+        tag: psql_tls
       functionAppcat:
         registry: ${appcat:images:appcat:registry}
         repository: ${appcat:images:appcat:repository}

--- a/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
@@ -6,6 +6,6 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.108.0-func
+  package: ghcr.io/vshn/appcat:psql_tls-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_keycloak.yaml
+++ b/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_keycloak.yaml
@@ -11846,6 +11846,15 @@ spec:
                                     - besteffort
                                     - guaranteed
                                   type: string
+                                tls:
+                                  description: TLS settings for the instance.
+                                  properties:
+                                    enabled:
+                                      default: true
+                                      description: Enabled specifies if the instance
+                                        should use TLS for the instance.
+                                      type: boolean
+                                  type: object
                                 vacuumEnabled:
                                   default: false
                                   type: boolean

--- a/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_keycloak.yaml
+++ b/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_keycloak.yaml
@@ -11851,8 +11851,9 @@ spec:
                                   properties:
                                     enabled:
                                       default: true
-                                      description: Enabled specifies if the instance
-                                        should use TLS for the instance.
+                                      description: |-
+                                        Enabled specifies if the instance should use TLS for the instance.
+                                        This change takes effect immediately and does not require a restart of the database.
                                       type: boolean
                                   type: object
                                 vacuumEnabled:

--- a/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_nextcloud.yaml
+++ b/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_nextcloud.yaml
@@ -11834,8 +11834,9 @@ spec:
                                   properties:
                                     enabled:
                                       default: true
-                                      description: Enabled specifies if the instance
-                                        should use TLS for the instance.
+                                      description: |-
+                                        Enabled specifies if the instance should use TLS for the instance.
+                                        This change takes effect immediately and does not require a restart of the database.
                                       type: boolean
                                   type: object
                                 vacuumEnabled:

--- a/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_nextcloud.yaml
+++ b/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_nextcloud.yaml
@@ -5634,13 +5634,10 @@ spec:
                           type: object
                         fqdn:
                           description: |-
-                            FQDN contains the FQDNs array, which will be used for the ingress.
+                            FQDN contains the FQDN which will be used for the ingress.
                             If it's not set, no ingress will be deployed.
                             This also enables strict hostname checking for this FQDN.
-                          items:
-                            type: string
-                          minItems: 1
-                          type: array
+                          type: string
                         postgreSQLParameters:
                           default: {}
                           description: |-
@@ -11832,6 +11829,15 @@ spec:
                                     - besteffort
                                     - guaranteed
                                   type: string
+                                tls:
+                                  description: TLS settings for the instance.
+                                  properties:
+                                    enabled:
+                                      default: true
+                                      description: Enabled specifies if the instance
+                                        should use TLS for the instance.
+                                      type: boolean
+                                  type: object
                                 vacuumEnabled:
                                   default: false
                                   type: boolean

--- a/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -5820,6 +5820,15 @@ spec:
                             - besteffort
                             - guaranteed
                           type: string
+                        tls:
+                          description: TLS settings for the instance.
+                          properties:
+                            enabled:
+                              default: true
+                              description: Enabled specifies if the instance should
+                                use TLS for the instance.
+                              type: boolean
+                          type: object
                         vacuumEnabled:
                           default: false
                           type: boolean

--- a/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/control-plane/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -5825,8 +5825,9 @@ spec:
                           properties:
                             enabled:
                               default: true
-                              description: Enabled specifies if the instance should
-                                use TLS for the instance.
+                              description: |-
+                                Enabled specifies if the instance should use TLS for the instance.
+                                This change takes effect immediately and does not require a restart of the database.
                               type: boolean
                           type: object
                         vacuumEnabled:

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
             nginx.ingress.kubernetes.io/enable-cors: "true"

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -41,7 +41,7 @@ spec:
           emailAlertingSmtpUsername: appcat@appuio.cloud
           externalDatabaseConnectionsEnabled: 'true'
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_redis.yaml
@@ -597,7 +597,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/tests/golden/control-plane/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/control-plane/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/control-plane/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/control-plane/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.108.0
+              image: ghcr.io/vshn/appcat:psql_tls
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/control-plane/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/control-plane/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
               value: 'true'
             - name: APPCAT_SLI_VSHNMARIADB
               value: 'true'
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -6,6 +6,6 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.108.0-func
+  package: ghcr.io/vshn/appcat:psql_tls-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/defaults/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
               value: 'false'
             - name: APPCAT_SLI_VSHNMARIADB
               value: 'false'
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
@@ -6,6 +6,6 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.108.0-func
+  package: ghcr.io/vshn/appcat:psql_tls-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/dev/appcat/appcat/20_xrd_vshn_keycloak.yaml
+++ b/tests/golden/dev/appcat/appcat/20_xrd_vshn_keycloak.yaml
@@ -11846,6 +11846,15 @@ spec:
                                     - besteffort
                                     - guaranteed
                                   type: string
+                                tls:
+                                  description: TLS settings for the instance.
+                                  properties:
+                                    enabled:
+                                      default: true
+                                      description: Enabled specifies if the instance
+                                        should use TLS for the instance.
+                                      type: boolean
+                                  type: object
                                 vacuumEnabled:
                                   default: false
                                   type: boolean

--- a/tests/golden/dev/appcat/appcat/20_xrd_vshn_keycloak.yaml
+++ b/tests/golden/dev/appcat/appcat/20_xrd_vshn_keycloak.yaml
@@ -11851,8 +11851,9 @@ spec:
                                   properties:
                                     enabled:
                                       default: true
-                                      description: Enabled specifies if the instance
-                                        should use TLS for the instance.
+                                      description: |-
+                                        Enabled specifies if the instance should use TLS for the instance.
+                                        This change takes effect immediately and does not require a restart of the database.
                                       type: boolean
                                   type: object
                                 vacuumEnabled:

--- a/tests/golden/dev/appcat/appcat/20_xrd_vshn_nextcloud.yaml
+++ b/tests/golden/dev/appcat/appcat/20_xrd_vshn_nextcloud.yaml
@@ -11834,8 +11834,9 @@ spec:
                                   properties:
                                     enabled:
                                       default: true
-                                      description: Enabled specifies if the instance
-                                        should use TLS for the instance.
+                                      description: |-
+                                        Enabled specifies if the instance should use TLS for the instance.
+                                        This change takes effect immediately and does not require a restart of the database.
                                       type: boolean
                                   type: object
                                 vacuumEnabled:

--- a/tests/golden/dev/appcat/appcat/20_xrd_vshn_nextcloud.yaml
+++ b/tests/golden/dev/appcat/appcat/20_xrd_vshn_nextcloud.yaml
@@ -5634,13 +5634,10 @@ spec:
                           type: object
                         fqdn:
                           description: |-
-                            FQDN contains the FQDNs array, which will be used for the ingress.
+                            FQDN contains the FQDN which will be used for the ingress.
                             If it's not set, no ingress will be deployed.
                             This also enables strict hostname checking for this FQDN.
-                          items:
-                            type: string
-                          minItems: 1
-                          type: array
+                          type: string
                         postgreSQLParameters:
                           default: {}
                           description: |-
@@ -11832,6 +11829,15 @@ spec:
                                     - besteffort
                                     - guaranteed
                                   type: string
+                                tls:
+                                  description: TLS settings for the instance.
+                                  properties:
+                                    enabled:
+                                      default: true
+                                      description: Enabled specifies if the instance
+                                        should use TLS for the instance.
+                                      type: boolean
+                                  type: object
                                 vacuumEnabled:
                                   default: false
                                   type: boolean

--- a/tests/golden/dev/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/dev/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -5820,6 +5820,15 @@ spec:
                             - besteffort
                             - guaranteed
                           type: string
+                        tls:
+                          description: TLS settings for the instance.
+                          properties:
+                            enabled:
+                              default: true
+                              description: Enabled specifies if the instance should
+                                use TLS for the instance.
+                              type: boolean
+                          type: object
                         vacuumEnabled:
                           default: false
                           type: boolean

--- a/tests/golden/dev/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/dev/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -5825,8 +5825,9 @@ spec:
                           properties:
                             enabled:
                               default: true
-                              description: Enabled specifies if the instance should
-                                use TLS for the instance.
+                              description: |-
+                                Enabled specifies if the instance should use TLS for the instance.
+                                This change takes effect immediately and does not require a restart of the database.
                               type: boolean
                           type: object
                         vacuumEnabled:

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'false'

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -41,7 +41,7 @@ spec:
           emailAlertingSmtpUsername: appcat@appuio.cloud
           externalDatabaseConnectionsEnabled: 'true'
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_redis.yaml
@@ -597,7 +597,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/tests/golden/dev/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/dev/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/dev/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/dev/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.108.0
+              image: ghcr.io/vshn/appcat:psql_tls
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/dev/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/dev/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
               value: 'true'
             - name: APPCAT_SLI_VSHNMARIADB
               value: 'true'
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/service-cluster/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -31,7 +31,7 @@ spec:
                   name: vcluster-kubeconfig
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
@@ -6,6 +6,6 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.108.0-func
+  package: ghcr.io/vshn/appcat:psql_tls-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_keycloak.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_keycloak.yaml
@@ -11846,6 +11846,15 @@ spec:
                                     - besteffort
                                     - guaranteed
                                   type: string
+                                tls:
+                                  description: TLS settings for the instance.
+                                  properties:
+                                    enabled:
+                                      default: true
+                                      description: Enabled specifies if the instance
+                                        should use TLS for the instance.
+                                      type: boolean
+                                  type: object
                                 vacuumEnabled:
                                   default: false
                                   type: boolean

--- a/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_keycloak.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_keycloak.yaml
@@ -11851,8 +11851,9 @@ spec:
                                   properties:
                                     enabled:
                                       default: true
-                                      description: Enabled specifies if the instance
-                                        should use TLS for the instance.
+                                      description: |-
+                                        Enabled specifies if the instance should use TLS for the instance.
+                                        This change takes effect immediately and does not require a restart of the database.
                                       type: boolean
                                   type: object
                                 vacuumEnabled:

--- a/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_nextcloud.yaml
@@ -11834,8 +11834,9 @@ spec:
                                   properties:
                                     enabled:
                                       default: true
-                                      description: Enabled specifies if the instance
-                                        should use TLS for the instance.
+                                      description: |-
+                                        Enabled specifies if the instance should use TLS for the instance.
+                                        This change takes effect immediately and does not require a restart of the database.
                                       type: boolean
                                   type: object
                                 vacuumEnabled:

--- a/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_nextcloud.yaml
@@ -5634,13 +5634,10 @@ spec:
                           type: object
                         fqdn:
                           description: |-
-                            FQDN contains the FQDNs array, which will be used for the ingress.
+                            FQDN contains the FQDN which will be used for the ingress.
                             If it's not set, no ingress will be deployed.
                             This also enables strict hostname checking for this FQDN.
-                          items:
-                            type: string
-                          minItems: 1
-                          type: array
+                          type: string
                         postgreSQLParameters:
                           default: {}
                           description: |-
@@ -11832,6 +11829,15 @@ spec:
                                     - besteffort
                                     - guaranteed
                                   type: string
+                                tls:
+                                  description: TLS settings for the instance.
+                                  properties:
+                                    enabled:
+                                      default: true
+                                      description: Enabled specifies if the instance
+                                        should use TLS for the instance.
+                                      type: boolean
+                                  type: object
                                 vacuumEnabled:
                                   default: false
                                   type: boolean

--- a/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -5820,6 +5820,15 @@ spec:
                             - besteffort
                             - guaranteed
                           type: string
+                        tls:
+                          description: TLS settings for the instance.
+                          properties:
+                            enabled:
+                              default: true
+                              description: Enabled specifies if the instance should
+                                use TLS for the instance.
+                              type: boolean
+                          type: object
                         vacuumEnabled:
                           default: false
                           type: boolean

--- a/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -5825,8 +5825,9 @@ spec:
                           properties:
                             enabled:
                               default: true
-                              description: Enabled specifies if the instance should
-                                use TLS for the instance.
+                              description: |-
+                                Enabled specifies if the instance should use TLS for the instance.
+                                This change takes effect immediately and does not require a restart of the database.
                               type: boolean
                           type: object
                         vacuumEnabled:

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_minio.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'true'

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -41,7 +41,7 @@ spec:
           emailAlertingSmtpUsername: appcat@appuio.cloud
           externalDatabaseConnectionsEnabled: 'true'
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_redis.yaml
@@ -597,7 +597,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/tests/golden/vshn-cloud/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/vshn-cloud/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn-cloud/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.108.0
+              image: ghcr.io/vshn/appcat:psql_tls
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
               value: 'true'
             - name: APPCAT_SLI_VSHNMARIADB
               value: 'true'
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
@@ -6,6 +6,6 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.108.0-func
+  package: ghcr.io/vshn/appcat:psql_tls-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_keycloak.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_keycloak.yaml
@@ -11846,6 +11846,15 @@ spec:
                                     - besteffort
                                     - guaranteed
                                   type: string
+                                tls:
+                                  description: TLS settings for the instance.
+                                  properties:
+                                    enabled:
+                                      default: true
+                                      description: Enabled specifies if the instance
+                                        should use TLS for the instance.
+                                      type: boolean
+                                  type: object
                                 vacuumEnabled:
                                   default: false
                                   type: boolean

--- a/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_keycloak.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_keycloak.yaml
@@ -11851,8 +11851,9 @@ spec:
                                   properties:
                                     enabled:
                                       default: true
-                                      description: Enabled specifies if the instance
-                                        should use TLS for the instance.
+                                      description: |-
+                                        Enabled specifies if the instance should use TLS for the instance.
+                                        This change takes effect immediately and does not require a restart of the database.
                                       type: boolean
                                   type: object
                                 vacuumEnabled:

--- a/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_nextcloud.yaml
@@ -11834,8 +11834,9 @@ spec:
                                   properties:
                                     enabled:
                                       default: true
-                                      description: Enabled specifies if the instance
-                                        should use TLS for the instance.
+                                      description: |-
+                                        Enabled specifies if the instance should use TLS for the instance.
+                                        This change takes effect immediately and does not require a restart of the database.
                                       type: boolean
                                   type: object
                                 vacuumEnabled:

--- a/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_nextcloud.yaml
@@ -5634,13 +5634,10 @@ spec:
                           type: object
                         fqdn:
                           description: |-
-                            FQDN contains the FQDNs array, which will be used for the ingress.
+                            FQDN contains the FQDN which will be used for the ingress.
                             If it's not set, no ingress will be deployed.
                             This also enables strict hostname checking for this FQDN.
-                          items:
-                            type: string
-                          minItems: 1
-                          type: array
+                          type: string
                         postgreSQLParameters:
                           default: {}
                           description: |-
@@ -11832,6 +11829,15 @@ spec:
                                     - besteffort
                                     - guaranteed
                                   type: string
+                                tls:
+                                  description: TLS settings for the instance.
+                                  properties:
+                                    enabled:
+                                      default: true
+                                      description: Enabled specifies if the instance
+                                        should use TLS for the instance.
+                                      type: boolean
+                                  type: object
                                 vacuumEnabled:
                                   default: false
                                   type: boolean

--- a/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -5820,6 +5820,15 @@ spec:
                             - besteffort
                             - guaranteed
                           type: string
+                        tls:
+                          description: TLS settings for the instance.
+                          properties:
+                            enabled:
+                              default: true
+                              description: Enabled specifies if the instance should
+                                use TLS for the instance.
+                              type: boolean
+                          type: object
                         vacuumEnabled:
                           default: false
                           type: boolean

--- a/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_postgres.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/20_xrd_vshn_postgres.yaml
@@ -5825,8 +5825,9 @@ spec:
                           properties:
                             enabled:
                               default: true
-                              description: Enabled specifies if the instance should
-                                use TLS for the instance.
+                              description: |-
+                                Enabled specifies if the instance should use TLS for the instance.
+                                This change takes effect immediately and does not require a restart of the database.
                               type: boolean
                           type: object
                         vacuumEnabled:

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_minio.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'true'

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -41,7 +41,7 @@ spec:
           emailAlertingSmtpUsername: appcat@appuio.cloud
           externalDatabaseConnectionsEnabled: 'true'
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_redis.yaml
@@ -597,7 +597,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.108.0
+          imageTag: psql_tls
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/tests/golden/vshn-managed/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/vshn-managed/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn-managed/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.108.0
+              image: ghcr.io/vshn/appcat:psql_tls
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/vshn-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
               value: 'true'
             - name: APPCAT_SLI_VSHNMARIADB
               value: 'true'
-          image: ghcr.io/vshn/appcat:v4.108.0
+          image: ghcr.io/vshn/appcat:psql_tls
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
Summary
- Short and easy implementation of TLS switch in VSHNPostgreSQL
- compatibile with SLI exporter
- switch happens without any pod distruption and takes place immediately
