### PR TITLE
Add service hash annotation to apisever and controller

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -566,6 +566,7 @@ parameters:
         quotasEnabled: ${appcat:quotasEnabled}
         secretNamespace: ${appcat:crossplane:namespace}
         forgejo:
+          enabled: true
           billing: true
           serviceName: VSHNForgejo
           compFunctionsOnly: true
@@ -577,7 +578,6 @@ parameters:
             - ca.crt
           mode: standalone
           offered: true
-          enabled: true
           restoreSA: forgejoserviceaccount
           restoreRoleRules: ${appcat:defaultRestoreRoleRules}
           additionalInputs:
@@ -629,8 +629,8 @@ parameters:
                 memory: "16Gi"
                 disk: 500Gi
         postgres:
-          billing: true
           enabled: true
+          billing: true
           additionalInputs:
             # Depending on the cluster, this needs to be set
             loadbalancerAnnotations: ""
@@ -768,8 +768,8 @@ parameters:
                 cpu: "500m"
                 memory: "512Mi"
         redis:
-          billing: true
           enabled: true
+          billing: true
           enableNetworkPolicy: true
           secretNamespace: ${appcat:services:vshn:secretNamespace}
           helmChartVersion: ${appcat:charts:redis:version}
@@ -810,6 +810,7 @@ parameters:
                 memory: "8Gi"
                 disk: 16Gi
         minio:
+          enabled: false
           billing: true
           serviceName: VSHNMinio
           compFunctionsOnly: true
@@ -819,7 +820,6 @@ parameters:
             - AWS_ACCESS_KEY_ID
           mode: distributed
           offered: false
-          enabled: false
           enableNetworkPolicy: true
           secretNamespace: ${appcat:services:vshn:secretNamespace}
           helmChartVersion: ${appcat:charts:minio:version}
@@ -841,6 +841,7 @@ parameters:
             minioChartVersion: ${appcat:charts:minio:version} # for backwards compatibility for now
           instances: []
         mariadb:
+          enabled: false
           billing: true
           serviceName: VSHNMariaDB
           compFunctionsOnly: true
@@ -854,7 +855,6 @@ parameters:
             - LOADBALANCER_IP
           mode: standalone
           offered: true
-          enabled: false
           restoreSA: mariadbrestoreserviceaccount
           restoreRoleRules: ${appcat:defaultRestoreRoleRules}
           additionalInputs:
@@ -911,6 +911,7 @@ parameters:
                 memory: "8Gi"
                 disk: 16Gi
         keycloak:
+          enabled: false
           billing: true
           serviceName: VSHNKeycloak
           compFunctionsOnly: true
@@ -922,7 +923,6 @@ parameters:
             - ca.crt
           mode: standalone
           offered: true
-          enabled: false
           restoreSA: keycloakserviceaccount
           restoreRoleRules: ${appcat:defaultRestoreRoleRules}
           additionalInputs:
@@ -967,6 +967,7 @@ parameters:
                 memory: "8Gi"
                 disk: 16Gi
         nextcloud:
+          enabled: false
           billing: true
           serviceName: VSHNNextcloud
           compFunctionsOnly: true
@@ -978,7 +979,6 @@ parameters:
             - ca.crt
           mode: standalone
           offered: true
-          enabled: false
           restoreSA: nextcloudserviceaccount
           restoreRoleRules: ${appcat:defaultRestoreRoleRules}
           additionalInputs:
@@ -1028,6 +1028,7 @@ parameters:
                 memory: "8Gi"
                 disk: 16Gi
         codey:
+          enabled: true
           billing: false
           serviceName: Codey
           connectionSecretKeys:
@@ -1038,7 +1039,6 @@ parameters:
             - ca.crt
           mode: standalone
           offered: true
-          enabled: true
           restoreSA: codeyserviceaccount
           restoreRoleRules: ${appcat:defaultRestoreRoleRules}
           openshiftTemplate:

--- a/component/appcat_apiserver.jsonnet
+++ b/component/appcat_apiserver.jsonnet
@@ -78,6 +78,9 @@ local extraDeploymentArgs =
 local apiserver = loadManifest('aggregated-apiserver.yaml') {
   metadata+: {
     namespace: apiserverParams.namespace,
+    annotations+: {
+      'metadata.appcat.vshn.io/enabled-service-hash': vars.GetVSHNServicesObject(),
+    },
   },
   spec+: {
     replicas: 2,

--- a/component/appcat_controller.jsonnet
+++ b/component/appcat_controller.jsonnet
@@ -1,4 +1,5 @@
 local common = import 'common.libsonnet';
+local vars = import 'config/vars.jsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
@@ -70,6 +71,9 @@ local controlKubeConfig = kube.Secret('controlclustercredentials') + {
 local controller = loadManifest('deployment.yaml') {
   metadata+: {
     namespace: controllersParams.namespace,
+    annotations+: {
+      'metadata.appcat.vshn.io/enabled-service-hash': vars.GetVSHNServicesObject(),
+    },
   },
   spec+: {
     replicas: 2,

--- a/component/config/vars.jsonnet
+++ b/component/config/vars.jsonnet
@@ -7,6 +7,21 @@ local cms = params.clusterManagementSystem;
 local isSingleCluster = cms.controlPlaneCluster && cms.serviceCluster;
 local isControlPlane = cms.controlPlaneCluster && !cms.serviceCluster;
 local isServiceCluster = !cms.controlPlaneCluster && cms.serviceCluster;
+local getSubObjects(obj) = [
+  obj[key]
+  for key in std.objectFields(obj)
+  if std.type(obj[key]) == 'object'
+];
+local getVSHNServicesObject() = std.md5(
+  std.manifestJson(
+    std.foldl(
+      function(acc, s)
+        if s.enabled == true then acc + s else acc,
+      getSubObjects(params.services.vshn),
+      {}
+    )
+  )
+);
 
 {
   isServiceCluster: isServiceCluster,
@@ -16,6 +31,7 @@ local isServiceCluster = !cms.controlPlaneCluster && cms.serviceCluster;
   isSingleOrControlPlaneCluster: isSingleCluster || isControlPlane,
   isSingleOrServiceCluster: isSingleCluster || isServiceCluster,
   isExoscale: inv.parameters.facts.cloud == 'exoscale',
+  GetVSHNServicesObject(): getVSHNServicesObject(),
   assert (cms.controlPlaneKubeconfig == '' && isSingleCluster) || !isSingleCluster : 'clusterManagementSystem.controlPlaneKubeconfig should be empty for converged clusters',
   assert (cms.controlPlaneKubeconfig != '' && isServiceCluster) || (isSingleCluster || isControlPlane) : 'clusterManagementSystem.controlPlaneKubeconfig should not be empty for service clusters',
 }

--- a/tests/golden/control-plane/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/apiserver/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: a7c475b8a17c149b40d8529e21b04658
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/control-plane/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: a7c475b8a17c149b40d8529e21b04658
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller

--- a/tests/golden/defaults/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/apiserver/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: 5a41f5cfd0635f10b46b72a1b83859d3
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/dev/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/apiserver/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: f1a27f82c3b5113e47030d7abaa6d596
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/dev/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: f1a27f82c3b5113e47030d7abaa6d596
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller

--- a/tests/golden/exodev/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/apiserver/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: c86b376dac7b8a5093b8e838f3fdeb4e
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/exodev/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: c86b376dac7b8a5093b8e838f3fdeb4e
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller

--- a/tests/golden/service-cluster/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: 89bbe08c575a54a9e05741b53080a248
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller

--- a/tests/golden/vshn-cloud/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/apiserver/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: 068118f76854173963ad2be8f5b0b334
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/vshn-cloud/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: 068118f76854173963ad2be8f5b0b334
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller

--- a/tests/golden/vshn-managed/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/apiserver/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: e908b96a1578ebf2bd445d9dd976c358
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/vshn-managed/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    metadata.appcat.vshn.io/enabled-service-hash: e908b96a1578ebf2bd445d9dd976c358
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller


### PR DESCRIPTION
This PR will make sure that apiserver and controller are being restarted by the k8s scheduler whenever we add or remove appcat vshn services.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
