### PR TITLE
Fix missing restAPI when using stackgres with OLM

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -55,7 +55,7 @@ parameters:
       appcat:
         registry: ghcr.io
         repository: vshn/appcat
-        tag: v4.116.0
+        tag: v4.115.1
       functionAppcat:
         registry: ${appcat:images:appcat:registry}
         repository: ${appcat:images:appcat:repository}

--- a/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
@@ -6,6 +6,6 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.116.0-func
+  package: ghcr.io/vshn/appcat:v4.115.1-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
             nginx.ingress.kubernetes.io/enable-cors: "true"

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -41,7 +41,7 @@ spec:
           emailAlertingSmtpUsername: appcat@appuio.cloud
           externalDatabaseConnectionsEnabled: 'true'
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_redis.yaml
@@ -597,7 +597,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/tests/golden/control-plane/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/control-plane/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/control-plane/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/control-plane/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.116.0
+              image: ghcr.io/vshn/appcat:v4.115.1
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/control-plane/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/control-plane/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
               value: 'true'
             - name: APPCAT_SLI_VSHNMARIADB
               value: 'true'
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -6,6 +6,6 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.116.0-func
+  package: ghcr.io/vshn/appcat:v4.115.1-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/defaults/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/defaults/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
               value: 'false'
             - name: APPCAT_SLI_VSHNMARIADB
               value: 'false'
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
@@ -6,6 +6,6 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.116.0-func
+  package: ghcr.io/vshn/appcat:v4.115.1-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'false'

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -41,7 +41,7 @@ spec:
           emailAlertingSmtpUsername: appcat@appuio.cloud
           externalDatabaseConnectionsEnabled: 'true'
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_redis.yaml
@@ -597,7 +597,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/tests/golden/dev/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/dev/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/dev/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/dev/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.116.0
+              image: ghcr.io/vshn/appcat:v4.115.1
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/dev/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/dev/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
               value: 'true'
             - name: APPCAT_SLI_VSHNMARIADB
               value: 'true'
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/service-cluster/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -31,7 +31,7 @@ spec:
                   name: vcluster-kubeconfig
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
@@ -6,6 +6,6 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.116.0-func
+  package: ghcr.io/vshn/appcat:v4.115.1-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-cloud/appcat/appcat/13_stackgres_openshift_operator_restapi.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/13_stackgres_openshift_operator_restapi.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+rules:
+  - apiGroups:
+      - stackgres.io
+    resources:
+      - sgconfigs
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: stackgres-sgconfig-restapi-patcher
+subjects:
+  - kind: ServiceAccount
+    name: stackgres-sgconfig-restapi-patcher
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations: {}
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        name: stackgres-sgconfig-restapi-patcher
+    spec:
+      containers:
+        - args:
+            - |-
+              cat <<EOF | kubectl -n ${TARGET_NAMESPACE} patch sgconfig stackgres-operator --type merge -p "$(cat)"
+              spec:
+                restapi:
+                  image:
+                    name: stackgres/restapi
+                    pullPolicy: IfNotPresent
+                  name: stackgres-restapi
+              EOF
+          command:
+            - sh
+            - -c
+          env:
+            - name: TARGET_NAMESPACE
+              value: syn-stackgres-operator
+          image: docker.io/bitnami/kubectl:1.25.15
+          name: patch-restapi
+      imagePullSecrets: []
+      initContainers: []
+      restartPolicy: Never
+      serviceAccountName: stackgres-sgconfig-restapi-patcher
+      terminationGracePeriodSeconds: 30
+      volumes: []

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_minio.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'true'

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -41,7 +41,7 @@ spec:
           emailAlertingSmtpUsername: appcat@appuio.cloud
           externalDatabaseConnectionsEnabled: 'true'
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_redis.yaml
@@ -597,7 +597,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/tests/golden/vshn-cloud/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/vshn-cloud/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn-cloud/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.116.0
+              image: ghcr.io/vshn/appcat:v4.115.1
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
               value: 'true'
             - name: APPCAT_SLI_VSHNMARIADB
               value: 'true'
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
@@ -6,6 +6,6 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat
 spec:
-  package: ghcr.io/vshn/appcat:v4.116.0-func
+  package: ghcr.io/vshn/appcat:v4.115.1-func
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-managed/appcat/appcat/13_stackgres_openshift_operator_restapi.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/13_stackgres_openshift_operator_restapi.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+rules:
+  - apiGroups:
+      - stackgres.io
+    resources:
+      - sgconfigs
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-100'
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: stackgres-sgconfig-restapi-patcher
+subjects:
+  - kind: ServiceAccount
+    name: stackgres-sgconfig-restapi-patcher
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations: {}
+  labels:
+    name: stackgres-sgconfig-restapi-patcher
+  name: stackgres-sgconfig-restapi-patcher
+  namespace: syn-stackgres-operator
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        name: stackgres-sgconfig-restapi-patcher
+    spec:
+      containers:
+        - args:
+            - |-
+              cat <<EOF | kubectl -n ${TARGET_NAMESPACE} patch sgconfig stackgres-operator --type merge -p "$(cat)"
+              spec:
+                restapi:
+                  image:
+                    name: stackgres/restapi
+                    pullPolicy: IfNotPresent
+                  name: stackgres-restapi
+              EOF
+          command:
+            - sh
+            - -c
+          env:
+            - name: TARGET_NAMESPACE
+              value: syn-stackgres-operator
+          image: docker.io/bitnami/kubectl:1.25.15
+          name: patch-restapi
+      imagePullSecrets: []
+      initContainers: []
+      restartPolicy: Never
+      serviceAccountName: stackgres-sgconfig-restapi-patcher
+      terminationGracePeriodSeconds: 30
+      volumes: []

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           ingress_annotations: |
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_minio.yaml
@@ -40,7 +40,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           minioChartRepository: https://charts.min.io

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'true'

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -41,7 +41,7 @@ spec:
           emailAlertingSmtpUsername: appcat@appuio.cloud
           externalDatabaseConnectionsEnabled: 'true'
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           initContainers: '{"clusterReconciliationCycle": {"limits": {"cpu": "300m",
             "memory": "200Mi"}, "requests": {"cpu": "100m", "memory": "100Mi"}}, "pgbouncerAuthFile":
             {"limits": {"cpu": "300m", "memory": "500Mi"}, "requests": {"cpu": "100m",

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_redis.yaml
@@ -597,7 +597,7 @@ spec:
           emailAlertingSmtpHost: smtp.eu.mailgun.org:465
           emailAlertingSmtpUsername: appcat@appuio.cloud
           ignoreNamespaceForBilling: vshn-test
-          imageTag: v4.116.0
+          imageTag: v4.115.1
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           ownerGroup: vshn.appcat.vshn.io

--- a/tests/golden/vshn-managed/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/apiserver/30_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --secure-port=9443
             - --tls-cert-file=/apiserver.local.config/certificates/tls.crt
             - --tls-private-key-file=/apiserver.local.config/certificates/tls.key
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/tests/golden/vshn-managed/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -23,7 +23,7 @@ spec:
           env:
             - name: PLANS_NAMESPACE
               value: syn-appcat
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/tests/golden/vshn-managed/appcat/appcat/sla_reporter/01_cronjob.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/sla_reporter/01_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: appcat-sla-reports-creds
-              image: ghcr.io/vshn/appcat:v4.116.0
+              image: ghcr.io/vshn/appcat:v4.115.1
               name: sla-reporter
               resources:
                 limits:

--- a/tests/golden/vshn-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/sli_exporter/apps_v1_deployment_appcat-sliexporter-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
               value: 'true'
             - name: APPCAT_SLI_VSHNMARIADB
               value: 'true'
-          image: ghcr.io/vshn/appcat:v4.116.0
+          image: ghcr.io/vshn/appcat:v4.115.1
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
We need the Stackgres RestAPI for our maintenance. Without the RestAPI we won't be able to find the latest minor versions available.

Unfortunately the RestAPI is not installed by default when using OLM and needs to be manually patched in the SGConfig.


## Checklist

- [ ] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
