### PR TITLE
Increase Crossplane poll rate

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -148,6 +148,7 @@ parameters:
           enabled: true
         args:
           - --enable-usages
+          - --poll-interval=1h
         image:
           repository: ${appcat:images:crossplane:registry}/${appcat:images:crossplane:image}
           tag: ${appcat:images:crossplane:tag}

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - core
             - start
             - --enable-usages
+            - --poll-interval=1h
           env:
             - name: GOMAXPROCS
               valueFrom:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - core
             - start
             - --enable-usages
+            - --poll-interval=1h
           env:
             - name: GOMAXPROCS
               valueFrom:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - core
             - start
             - --enable-usages
+            - --poll-interval=1h
           env:
             - name: GOMAXPROCS
               valueFrom:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - core
             - start
             - --enable-usages
+            - --poll-interval=1h
           env:
             - name: GOMAXPROCS
               valueFrom:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - core
             - start
             - --enable-usages
+            - --poll-interval=1h
           env:
             - name: GOMAXPROCS
               valueFrom:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - core
             - start
             - --enable-usages
+            - --poll-interval=1h
           env:
             - name: GOMAXPROCS
               valueFrom:


### PR DESCRIPTION
This change will decrease the load on the K8s API servers by 5-10x.

There's no impact on the time it takes until changes are reflected on the claims or composites. Crossplane will reconcile unready composites more aggressively. The 1h poll rate only applies to composites that are considdered in a ready and synced state.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
