### PR TITLE
Update token in release workflow pr

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,7 +66,7 @@ jobs:
           # We also need to use the personal access token here. As subsequent
           # actions will not trigger by tags/pushes that use `GITHUB_TOKEN`
           # https://github.com/orgs/community/discussions/25702#discussioncomment-3248819
-          token: ${{ secrets.COMPONENT_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           # This is broken in checkout@v4...
           # https://github.com/actions/checkout/issues/1781
           fetch-tags: true


### PR DESCRIPTION
The workflow for releasing a new componet appcat version from a PR was using the wrong token. 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
