### PR TITLE
Add parameter to pass default app domain of OCP clusters

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -545,6 +545,7 @@ parameters:
         secretNamespace: syn-appcat
         secretName: mailgun-smtp-credentials
       vshn:
+        ocpDefaultAppsDomain: ""
         enabled: false
         externalDatabaseConnectionsEnabled: "false"
         e2eTests: false

--- a/component/vshn_appcat_services.jsonnet
+++ b/component/vshn_appcat_services.jsonnet
@@ -110,6 +110,7 @@ local vshn_appcat_service(name, serviceParams) =
                         quotasEnabled: std.toString(params.services.vshn.quotasEnabled),
                         isOpenshift: std.toString(isOpenshift),
                         sliNamespace: params.slos.namespace,
+                        ocpDefaultAppsDomain: params.services.vshn.ocpDefaultAppsDomain,
                         ownerKind: xrd.spec.names.kind,
                         ownerGroup: xrd.spec.group,
                         ownerVersion: xrd.spec.versions[0].name,

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -48,6 +48,7 @@ spec:
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNKeycloak
           ownerVersion: v1

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -45,6 +45,7 @@ spec:
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNMariaDB
           ownerVersion: v1

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -57,6 +57,7 @@ spec:
           mode: standalone
           nextcloud_image: docker.io/library/nextcloud
           oc_image: quay.io/appuio/oc:v4.13
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNNextcloud
           ownerVersion: v1

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -48,6 +48,7 @@ spec:
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNKeycloak
           ownerVersion: v1

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -45,6 +45,7 @@ spec:
           isOpenshift: 'false'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNMariaDB
           ownerVersion: v1

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -55,6 +55,7 @@ spec:
           mode: standalone
           nextcloud_image: dockerhub.vshn.net/library/nextcloud
           oc_image: quay.io/appuio/oc:v4.13
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNNextcloud
           ownerVersion: v1

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -48,6 +48,7 @@ spec:
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNKeycloak
           ownerVersion: v1

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -45,6 +45,7 @@ spec:
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNMariaDB
           ownerVersion: v1

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_minio.yaml
@@ -47,6 +47,7 @@ spec:
           minioChartRepository: https://charts.min.io
           minioChartVersion: 5.0.13
           mode: distributed
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNMinio
           ownerVersion: v1

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -55,6 +55,7 @@ spec:
           mode: standalone
           nextcloud_image: docker.io/library/nextcloud
           oc_image: quay.io/appuio/oc:v4.13
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNNextcloud
           ownerVersion: v1

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -48,6 +48,7 @@ spec:
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNKeycloak
           ownerVersion: v1

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -45,6 +45,7 @@ spec:
           isOpenshift: 'true'
           maintenanceSA: helm-based-service-maintenance
           mode: standalone
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNMariaDB
           ownerVersion: v1

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_minio.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_minio.yaml
@@ -47,6 +47,7 @@ spec:
           minioChartRepository: https://charts.min.io
           minioChartVersion: 5.0.13
           mode: distributed
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNMinio
           ownerVersion: v1

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -55,6 +55,7 @@ spec:
           mode: standalone
           nextcloud_image: docker.io/library/nextcloud
           oc_image: quay.io/appuio/oc:v4.13
+          ocpDefaultAppsDomain: ''
           ownerGroup: vshn.appcat.vshn.io
           ownerKind: XVSHNNextcloud
           ownerVersion: v1


### PR DESCRIPTION
Adds a new parameter `ocpDefaultAppsDomain` to `.paramteres.appcat.services.vshn` with which to pass the FQDN of the default apps domain to jsonnets.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.