### PR TITLE
Update resource limits cluster-controller stackgres

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -600,7 +600,7 @@ parameters:
                 cpu: "32m"
                 memory: "128Mi"
               limits:
-                cpu: "32m"
+                cpu: "250m"
                 memory: "256Mi"
             runDbops:
               requests:

--- a/tests/golden/control-plane/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/tests/golden/control-plane/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -8,12 +8,12 @@ data:
     "standard-2": {"size": {"cpu": "400m", "disk": "20Gi", "enabled": true, "memory":
     "1936Mi"}}, "standard-4": {"size": {"cpu": "900m", "disk": "40Gi", "enabled":
     true, "memory": "3984Mi"}}}'
-  sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"}, "requests":
-    {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu": "400m",
-    "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy": {"limits":
-    {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory": "64Mi"}},
-    "pgbouncer": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu":
-    "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
+  sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+    "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu":
+    "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy":
+    {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory":
+    "64Mi"}}, "pgbouncer": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests":
+    {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
     "20Mi"}, "requests": {"cpu": "10m", "memory": "4Mi"}}, "prometheusPostgresExporter":
     {"limits": {"cpu": "150m", "memory": "256Mi"}, "requests": {"cpu": "10m", "memory":
     "16Mi"}}, "runDbops": {"limits": {"cpu": "250m", "memory": "256Mi"}, "requests":

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -82,7 +82,7 @@ spec:
           salesOrder: ''
           serviceName: postgresql
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"},
+          sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
             "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
             "64Mi"}}, "envoy": {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests":

--- a/tests/golden/dev/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/tests/golden/dev/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -8,12 +8,12 @@ data:
     "standard-2": {"size": {"cpu": "400m", "disk": "20Gi", "enabled": true, "memory":
     "1936Mi"}}, "standard-4": {"size": {"cpu": "900m", "disk": "40Gi", "enabled":
     true, "memory": "3984Mi"}}}'
-  sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"}, "requests":
-    {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu": "400m",
-    "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy": {"limits":
-    {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory": "64Mi"}},
-    "pgbouncer": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu":
-    "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
+  sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+    "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu":
+    "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy":
+    {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory":
+    "64Mi"}}, "pgbouncer": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests":
+    {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
     "20Mi"}, "requests": {"cpu": "10m", "memory": "4Mi"}}, "prometheusPostgresExporter":
     {"limits": {"cpu": "150m", "memory": "256Mi"}, "requests": {"cpu": "10m", "memory":
     "16Mi"}}, "runDbops": {"limits": {"cpu": "250m", "memory": "256Mi"}, "requests":

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -82,7 +82,7 @@ spec:
           salesOrder: ''
           serviceName: postgresql
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"},
+          sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
             "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
             "64Mi"}}, "envoy": {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests":

--- a/tests/golden/vshn-cloud/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -8,12 +8,12 @@ data:
     "standard-2": {"size": {"cpu": "400m", "disk": "20Gi", "enabled": true, "memory":
     "1936Mi"}}, "standard-4": {"size": {"cpu": "900m", "disk": "40Gi", "enabled":
     true, "memory": "3984Mi"}}}'
-  sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"}, "requests":
-    {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu": "400m",
-    "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy": {"limits":
-    {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory": "64Mi"}},
-    "pgbouncer": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu":
-    "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
+  sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+    "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu":
+    "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy":
+    {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory":
+    "64Mi"}}, "pgbouncer": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests":
+    {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
     "20Mi"}, "requests": {"cpu": "10m", "memory": "4Mi"}}, "prometheusPostgresExporter":
     {"limits": {"cpu": "150m", "memory": "256Mi"}, "requests": {"cpu": "10m", "memory":
     "16Mi"}}, "runDbops": {"limits": {"cpu": "250m", "memory": "256Mi"}, "requests":

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -82,7 +82,7 @@ spec:
           salesOrder: ''
           serviceName: postgresql
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"},
+          sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
             "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
             "64Mi"}}, "envoy": {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests":

--- a/tests/golden/vshn-managed/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -8,12 +8,12 @@ data:
     "standard-2": {"size": {"cpu": "400m", "disk": "20Gi", "enabled": true, "memory":
     "1936Mi"}}, "standard-4": {"size": {"cpu": "900m", "disk": "40Gi", "enabled":
     true, "memory": "3984Mi"}}}'
-  sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"}, "requests":
-    {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu": "400m",
-    "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy": {"limits":
-    {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory": "64Mi"}},
-    "pgbouncer": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu":
-    "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
+  sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+    "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu":
+    "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy":
+    {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory":
+    "64Mi"}}, "pgbouncer": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests":
+    {"cpu": "16m", "memory": "4Mi"}}, "postgresUtil": {"limits": {"cpu": "20m", "memory":
     "20Mi"}, "requests": {"cpu": "10m", "memory": "4Mi"}}, "prometheusPostgresExporter":
     {"limits": {"cpu": "150m", "memory": "256Mi"}, "requests": {"cpu": "10m", "memory":
     "16Mi"}}, "runDbops": {"limits": {"cpu": "250m", "memory": "256Mi"}, "requests":

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -82,7 +82,7 @@ spec:
           salesOrder: ST10120
           serviceName: postgresql
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "32m", "memory": "256Mi"},
+          sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
             "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
             "64Mi"}}, "envoy": {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests":


### PR DESCRIPTION
* This PR will update the resource limits for cluster-controller container in Stackgres clusters. Currently all new instances are blockec

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
