### PR TITLE
Increase error rate before an alert triggers

### DIFF
--- a/component/vshn_alerting.jsonnet
+++ b/component/vshn_alerting.jsonnet
@@ -24,9 +24,9 @@ local genGenericAlertingRule(serviceName, recordingRule=null) = {
         rules: [
           {
             alert: serviceName + 'Sla',
-            // this query can be read as: if the rate of probes that are not successful is higher than 0.2 in the last 5 minutes and in the last minute, then alert
-            // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 45 seconds
-            expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[1m]) > 0.75',
+            // this query can be read as: if the rate of probes that are not successful is higher than 0.4 in the last 5 minutes and in the last minute, then alert
+            // rate works on per second basis, so 0.4 means 40% of the probes are failing, which for 5 minutes is 2 minutes
+            expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="false", maintenance="false"}[5m]) > 0.4',
             annotations: {
               summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}',
               title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}',
@@ -43,9 +43,9 @@ local genGenericAlertingRule(serviceName, recordingRule=null) = {
           },
           {
             alert: serviceName + 'SlaHA',
-            // this query can be read as: if the rate of probes that are not successful is higher than 0.2 in the last 5 minutes and in the last minute, then alert
-            // rate works on per second basis, so 0.2 means 20% of the probes are failing, which for 5 minutes is 1 minute and for 1 minute is 45 seconds
-            expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true"}[1m]) > 0.75',
+            // this query can be read as: if the rate of probes that are not successful is higher than 0.4 in the last 5 minutes and in the last minute, then alert
+            // rate works on per second basis, so 0.4 means 40% of the probes are failing, which for 5 minutes is 2 minute
+            expr: 'rate(appcat_probes_seconds_count{reason!="success", service="' + serviceName + '", ha="true"}[5m]) > 0.4',
             annotations: {
               summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}',
               title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}',

--- a/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNForgejo_Opsgenie.yaml
+++ b/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNForgejo_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNForgejo",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNForgejo", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNForgejo",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNForgejo", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNKeycloak_Opsgenie.yaml
+++ b/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNKeycloak_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNKeycloak", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNKeycloak", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNMariaDB_Opsgenie.yaml
+++ b/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNMariaDB_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMariaDB",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMariaDB", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMariaDB",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMariaDB", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNNextcloud_Opsgenie.yaml
+++ b/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNNextcloud_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNNextcloud",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNNextcloud", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNNextcloud",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNNextcloud", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/dev/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNForgejo_Opsgenie.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNForgejo_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNForgejo",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNForgejo", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNForgejo",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNForgejo", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNKeycloak_Opsgenie.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNKeycloak_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNKeycloak", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNKeycloak", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNMariaDB_Opsgenie.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNMariaDB_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMariaDB",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMariaDB", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMariaDB",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMariaDB", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNNextcloud_Opsgenie.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNNextcloud_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNNextcloud",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNNextcloud", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNNextcloud",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNNextcloud", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNForgejo_Opsgenie.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNForgejo_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNForgejo",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNForgejo", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNForgejo",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNForgejo", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNKeycloak_Opsgenie.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNKeycloak_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNKeycloak", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNKeycloak", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNMariaDB_Opsgenie.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNMariaDB_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMariaDB",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMariaDB", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMariaDB",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMariaDB", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNMinio_Opsgenie.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNMinio_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMinio",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMinio", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMinio",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMinio", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNNextcloud_Opsgenie.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNNextcloud_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNNextcloud",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNNextcloud", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNNextcloud",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNNextcloud", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNForgejo_Opsgenie.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNForgejo_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNForgejo",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNForgejo", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNForgejo",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNForgejo", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNKeycloak_Opsgenie.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNKeycloak_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNKeycloak", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNKeycloak",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNKeycloak", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNMariaDB_Opsgenie.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNMariaDB_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMariaDB",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMariaDB", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMariaDB",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMariaDB", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNMinio_Opsgenie.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNMinio_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMinio",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMinio", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNMinio",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNMinio", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNNextcloud_Opsgenie.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNNextcloud_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNNextcloud",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNNextcloud", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNNextcloud",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNNextcloud", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNPostgreSQL_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNPostgreSQL",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNPostgreSQL", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'

--- a/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/sli_exporter/90_VSHNRedis_Opsgenie.yaml
@@ -16,8 +16,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
-            ha="false", maintenance="false"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="false", maintenance="false"}[1m]) > 0.75
+            ha="false", maintenance="false"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'
@@ -32,8 +31,7 @@ spec:
             summary: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
             title: '{{$labels.service}} {{$labels.name}} down in {{$labels.namespace}}'
           expr: rate(appcat_probes_seconds_count{reason!="success", service="VSHNRedis",
-            ha="true"}[5m]) > 0.2 and rate(appcat_probes_seconds_count{reason!="success",
-            service="VSHNRedis", ha="true"}[1m]) > 0.75
+            ha="true"}[5m]) > 0.4
           labels:
             OnCall: '{{ if eq $labels.sla "guaranteed" }}true{{ else }}false{{ end
               }}'


### PR DESCRIPTION
This change will increase the error rate to 2 minutes per 5 minutes. This should avoid any unnecessary oncall alerts during maintenance.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
