### PR TITLE
Ignore Changelog for merge to master

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -43,5 +43,8 @@
       ]
     }
   ],
-  "template": "${{CATEGORIZED_COUNT}} changes since ${{FROM_TAG}}\n\n${{CHANGELOG}}"
+  "template": "${{CATEGORIZED_COUNT}} changes since ${{FROM_TAG}}\n\n${{CHANGELOG}}",
+  "ignore_labels": [
+    "ignoreChangelog"
+  ]
 }

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,10 +15,17 @@ jobs:
     name: Check labels
     runs-on: ubuntu-latest
     steps:
+      - name: Ignore from Changelog if merge to master
+        uses: actions-ecosystem/action-add-labels@v1
+        if: github.base_ref == 'master'
+        with:
+          labels: ignoreChangelog
+
       - uses: docker://agilepathway/pull-request-label-checker:v1.6.51
         with:
           one_of: enhancement,feature,minor,change,breaking,major,bug,fix,patch,documentation,dependency
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+
   create-release:
     if: github.event.pull_request.merged && github.base_ref == 'master'
     runs-on: ubuntu-latest


### PR DESCRIPTION
When the PR is merged from develop to master the changelog will also create an entry for that PR as well.

Which will clutter the changelog with "useless" PRs for the merges to master.

This commit fixes that by adding an ignore label and instruct the changelog builder to ignore all PRs with the label.

## Checklist

- [ ] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [ ] PR contains a single logical change (to build a better changelog).
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
