### PR TITLE
setting more reasonable default for our controller

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -332,7 +332,7 @@ parameters:
           memory: 50Mi
         limits:
           cpu: 200m
-          memory: 200Mi
+          memory: 300Mi
 
     stackgres:
       namespace: syn-stackgres-operator

--- a/tests/golden/control-plane/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -41,7 +41,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 200Mi
+              memory: 300Mi
             requests:
               cpu: 100m
               memory: 50Mi

--- a/tests/golden/dev/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -41,7 +41,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 200Mi
+              memory: 300Mi
             requests:
               cpu: 100m
               memory: 50Mi

--- a/tests/golden/exodev/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -41,7 +41,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 200Mi
+              memory: 300Mi
             requests:
               cpu: 100m
               memory: 50Mi

--- a/tests/golden/service-cluster/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -46,7 +46,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 200Mi
+              memory: 300Mi
             requests:
               cpu: 100m
               memory: 50Mi

--- a/tests/golden/vshn-cloud/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -41,7 +41,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 200Mi
+              memory: 300Mi
             requests:
               cpu: 100m
               memory: 50Mi

--- a/tests/golden/vshn-managed/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -41,7 +41,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 200Mi
+              memory: 300Mi
             requests:
               cpu: 100m
               memory: 50Mi


### PR DESCRIPTION
- Since our appcat-controller must work on much more resources it needs more RAM, setting 300mb
