### PR TITLE
Fixed postgresql being incorrectly named for OpenShift templates

### DIFF
--- a/component/vshn_postgres.jsonnet
+++ b/component/vshn_postgres.jsonnet
@@ -279,7 +279,7 @@ local templateMessage = 'Your PostgreSQL by VSHN instance is being provisioned, 
 
 local osTemplate =
   common.OpenShiftTemplate('postgresqlbyvshn',
-                           'PostgreSQL',
+                           'VSHNPostgreSQL',
                            templateDescription,
                            'icon-postgresql',
                            'database,sql,postgresql',

--- a/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
@@ -18,20 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-52-4-v4-166-2
-spec:
-  package: ghcr.io/vshn/appcat:v4.166.2-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-53-0-v4-167-0
 spec:
   package: ghcr.io/vshn/appcat:v4.167.0-func
@@ -77,6 +63,20 @@ metadata:
   name: function-appcat-v3-54-1-v4-168-1
 spec:
   package: ghcr.io/vshn/appcat:v4.168.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-54-2-v4-168-2
+spec:
+  package: ghcr.io/vshn/appcat:v4.168.2-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -18,20 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-52-4-v4-166-2
-spec:
-  package: ghcr.io/vshn/appcat:v4.166.2-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-53-0-v4-167-0
 spec:
   package: ghcr.io/vshn/appcat:v4.167.0-func
@@ -77,6 +63,20 @@ metadata:
   name: function-appcat-v3-54-1-v4-168-1
 spec:
   package: ghcr.io/vshn/appcat:v4.168.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-54-2-v4-168-2
+spec:
+  package: ghcr.io/vshn/appcat:v4.168.2-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
@@ -18,20 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-52-4-v4-166-2
-spec:
-  package: ghcr.io/vshn/appcat:v4.166.2-func
-  packagePullPolicy: Always
-  runtimeConfigRef:
-    name: enable-proxy
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-53-0-v4-167-0
 spec:
   package: ghcr.io/vshn/appcat:v4.167.0-func
@@ -77,6 +63,20 @@ metadata:
   name: function-appcat-v3-54-1-v4-168-1
 spec:
   package: ghcr.io/vshn/appcat:v4.168.1-func
+  packagePullPolicy: Always
+  runtimeConfigRef:
+    name: enable-proxy
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-54-2-v4-168-2
+spec:
+  package: ghcr.io/vshn/appcat:v4.168.2-func
   packagePullPolicy: Always
   runtimeConfigRef:
     name: enable-proxy

--- a/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
@@ -18,20 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-52-4-v4-166-2
-spec:
-  package: ghcr.io/vshn/appcat:v4.166.2-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-53-0-v4-167-0
 spec:
   package: ghcr.io/vshn/appcat:v4.167.0-func
@@ -77,6 +63,20 @@ metadata:
   name: function-appcat-v3-54-1-v4-168-1
 spec:
   package: ghcr.io/vshn/appcat:v4.168.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-54-2-v4-168-2
+spec:
+  package: ghcr.io/vshn/appcat:v4.168.2-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
@@ -18,20 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-52-4-v4-166-2
-spec:
-  package: ghcr.io/vshn/appcat:v4.166.2-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-53-0-v4-167-0
 spec:
   package: ghcr.io/vshn/appcat:v4.167.0-func
@@ -77,6 +63,20 @@ metadata:
   name: function-appcat-v3-54-1-v4-168-1
 spec:
   package: ghcr.io/vshn/appcat:v4.168.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-54-2-v4-168-2
+spec:
+  package: ghcr.io/vshn/appcat:v4.168.2-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-cloud/appcat/appcat/21_openshift_template_postgresql_vshn.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_openshift_template_postgresql_vshn.yaml
@@ -10,7 +10,7 @@ metadata:
       date back to 1986 as part of the POSTGRES project at the University of California
       at Berkeley and has more than 30 years of active development on the core platform.
     iconClass: icon-postgresql
-    openshift.io/display-name: PostgreSQL
+    openshift.io/display-name: VSHNPostgreSQL
     openshift.io/documentation-url: https://vs.hn/vshn-postgresql
     openshift.io/provider-display-name: VSHN
     openshift.io/support-url: https://www.vshn.ch/en/contact/

--- a/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
@@ -18,20 +18,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '-40'
-  name: function-appcat-v3-52-4-v4-166-2
-spec:
-  package: ghcr.io/vshn/appcat:v4.166.2-func
-  packagePullPolicy: IfNotPresent
-  runtimeConfigRef:
-    name: function-appcat
-  skipDependencyResolution: true
----
-apiVersion: pkg.crossplane.io/v1beta1
-kind: Function
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-v3-53-0-v4-167-0
 spec:
   package: ghcr.io/vshn/appcat:v4.167.0-func
@@ -77,6 +63,20 @@ metadata:
   name: function-appcat-v3-54-1-v4-168-1
 spec:
   package: ghcr.io/vshn/appcat:v4.168.1-func
+  packagePullPolicy: IfNotPresent
+  runtimeConfigRef:
+    name: function-appcat
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: '-40'
+  name: function-appcat-v3-54-2-v4-168-2
+spec:
+  package: ghcr.io/vshn/appcat:v4.168.2-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-managed/appcat/appcat/21_openshift_template_postgresql_vshn.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_openshift_template_postgresql_vshn.yaml
@@ -10,7 +10,7 @@ metadata:
       date back to 1986 as part of the POSTGRES project at the University of California
       at Berkeley and has more than 30 years of active development on the core platform.
     iconClass: icon-postgresql
-    openshift.io/display-name: PostgreSQL
+    openshift.io/display-name: VSHNPostgreSQL
     openshift.io/documentation-url: https://vs.hn/vshn-postgresql
     openshift.io/provider-display-name: VSHN
     openshift.io/support-url: https://www.vshn.ch/en/contact/


### PR DESCRIPTION
## Summary

- VSHNPostgresql was named "Postgresql" and thus was inconsistent with the naming of other AppCat services.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.