### PR TITLE
Reset provider-kubernetes reconcile rate to default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -486,17 +486,7 @@ parameters:
           serviceAccountName: provider-kubernetes
         defaultProviderConfig: {}
         additionalProviderConfigs: []
-        additionalRuntimeConfig:
-          spec:
-            deploymentTemplate:
-              spec:
-                template:
-                  spec:
-                    containers:
-                      - name: package-runtime
-                        securityContext: {}
-                        args:
-                          - --max-reconcile-rate=20
+        additionalRuntimeConfig: {}
       helm:
         enabled: false
         apiVersion: helm.crossplane.io/v1beta1

--- a/tests/golden/control-plane/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_provider_kubernetes.yaml
@@ -26,9 +26,7 @@ spec:
       template:
         spec:
           containers:
-            - args:
-                - --max-reconcile-rate=20
-              name: package-runtime
+            - name: package-runtime
               securityContext: {}
           securityContext: {}
           serviceAccountName: provider-kubernetes

--- a/tests/golden/dev/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/dev/appcat/appcat/10_provider_kubernetes.yaml
@@ -26,9 +26,7 @@ spec:
       template:
         spec:
           containers:
-            - args:
-                - --max-reconcile-rate=20
-              name: package-runtime
+            - name: package-runtime
               securityContext: {}
           securityContext: {}
           serviceAccountName: provider-kubernetes

--- a/tests/golden/exodev/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_provider_kubernetes.yaml
@@ -26,9 +26,7 @@ spec:
       template:
         spec:
           containers:
-            - args:
-                - --max-reconcile-rate=20
-              name: package-runtime
+            - name: package-runtime
               securityContext: {}
           securityContext: {}
           serviceAccountName: provider-kubernetes

--- a/tests/golden/vshn-cloud/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_provider_kubernetes.yaml
@@ -26,9 +26,7 @@ spec:
       template:
         spec:
           containers:
-            - args:
-                - --max-reconcile-rate=20
-              name: package-runtime
+            - name: package-runtime
               securityContext: {}
           securityContext: {}
           serviceAccountName: provider-kubernetes

--- a/tests/golden/vshn-managed/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_provider_kubernetes.yaml
@@ -26,9 +26,7 @@ spec:
       template:
         spec:
           containers:
-            - args:
-                - --max-reconcile-rate=20
-              name: package-runtime
+            - name: package-runtime
               securityContext: {}
           securityContext: {}
           serviceAccountName: provider-kubernetes


### PR DESCRIPTION
This resets the setting back to the default settings. According to the developers this provides the best performance.

https://github.com/crossplane-contrib/provider-kubernetes/pull/203




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
