### PR TITLE
Fix e2e connection job assertion

### DIFF
--- a/tests/e2e/common/scripts/check-protection.sh
+++ b/tests/e2e/common/scripts/check-protection.sh
@@ -7,12 +7,16 @@ name="$2"
 
 ns=$(kubectl -n "$NAMESPACE" get "$type" "$name" -oyaml | yq -r '.status.instanceNamespace')
 
+kubectl -n "$NAMESPACE" patch "$type" "$name" -p '{"spec":{"parameters":{"security":{"deletionProtection": true}}}}' --type merge
+
 if ! kubectl -n "$NAMESPACE" delete "$type" "$name" ; then
   echo "instance protected"
 else
   echo "instance got deleted! Please check deletion protection!"
     false
 fi
+
+kubectl -n "$NAMESPACE" patch "$type" "$name" -p '{"spec":{"parameters":{"security":{"deletionProtection": false}}}}' --type merge
 
 if ! kubectl delete ns "$ns" ; then
   echo "namespace protected"

--- a/tests/e2e/forgejo/10-install.yaml
+++ b/tests/e2e/forgejo/10-install.yaml
@@ -4,6 +4,8 @@ metadata:
   name: forgejo-e2e
 spec:
   parameters:
+    security:
+      deletionProtection: false
     service:
       adminEmail: "example@vshn.vshn"
       fqdn:

--- a/tests/e2e/forgejo/30-assert.yaml
+++ b/tests/e2e/forgejo/30-assert.yaml
@@ -8,6 +8,8 @@ metadata:
   name: connect-forgejo-e2e
 status:
   conditions:
+    - type: SuccessCriteriaMet
+      status: 'True'
     - type: Complete
       status: 'True'
   succeeded: 1

--- a/tests/e2e/forgejo/40-assert.yaml
+++ b/tests/e2e/forgejo/40-assert.yaml
@@ -8,6 +8,8 @@ metadata:
   name: ingress-forgejo-e2e
 status:
   conditions:
+    - type: SuccessCriteriaMet
+      status: 'True'
     - type: Complete
       status: 'True'
   succeeded: 1
@@ -19,6 +21,8 @@ metadata:
   name: config-forgejo-e2e
 status:
   conditions:
+    - type: SuccessCriteriaMet
+      status: 'True'
     - type: Complete
       status: 'True'
   succeeded: 1

--- a/tests/e2e/keycloak/10-assert.yaml
+++ b/tests/e2e/keycloak/10-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 780
+timeout: 900
 ---
 apiVersion: vshn.appcat.vshn.io/v1
 kind: VSHNKeycloak
@@ -18,7 +18,7 @@ spec:
         keepDaily: 6
       schedule: '*/5 * * * *'
     security:
-      deletionProtection: true
+      deletionProtection: false
     service:
       postgreSQLParameters:
         instances: 1

--- a/tests/e2e/keycloak/10-install.yaml
+++ b/tests/e2e/keycloak/10-install.yaml
@@ -5,6 +5,8 @@ metadata:
   name: keycloak-e2e
 spec:
   parameters:
+    security:
+      deletionProtection: false
     service:
       fqdn: keycloak-e2e.example.com
       customMounts:

--- a/tests/e2e/keycloak/20-assert.yaml
+++ b/tests/e2e/keycloak/20-assert.yaml
@@ -8,6 +8,8 @@ metadata:
   name: connect-keycloak-e2e
 status:
   conditions:
+    - type: SuccessCriteriaMet
+      status: 'True'
     - type: Complete
       status: 'True'
   succeeded: 1

--- a/tests/e2e/mariadb/10-assert.yaml
+++ b/tests/e2e/mariadb/10-assert.yaml
@@ -15,7 +15,7 @@ spec:
   parameters:
     backup: {}
     security:
-      deletionProtection: true
+      deletionProtection: false
     service:
       serviceLevel: besteffort
       version: "11.5"

--- a/tests/e2e/mariadb/10-install.yaml
+++ b/tests/e2e/mariadb/10-install.yaml
@@ -4,6 +4,8 @@ metadata:
   name: mariadb-e2e
 spec:
   parameters:
+    security:
+      deletionProtection: false
     service:
     size:
       plan: standard-2

--- a/tests/e2e/mariadb/20-assert.yaml
+++ b/tests/e2e/mariadb/20-assert.yaml
@@ -8,6 +8,8 @@ metadata:
   name: connect-mariadb
 status:
   conditions:
+    - type: SuccessCriteriaMet
+      status: 'True'
     - type: Complete
       status: 'True'
   succeeded: 1

--- a/tests/e2e/mariadb/50-assert.yaml
+++ b/tests/e2e/mariadb/50-assert.yaml
@@ -36,6 +36,8 @@ metadata:
   name: connect-mariadb-scaled
 status:
   conditions:
+    - type: SuccessCriteriaMet
+      status: 'True'
     - type: Complete
       status: 'True'
   succeeded: 1

--- a/tests/e2e/nextcloud/10-assert.yaml
+++ b/tests/e2e/nextcloud/10-assert.yaml
@@ -17,7 +17,7 @@ spec:
       retention:
         keepDaily: 6
     security:
-      deletionProtection: true
+      deletionProtection: false
     service:
       postgreSQLParameters:
         instances: 1

--- a/tests/e2e/nextcloud/10-install.yaml
+++ b/tests/e2e/nextcloud/10-install.yaml
@@ -4,6 +4,8 @@ metadata:
   name: nextcloud-e2e
 spec:
   parameters:
+    security:
+      deletionProtection: false
     service:
       fqdn:
         - nextcloud-e2e.example.com

--- a/tests/e2e/nextcloud/20-assert.yaml
+++ b/tests/e2e/nextcloud/20-assert.yaml
@@ -8,6 +8,8 @@ metadata:
   name: connect-nextcloud-e2e
 status:
   conditions:
+    - type: SuccessCriteriaMet
+      status: 'True'
     - type: Complete
       status: 'True'
   succeeded: 1

--- a/tests/e2e/postgresql/10-assert.yaml
+++ b/tests/e2e/postgresql/10-assert.yaml
@@ -18,7 +18,7 @@ spec:
       retention: 6
     instances: 1
     security:
-      deletionProtection: true
+      deletionProtection: false
     service:
       vacuumEnabled: true
       repackEnabled: true

--- a/tests/e2e/postgresql/10-install.yaml
+++ b/tests/e2e/postgresql/10-install.yaml
@@ -4,6 +4,8 @@ metadata:
   name: postgresql-e2e-test
 spec:
   parameters:
+    security:
+      deletionProtection: false
     service:
       vacuumEnabled: true
       repackEnabled: true

--- a/tests/e2e/postgresql/20-assert.yaml
+++ b/tests/e2e/postgresql/20-assert.yaml
@@ -8,6 +8,8 @@ metadata:
   name: connect-postgresql
 status:
   conditions:
+    - type: SuccessCriteriaMet
+      status: 'True'
     - type: Complete
       status: 'True'
   succeeded: 1

--- a/tests/e2e/redis/10-assert.yaml
+++ b/tests/e2e/redis/10-assert.yaml
@@ -17,7 +17,7 @@ spec:
       retention:
         keepDaily: 6
     security:
-      deletionProtection: true
+      deletionProtection: false
     service:
       serviceLevel: besteffort
       version: "7.2"

--- a/tests/e2e/redis/10-install.yaml
+++ b/tests/e2e/redis/10-install.yaml
@@ -4,6 +4,8 @@ metadata:
   name: redis-e2e-test
 spec:
   parameters:
+    security:
+      deletionProtection: false
     size:
       plan: standard-2
   writeConnectionSecretToRef:

--- a/tests/e2e/redis/20-assert.yaml
+++ b/tests/e2e/redis/20-assert.yaml
@@ -8,6 +8,8 @@ metadata:
   name: connect-redis
 status:
   conditions:
+    - type: SuccessCriteriaMet
+      status: 'True'
     - type: Complete
       status: 'True'
   succeeded: 1

--- a/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: Always
-  runtimeConfigRef:
-    name: enable-proxy
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: Always
-  runtimeConfigRef:
-    name: enable-proxy
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: Always
+  runtimeConfigRef:
+    name: enable-proxy
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: Always
+  runtimeConfigRef:
+    name: enable-proxy
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: Always
   runtimeConfigRef:
     name: enable-proxy

--- a/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat


### PR DESCRIPTION
Somewhere between k8s 1.29 and 1.31 jobs received a new condition c`type `SuccessCriteriaMet` see https://kubernetes.io/docs/concepts/workloads/controllers/job/#success-policy.

However, this new condition confused our Kuttl tests as it expected a condition with type `Complete` as the first element of the array.

Also, the deletion protection is now only enabled during the actual test. Otherwise it's disabled, this prevents left over instances, if the tests fail for some reason before the deletion protection gets removed.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
