### PR TITLE
Distinct name for the ArgoCD app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ push-golden: clean gen-golden ## Push the target instance to the local forgejo i
 	git push -u origin master --force && \
 	rm -rf .git
 	yq eval-all '. as $$item ireduce ({}; . * $$item )' hack/base_app.yaml tests/golden/$(instance)/appcat/apps/appcat.yaml \
-	| yq '.metadata.name = "$(repo)"' | yq '.spec.source.repoURL = "http://forgejo-http.forgejo.svc:3000/gitea_admin/$(repo)"' \
+	| yq '.metadata.name = "$(instance)"' | yq '.spec.source.repoURL = "http://forgejo-http.forgejo.svc:3000/gitea_admin/$(repo)"' \
 	| yq '.spec.destination.server = "$(cluster)"' | kubectl apply -f -
 
 .PHONY: push-non-converged


### PR DESCRIPTION
During an internal discussion we found out, that the default name for the development ArgoCD app is the same as we use in production.

So if not careful it could happen that someone overrides the production app.

With a distinct name we ensure that if someone is connected to a prod cluster and executes `make push-golden` that we don't override the production app but rather create an additional one. This additional one will then simply error out as it can't connect to the local forgejo instance.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
