### PR TITLE
Fix pending annotation issues

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -27,13 +27,13 @@ parameters:
         version: 11.0.1
     images:
       provider-kubernetes:
-        registry: xpkg.upbound.io
-        repository: upbound/provider-kubernetes
-        tag: v0.17.1
+        registry: ghcr.io
+        repository: vshn/provider-kubernetes
+        tag: v0.18.0-vshn
       provider-helm:
-        registry: xpkg.upbound.io
-        repository: upbound/provider-helm
-        tag: v0.21.0
+        registry: ghcr.io
+        repository: vshn/provider-helm
+        tag: v0.21.0-vshn
       provider-exoscale:
         registry: ghcr.io
         repository: vshn/provider-exoscale

--- a/tests/golden/control-plane/appcat/appcat/10_provider_helm.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_provider_helm.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-helm
   name: provider-helm
 spec:
-  package: xpkg.upbound.io/upbound/provider-helm:v0.21.0
+  package: ghcr.io/vshn/provider-helm:v0.21.0-vshn
   runtimeConfigRef:
     name: provider-helm
 ---

--- a/tests/golden/control-plane/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: xpkg.upbound.io/upbound/provider-kubernetes:v0.17.1
+  package: ghcr.io/vshn/provider-kubernetes:v0.18.0-vshn
   runtimeConfigRef:
     name: provider-kubernetes
 ---

--- a/tests/golden/dev/appcat/appcat/10_provider_helm.yaml
+++ b/tests/golden/dev/appcat/appcat/10_provider_helm.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-helm
   name: provider-helm
 spec:
-  package: xpkg.upbound.io/upbound/provider-helm:v0.21.0
+  package: ghcr.io/vshn/provider-helm:v0.21.0-vshn
   runtimeConfigRef:
     name: provider-helm
 ---

--- a/tests/golden/dev/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/dev/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: xpkg.upbound.io/upbound/provider-kubernetes:v0.17.1
+  package: ghcr.io/vshn/provider-kubernetes:v0.18.0-vshn
   runtimeConfigRef:
     name: provider-kubernetes
 ---

--- a/tests/golden/exodev/appcat/appcat/10_provider_helm.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_provider_helm.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-helm
   name: provider-helm
 spec:
-  package: xpkg.upbound.io/upbound/provider-helm:v0.21.0
+  package: ghcr.io/vshn/provider-helm:v0.21.0-vshn
   runtimeConfigRef:
     name: provider-helm
 ---

--- a/tests/golden/exodev/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: xpkg.upbound.io/upbound/provider-kubernetes:v0.17.1
+  package: ghcr.io/vshn/provider-kubernetes:v0.18.0-vshn
   runtimeConfigRef:
     name: provider-kubernetes
 ---

--- a/tests/golden/vshn-cloud/appcat/appcat/10_provider_helm.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_provider_helm.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-helm
   name: provider-helm
 spec:
-  package: xpkg.upbound.io/upbound/provider-helm:v0.21.0
+  package: ghcr.io/vshn/provider-helm:v0.21.0-vshn
   runtimeConfigRef:
     name: provider-helm
 ---

--- a/tests/golden/vshn-cloud/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: xpkg.upbound.io/upbound/provider-kubernetes:v0.17.1
+  package: ghcr.io/vshn/provider-kubernetes:v0.18.0-vshn
   runtimeConfigRef:
     name: provider-kubernetes
 ---

--- a/tests/golden/vshn-managed/appcat/appcat/10_provider_helm.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_provider_helm.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-helm
   name: provider-helm
 spec:
-  package: xpkg.upbound.io/upbound/provider-helm:v0.21.0
+  package: ghcr.io/vshn/provider-helm:v0.21.0-vshn
   runtimeConfigRef:
     name: provider-helm
 ---

--- a/tests/golden/vshn-managed/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: xpkg.upbound.io/upbound/provider-kubernetes:v0.17.1
+  package: ghcr.io/vshn/provider-kubernetes:v0.18.0-vshn
   runtimeConfigRef:
     name: provider-kubernetes
 ---


### PR DESCRIPTION
Crossplane runtime now has a feature to disable the pending annotation for any given resources.

But currently the upstream providers don't integrate this yet. There are pending PRs for that:

https://github.com/crossplane-contrib/provider-helm/pull/289
https://github.com/crossplane-contrib/provider-kubernetes/pull/367

Until those are fixed, we're rolling our own forks.

https://github.com/vshn/provider-cloudscale
https://github.com/vshn/provider-helm

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
