### PR TITLE
Revert `RECONCILIATION_PERIOD` for StackGres

### DIFF
--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -96,7 +96,6 @@ local stackgresOperator = [
         env: [
           { name: 'APP_OPTS', value: '-Dquarkus.vertx.max-worker-execute-time=5000' },
           { name: 'JAVA_OPTS', value: '-Dquarkus.vertx.max-worker-execute-time=5000' },
-          { name: 'RECONCILIATION_PERIOD', value: '3600' },
           { name: 'RECONCILIATION_PRIORITY_TIMEOUT', value: '50' },
           { name: 'RECONCILIATION_CACHE_EXPIRATION', value: '30' },
           { name: 'RECONCILIATION_CACHE_SIZE', value: '5000' },

--- a/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: Always
-  runtimeConfigRef:
-    name: enable-proxy
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: Always
-  runtimeConfigRef:
-    name: enable-proxy
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: Always
+  runtimeConfigRef:
+    name: enable-proxy
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: Always
+  runtimeConfigRef:
+    name: enable-proxy
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: Always
   runtimeConfigRef:
     name: enable-proxy

--- a/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-cloud/appcat/appcat/11_stackgres_openshift_operator.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/11_stackgres_openshift_operator.yaml
@@ -28,8 +28,6 @@ spec:
         value: -Dquarkus.vertx.max-worker-execute-time=5000
       - name: JAVA_OPTS
         value: -Dquarkus.vertx.max-worker-execute-time=5000
-      - name: RECONCILIATION_PERIOD
-        value: '3600'
       - name: RECONCILIATION_PRIORITY_TIMEOUT
         value: '50'
       - name: RECONCILIATION_CACHE_EXPIRATION

--- a/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
@@ -18,34 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-6-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-50-7-v4-163-4
-spec:
-  package: ghcr.io/vshn/appcat:v4.163.4-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-50-8-v4-164-0
 spec:
   package: ghcr.io/vshn/appcat:v4.164.0-func
@@ -77,6 +49,34 @@ metadata:
   name: function-appcat-v3-51-1-v4-165-1
 spec:
   package: ghcr.io/vshn/appcat:v4.165.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-0-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-52-1-v4-166-0
+spec:
+  package: ghcr.io/vshn/appcat:v4.166.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-managed/appcat/appcat/11_stackgres_openshift_operator.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/11_stackgres_openshift_operator.yaml
@@ -28,8 +28,6 @@ spec:
         value: -Dquarkus.vertx.max-worker-execute-time=5000
       - name: JAVA_OPTS
         value: -Dquarkus.vertx.max-worker-execute-time=5000
-      - name: RECONCILIATION_PERIOD
-        value: '3600'
       - name: RECONCILIATION_PRIORITY_TIMEOUT
         value: '50'
       - name: RECONCILIATION_CACHE_EXPIRATION


### PR DESCRIPTION
It can cause the authentication to take quite a bit to get ready with slowed down reconcile rates.

This then gets amplified by Keycloak, which is notoriously slow to begin with.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
