### PR TITLE
Increase the default cluster-controller memory limit resource

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -673,8 +673,8 @@ parameters:
                 cpu: "32m"
                 memory: "128Mi"
               limits:
-                cpu: "250m"
-                memory: "256Mi"
+                cpu: "500m"
+                memory: "512Mi"
             runDbops:
               requests:
                 cpu: "100m"

--- a/tests/golden/control-plane/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/tests/golden/control-plane/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -8,7 +8,7 @@ data:
     "standard-2": {"size": {"cpu": "400m", "disk": "20Gi", "enabled": true, "memory":
     "1936Mi"}}, "standard-4": {"size": {"cpu": "900m", "disk": "40Gi", "enabled":
     true, "memory": "3984Mi"}}}'
-  sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+  sideCars: '{"clusterController": {"limits": {"cpu": "500m", "memory": "512Mi"},
     "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu":
     "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy":
     {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory":

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -84,7 +84,7 @@ spec:
           serviceID: vshn-postgresql
           serviceName: postgresql
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+          sideCars: '{"clusterController": {"limits": {"cpu": "500m", "memory": "512Mi"},
             "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
             "64Mi"}}, "envoy": {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests":

--- a/tests/golden/dev/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/tests/golden/dev/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -8,7 +8,7 @@ data:
     "standard-2": {"size": {"cpu": "400m", "disk": "20Gi", "enabled": true, "memory":
     "1936Mi"}}, "standard-4": {"size": {"cpu": "900m", "disk": "40Gi", "enabled":
     true, "memory": "3984Mi"}}}'
-  sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+  sideCars: '{"clusterController": {"limits": {"cpu": "500m", "memory": "512Mi"},
     "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu":
     "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy":
     {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory":

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -85,7 +85,7 @@ spec:
           serviceID: vshn-postgresql
           serviceName: postgresql
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+          sideCars: '{"clusterController": {"limits": {"cpu": "500m", "memory": "512Mi"},
             "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
             "64Mi"}}, "envoy": {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests":

--- a/tests/golden/vshn-cloud/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -8,7 +8,7 @@ data:
     "standard-2": {"size": {"cpu": "400m", "disk": "20Gi", "enabled": true, "memory":
     "1936Mi"}}, "standard-4": {"size": {"cpu": "900m", "disk": "40Gi", "enabled":
     true, "memory": "3984Mi"}}}'
-  sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+  sideCars: '{"clusterController": {"limits": {"cpu": "500m", "memory": "512Mi"},
     "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu":
     "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy":
     {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory":

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -84,7 +84,7 @@ spec:
           serviceID: vshn-postgresql
           serviceName: postgresql
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+          sideCars: '{"clusterController": {"limits": {"cpu": "500m", "memory": "512Mi"},
             "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
             "64Mi"}}, "envoy": {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests":

--- a/tests/golden/vshn-managed/appcat/appcat/20_plans_vshn_postgresql.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/20_plans_vshn_postgresql.yaml
@@ -8,7 +8,7 @@ data:
     "standard-2": {"size": {"cpu": "400m", "disk": "20Gi", "enabled": true, "memory":
     "1936Mi"}}, "standard-4": {"size": {"cpu": "900m", "disk": "40Gi", "enabled":
     true, "memory": "3984Mi"}}}'
-  sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+  sideCars: '{"clusterController": {"limits": {"cpu": "500m", "memory": "512Mi"},
     "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits": {"cpu":
     "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory": "64Mi"}}, "envoy":
     {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests": {"cpu": "32m", "memory":

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -84,7 +84,7 @@ spec:
           serviceID: vshn-postgresql
           serviceName: postgresql
           sgNamespace: stackgres
-          sideCars: '{"clusterController": {"limits": {"cpu": "250m", "memory": "256Mi"},
+          sideCars: '{"clusterController": {"limits": {"cpu": "500m", "memory": "512Mi"},
             "requests": {"cpu": "32m", "memory": "128Mi"}}, "createBackup": {"limits":
             {"cpu": "400m", "memory": "500Mi"}, "requests": {"cpu": "100m", "memory":
             "64Mi"}}, "envoy": {"limits": {"cpu": "500m", "memory": "512Mi"}, "requests":


### PR DESCRIPTION
In almost every cluster I see the side car cluster-controller being killed due to OOM. We need to increase it across all instances.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
