### PR TITLE
restoring SLO targets rules on Exoscale clusters

### DIFF
--- a/component/vshn_appcat_services.jsonnet
+++ b/component/vshn_appcat_services.jsonnet
@@ -192,7 +192,7 @@ local vshn_appcat_service(name, serviceParams) =
      [if isOpenshift && std.objectHas(serviceParams, 'openshiftTemplate') then '21_openshift_template_%s_vshn' % name]: osTemplate,
 
    } else {})
-  + if vars.isSingleOrServiceCluster && !vars.isExoscale then {
+  + if vars.isSingleOrServiceCluster then {
     ['22_prom_rule_sla_%s' % name]: promRuleSLA,
     [if params.services.vshn.enabled && serviceParams.enabled then 'sli_exporter/70_slo_vshn_%s' % name]: slos.Get('vshn-' + name),
     [if params.services.vshn.enabled && serviceParams.enabled then 'sli_exporter/80_slo_vshn_%s_ha' % name]: slos.Get('vshn-' + name + '-ha'),

--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -315,7 +315,7 @@ local plansCM = kube.ConfigMap('vshnpostgresqlplans') + {
      [if isOpenshift then '11_stackgres_openshift_operator']: std.prune(stackgresOperator),
      [if isOpenshift then '12_stackgres_openshift_operator_netpol']: stackgresNetworkPolicy,
    } else {})
-+ if vars.isSingleOrServiceCluster && !vars.isExoscale then {
++ if vars.isSingleOrServiceCluster then {
   '22_prom_rule_sla_postgres': promRulePostgresSLA,
   [if params.slos.enabled && params.services.vshn.enabled && params.services.vshn.postgres.enabled then 'sli_exporter/70_slo_vshn_postgresql']: slos.Get('vshn-postgresql'),
   [if params.slos.enabled && params.services.vshn.enabled && params.services.vshn.postgres.enabled then 'sli_exporter/80_slo_vshn_postgresql_ha']: slos.Get('vshn-postgresql-ha'),

--- a/component/vshn_redis.jsonnet
+++ b/component/vshn_redis.jsonnet
@@ -572,7 +572,7 @@ local plansCM = kube.ConfigMap('vshnredisplans') + {
    '21_composition_vshn_redis': composition,
    [if isOpenshift then '21_openshift_template_redis_vshn']: osTemplate,
  } else {})
-+ if vars.isSingleOrServiceCluster && !vars.isExoscale then {
++ if vars.isSingleOrServiceCluster then {
   '22_prom_rule_sla_redis': promRuleRedisSLA,
   [if params.services.vshn.enabled && params.services.vshn.redis.enabled then 'sli_exporter/70_slo_vshn_redis']: slos.Get('vshn-redis'),
   [if params.services.vshn.enabled && params.services.vshn.redis.enabled then 'sli_exporter/80_slo_vshn_redis_ha']: slos.Get('vshn-redis-ha'),

--- a/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_keycloak.yaml
+++ b/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_keycloak.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    name: vshn-vshnkeycloak-sla
+  name: vshn-vshnkeycloak-sla
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-vshnkeycloak-sla-target
+      rules:
+        - expr: vector(99.25)
+          labels:
+            service: VSHNKeycloak
+          record: sla:objective:ratio

--- a/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_mariadb.yaml
+++ b/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_mariadb.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    name: vshn-vshnmariadb-sla
+  name: vshn-vshnmariadb-sla
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-vshnmariadb-sla-target
+      rules:
+        - expr: vector(99.25)
+          labels:
+            service: VSHNMariaDB
+          record: sla:objective:ratio

--- a/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_minio.yaml
+++ b/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_minio.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    name: vshn-vshnminio-sla
+  name: vshn-vshnminio-sla
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-vshnminio-sla-target
+      rules:
+        - expr: vector(99.25)
+          labels:
+            service: VSHNMinio
+          record: sla:objective:ratio

--- a/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_nextcloud.yaml
+++ b/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_nextcloud.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    name: vshn-vshnnextcloud-sla
+  name: vshn-vshnnextcloud-sla
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-vshnnextcloud-sla-target
+      rules:
+        - expr: vector(99.25)
+          labels:
+            service: VSHNNextcloud
+          record: sla:objective:ratio

--- a/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_postgres.yaml
+++ b/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_postgres.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    name: vshn-vshnpostgresql-sla
+  name: vshn-vshnpostgresql-sla
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-vshnpostgresql-sla-target
+      rules:
+        - expr: vector(99.25)
+          labels:
+            service: VSHNPostgreSQL
+          record: sla:objective:ratio

--- a/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_redis.yaml
+++ b/tests/golden/exodev/appcat/appcat/22_prom_rule_sla_redis.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    name: vshn-vshnredis-sla
+  name: vshn-vshnredis-sla
+  namespace: appcat-slos
+spec:
+  groups:
+    - name: appcat-vshnredis-sla-target
+      rules:
+        - expr: vector(99.25)
+          labels:
+            service: VSHNRedis
+          record: sla:objective:ratio

--- a/tests/vshn-managed.yml
+++ b/tests/vshn-managed.yml
@@ -12,7 +12,8 @@ parameters:
     cloud: cloudscale
     distribution: openshift4
     sales_order: "ST10120"
-    service_level: "premium"
+    service_level: guaranteed_availability
+
 
 
   global:

--- a/tests/vshn-managed.yml
+++ b/tests/vshn-managed.yml
@@ -14,8 +14,6 @@ parameters:
     sales_order: "ST10120"
     service_level: guaranteed_availability
 
-
-
   global:
     appuio_metered_billing_zone_label_map:
       c-green-test-1234: 'Kind - Local Test 0'


### PR DESCRIPTION
## Sumamry

We need to restore SLO alerts/rules as we have now Appcat released to Exoscale clusters including our VSHNDatabases


## Checklist

- [X] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
