### PR TITLE
Fix service name hash

### DIFF
--- a/component/appcat_apiserver.jsonnet
+++ b/component/appcat_apiserver.jsonnet
@@ -79,7 +79,7 @@ local apiserver = loadManifest('aggregated-apiserver.yaml') {
   metadata+: {
     namespace: apiserverParams.namespace,
     annotations+: {
-      'metadata.appcat.vshn.io/enabled-service-hash': vars.GetVSHNServicesObject(),
+      'metadata.appcat.vshn.io/enabled-services-hash': std.md5(std.join('-', vars.GetEnabledVSHNServiceNames())),
     },
   },
   spec+: {

--- a/component/appcat_controller.jsonnet
+++ b/component/appcat_controller.jsonnet
@@ -72,7 +72,7 @@ local controller = loadManifest('deployment.yaml') {
   metadata+: {
     namespace: controllersParams.namespace,
     annotations+: {
-      'metadata.appcat.vshn.io/enabled-service-hash': vars.GetVSHNServicesObject(),
+      'metadata.appcat.vshn.io/enabled-services-hash': std.md5(std.join('-', vars.GetEnabledVSHNServiceNames())),
     },
   },
   spec+: {

--- a/component/config/vars.jsonnet
+++ b/component/config/vars.jsonnet
@@ -3,25 +3,16 @@ local kap = import 'lib/kapitan.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.appcat;
 local cms = params.clusterManagementSystem;
+local vshnServices = params.services.vshn;
 
 local isSingleCluster = cms.controlPlaneCluster && cms.serviceCluster;
 local isControlPlane = cms.controlPlaneCluster && !cms.serviceCluster;
 local isServiceCluster = !cms.controlPlaneCluster && cms.serviceCluster;
-local getSubObjects(obj) = [
-  obj[key]
-  for key in std.objectFields(obj)
-  if std.type(obj[key]) == 'object'
+local getEnabledVSHNServiceNames() = [
+  key
+  for key in std.objectFields(vshnServices)
+  if std.type(vshnServices[key]) == 'object' && std.objectHas(vshnServices[key], 'enabled') && vshnServices[key].enabled == true
 ];
-local getVSHNServicesObject() = std.md5(
-  std.manifestJson(
-    std.foldl(
-      function(acc, s)
-        if s.enabled == true then acc + s else acc,
-      getSubObjects(params.services.vshn),
-      {}
-    )
-  )
-);
 
 {
   isServiceCluster: isServiceCluster,
@@ -31,7 +22,7 @@ local getVSHNServicesObject() = std.md5(
   isSingleOrControlPlaneCluster: isSingleCluster || isControlPlane,
   isSingleOrServiceCluster: isSingleCluster || isServiceCluster,
   isExoscale: inv.parameters.facts.cloud == 'exoscale',
-  GetVSHNServicesObject(): getVSHNServicesObject(),
+  GetEnabledVSHNServiceNames(): getEnabledVSHNServiceNames(),
   assert (cms.controlPlaneKubeconfig == '' && isSingleCluster) || !isSingleCluster : 'clusterManagementSystem.controlPlaneKubeconfig should be empty for converged clusters',
   assert (cms.controlPlaneKubeconfig != '' && isServiceCluster) || (isSingleCluster || isControlPlane) : 'clusterManagementSystem.controlPlaneKubeconfig should not be empty for service clusters',
 }

--- a/tests/golden/control-plane/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/apiserver/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: 355d893e0e06924d58a19845304d936e
+    metadata.appcat.vshn.io/enabled-services-hash: 3d50aeee31a67654c31bb6df8f0b8981
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/control-plane/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: 355d893e0e06924d58a19845304d936e
+    metadata.appcat.vshn.io/enabled-services-hash: 3d50aeee31a67654c31bb6df8f0b8981
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller

--- a/tests/golden/defaults/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/apiserver/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: 56c6233ddd2c35cc95def9af91215f42
+    metadata.appcat.vshn.io/enabled-services-hash: dc4e49a05744354fe916ee3996f8da19
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/dev/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/apiserver/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: 347f69e57daae0a1bb5750dcd3e7dc33
+    metadata.appcat.vshn.io/enabled-services-hash: 3d50aeee31a67654c31bb6df8f0b8981
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/dev/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: 347f69e57daae0a1bb5750dcd3e7dc33
+    metadata.appcat.vshn.io/enabled-services-hash: 3d50aeee31a67654c31bb6df8f0b8981
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller

--- a/tests/golden/exodev/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/apiserver/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: c86b376dac7b8a5093b8e838f3fdeb4e
+    metadata.appcat.vshn.io/enabled-services-hash: b93a25d691352553157ddfb29880b694
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/exodev/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: c86b376dac7b8a5093b8e838f3fdeb4e
+    metadata.appcat.vshn.io/enabled-services-hash: b93a25d691352553157ddfb29880b694
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller

--- a/tests/golden/service-cluster/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: fb306fcdbba94a72d71c1cc09fcb5d8a
+    metadata.appcat.vshn.io/enabled-services-hash: 3d50aeee31a67654c31bb6df8f0b8981
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller

--- a/tests/golden/vshn-cloud/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/apiserver/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: d8230a96bcd2664b9ea9fa752ba3bcf8
+    metadata.appcat.vshn.io/enabled-services-hash: 05da3ea78684190be4d162a2852b7ea3
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/vshn-cloud/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: d8230a96bcd2664b9ea9fa752ba3bcf8
+    metadata.appcat.vshn.io/enabled-services-hash: 05da3ea78684190be4d162a2852b7ea3
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller

--- a/tests/golden/vshn-managed/appcat/appcat/apiserver/30_deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/apiserver/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: b6c054e9708103a0e85eca4b28b56903
+    metadata.appcat.vshn.io/enabled-services-hash: 05da3ea78684190be4d162a2852b7ea3
   labels:
     api: appcat
     apiserver: 'true'

--- a/tests/golden/vshn-managed/appcat/appcat/controllers/appcat/30_deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/controllers/appcat/30_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    metadata.appcat.vshn.io/enabled-service-hash: b6c054e9708103a0e85eca4b28b56903
+    metadata.appcat.vshn.io/enabled-services-hash: 05da3ea78684190be4d162a2852b7ea3
   labels:
     appcat-controller: appcat-controller
   name: appcat-controller


### PR DESCRIPTION
THe data feeded to the md5 function was wrong. The new function gets the vshn services that are enabled.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
