### PR TITLE
Pull kubectl image from registry.k8s.io

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -79,9 +79,9 @@ parameters:
         repository: vshn/billing-collector-cloudservices
         tag: v3.6.0
       kubectl:
-        registry: docker.io
-        image: bitnamilegacy/kubectl
-        tag: '1.25.15'
+        registry: registry.k8s.io
+        image: kubectl
+        tag: 'v1.33.4'
       proxysql:
         registry: docker.io
         image: proxysql/proxysql

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -48,7 +48,7 @@ spec:
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'false'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://docker-registry.inventage.com:10121/v2/keycloak-competence-center/keycloak-managed/tags/list
           mode: standalone

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -55,7 +55,7 @@ spec:
             nginx.ingress.kubernetes.io/enable-cors: "true"
             nginx.ingress.kubernetes.io/cors-allow-headers: "X-Forwarded-For"
           isOpenshift: 'false'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://hub.docker.com/v2/namespaces/library/repositories/nextcloud/tags?page_size=100
           mode: standalone

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -67,7 +67,7 @@ spec:
             "pg_stat_database_deadlocks", "pg_stat_database_temp_bytes", "pg_stat_database_xact_commit",
             "pg_stat_database_xact_rollback", "pg_static", "pg_up", "pgbouncer_show_stats_total_xact_count",
             "pgbouncer_show_stats_totals_bytes_received", "pgbouncer_show_stats_totals_bytes_sent"]'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           loadbalancerAnnotations: |
             foo: bar
           maintenanceSA: helm-based-service-maintenance

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_redis.yaml
@@ -49,7 +49,7 @@ spec:
           imageRepositoryPrefix: bitnamilegacy
           imageTag: v4.167.0
           isOpenshift: 'false'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://hub.docker.com/v2/repositories/bitnamilegacy/redis/tags/?page_size=100
           mode: standalone

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -48,7 +48,7 @@ spec:
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'false'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://docker-registry.inventage.com:10121/v2/keycloak-competence-center/keycloak-managed/tags/list
           mode: standalone

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -53,7 +53,7 @@ spec:
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'false'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://hub.docker.com/v2/namespaces/library/repositories/nextcloud/tags?page_size=100
           mode: standalone

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -67,7 +67,7 @@ spec:
             "pg_stat_database_deadlocks", "pg_stat_database_temp_bytes", "pg_stat_database_xact_commit",
             "pg_stat_database_xact_rollback", "pg_static", "pg_up", "pgbouncer_show_stats_total_xact_count",
             "pgbouncer_show_stats_totals_bytes_received", "pgbouncer_show_stats_totals_bytes_sent"]'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           loadbalancerAnnotations: |
             foo: bar
           maintenanceSA: helm-based-service-maintenance

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_redis.yaml
@@ -49,7 +49,7 @@ spec:
           imageRepositoryPrefix: bitnamilegacy
           imageTag: v4.167.0
           isOpenshift: 'false'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://hub.docker.com/v2/repositories/bitnamilegacy/redis/tags/?page_size=100
           mode: standalone

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -48,7 +48,7 @@ spec:
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'true'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://docker-registry.inventage.com:10121/v2/keycloak-competence-center/keycloak-managed/tags/list
           mode: standalone

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -53,7 +53,7 @@ spec:
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'true'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://hub.docker.com/v2/namespaces/library/repositories/nextcloud/tags?page_size=100
           mode: standalone

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -67,7 +67,7 @@ spec:
             "pg_stat_database_deadlocks", "pg_stat_database_temp_bytes", "pg_stat_database_xact_commit",
             "pg_stat_database_xact_rollback", "pg_static", "pg_up", "pgbouncer_show_stats_total_xact_count",
             "pgbouncer_show_stats_totals_bytes_received", "pgbouncer_show_stats_totals_bytes_sent"]'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           loadbalancerAnnotations: |
             foo: bar
           maintenanceSA: helm-based-service-maintenance

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_redis.yaml
@@ -49,7 +49,7 @@ spec:
           imageRepositoryPrefix: bitnamilegacy
           imageTag: v4.167.0
           isOpenshift: 'true'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://hub.docker.com/v2/repositories/bitnamilegacy/redis/tags/?page_size=100
           mode: standalone

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -48,7 +48,7 @@ spec:
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'true'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://docker-registry.inventage.com:10121/v2/keycloak-competence-center/keycloak-managed/tags/list
           mode: standalone

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -53,7 +53,7 @@ spec:
           ingress_annotations: |
             cert-manager.io/cluster-issuer: letsencrypt-staging
           isOpenshift: 'true'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://hub.docker.com/v2/namespaces/library/repositories/nextcloud/tags?page_size=100
           mode: standalone

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_postgres.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_postgres.yaml
@@ -67,7 +67,7 @@ spec:
             "pg_stat_database_deadlocks", "pg_stat_database_temp_bytes", "pg_stat_database_xact_commit",
             "pg_stat_database_xact_rollback", "pg_static", "pg_up", "pgbouncer_show_stats_total_xact_count",
             "pgbouncer_show_stats_totals_bytes_received", "pgbouncer_show_stats_totals_bytes_sent"]'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           loadbalancerAnnotations: |
             foo: bar
           maintenanceSA: helm-based-service-maintenance

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_redis.yaml
@@ -49,7 +49,7 @@ spec:
           imageRepositoryPrefix: bitnamilegacy
           imageTag: v4.167.0
           isOpenshift: 'true'
-          kubectl_image: docker.io/bitnamilegacy/kubectl:1.25.15
+          kubectl_image: registry.k8s.io/kubectl:v1.33.4
           maintenanceSA: helm-based-service-maintenance
           maintenanceURL: https://hub.docker.com/v2/repositories/bitnamilegacy/redis/tags/?page_size=100
           mode: standalone


### PR DESCRIPTION
* We can pull the image from registry.k8s.io/kubectl, which will allow us to get rid of the bitnamilegacy image.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.