### PR TITLE
Fix unescaped function names and dedup them

### DIFF
--- a/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
@@ -18,23 +18,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-2-v4-156-0
+  name: function-appcat-v3-44-3-v4-153-1
 spec:
-  package: ghcr.io/vshn/appcat:v4.156.0-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-1-v4-154-0
-spec:
-  package: ghcr.io/vshn/appcat:v4.154.0-func
+  package: ghcr.io/vshn/appcat:v4.153.1-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat
@@ -60,9 +46,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-3-v4-153-1
+  name: function-appcat-v3-45-1-v4-154-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.153.1-func
+  package: ghcr.io/vshn/appcat:v4.154.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat
@@ -74,9 +60,23 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-2-v4-152-2
+  name: function-appcat-v3-45-2-v4-156-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.152.2-func
+  package: ghcr.io/vshn/appcat:v4.156.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-46-0-v4-158-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.158.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -18,23 +18,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-2-v4-156-0
+  name: function-appcat-v3-44-3-v4-153-1
 spec:
-  package: ghcr.io/vshn/appcat:v4.156.0-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-1-v4-154-0
-spec:
-  package: ghcr.io/vshn/appcat:v4.154.0-func
+  package: ghcr.io/vshn/appcat:v4.153.1-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat
@@ -60,9 +46,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-3-v4-153-1
+  name: function-appcat-v3-45-1-v4-154-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.153.1-func
+  package: ghcr.io/vshn/appcat:v4.154.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat
@@ -74,9 +60,23 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-2-v4-152-2
+  name: function-appcat-v3-45-2-v4-156-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.152.2-func
+  package: ghcr.io/vshn/appcat:v4.156.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-46-0-v4-158-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.158.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
@@ -18,23 +18,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-2-v4-156-0
+  name: function-appcat-v3-44-3-v4-153-1
 spec:
-  package: ghcr.io/vshn/appcat:v4.156.0-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: enable-proxy
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-1-v4-154-0
-spec:
-  package: ghcr.io/vshn/appcat:v4.154.0-func
+  package: ghcr.io/vshn/appcat:v4.153.1-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: enable-proxy
@@ -60,9 +46,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-3-v4-153-1
+  name: function-appcat-v3-45-1-v4-154-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.153.1-func
+  package: ghcr.io/vshn/appcat:v4.154.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: enable-proxy
@@ -74,9 +60,23 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-2-v4-152-2
+  name: function-appcat-v3-45-2-v4-156-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.152.2-func
+  package: ghcr.io/vshn/appcat:v4.156.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: enable-proxy
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-46-0-v4-158-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.158.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: enable-proxy

--- a/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
@@ -18,23 +18,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-2-v4-156-0
+  name: function-appcat-v3-44-3-v4-153-1
 spec:
-  package: ghcr.io/vshn/appcat:v4.156.0-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-1-v4-154-0
-spec:
-  package: ghcr.io/vshn/appcat:v4.154.0-func
+  package: ghcr.io/vshn/appcat:v4.153.1-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat
@@ -60,9 +46,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-3-v4-153-1
+  name: function-appcat-v3-45-1-v4-154-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.153.1-func
+  package: ghcr.io/vshn/appcat:v4.154.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat
@@ -74,9 +60,23 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-2-v4-152-2
+  name: function-appcat-v3-45-2-v4-156-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.152.2-func
+  package: ghcr.io/vshn/appcat:v4.156.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-46-0-v4-158-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.158.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
@@ -18,23 +18,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-2-v4-156-0
+  name: function-appcat-v3-44-3-v4-153-1
 spec:
-  package: ghcr.io/vshn/appcat:v4.156.0-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-1-v4-154-0
-spec:
-  package: ghcr.io/vshn/appcat:v4.154.0-func
+  package: ghcr.io/vshn/appcat:v4.153.1-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat
@@ -60,9 +46,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-3-v4-153-1
+  name: function-appcat-v3-45-1-v4-154-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.153.1-func
+  package: ghcr.io/vshn/appcat:v4.154.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat
@@ -74,9 +60,23 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-2-v4-152-2
+  name: function-appcat-v3-45-2-v4-156-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.152.2-func
+  package: ghcr.io/vshn/appcat:v4.156.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-46-0-v4-158-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.158.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
@@ -18,23 +18,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-2-v4-156-0
+  name: function-appcat-v3-44-3-v4-153-1
 spec:
-  package: ghcr.io/vshn/appcat:v4.156.0-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-45-1-v4-154-0
-spec:
-  package: ghcr.io/vshn/appcat:v4.154.0-func
+  package: ghcr.io/vshn/appcat:v4.153.1-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat
@@ -60,9 +46,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-3-v4-153-1
+  name: function-appcat-v3-45-1-v4-154-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.153.1-func
+  package: ghcr.io/vshn/appcat:v4.154.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat
@@ -74,9 +60,23 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-44-2-v4-152-2
+  name: function-appcat-v3-45-2-v4-156-0
 spec:
-  package: ghcr.io/vshn/appcat:v4.152.2-func
+  package: ghcr.io/vshn/appcat:v4.156.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-46-0-v4-158-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.158.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat


### PR DESCRIPTION
This fixes two issues:

- One function was generated with name that contains dots which is invalid on k8s
- With that fixed it can happen that dupes are generated. It now also filters those as well

So currently it's a bit a racecondition if argo deploys the broken one first or the right one first, which can leave to broken reconciles.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
