### PR TITLE
Dependency updates September 2025

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -34,12 +34,12 @@ parameters:
     images:
       provider-kubernetes:
         registry: ghcr.io
-        repository: vshn/provider-kubernetes
-        tag: v0.18.0-vshn
+        repository: crossplane-contrib/provider-kubernetes
+        tag: v1.0.0
       provider-helm:
         registry: ghcr.io
-        repository: vshn/provider-helm
-        tag: v0.21.0-vshn
+        repository: crossplane-contrib/provider-helm
+        tag: v1.0.0
       provider-exoscale:
         registry: ghcr.io
         repository: vshn/provider-exoscale

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -24,7 +24,7 @@ parameters:
         version: 8.0.1
       forgejo:
         source: oci://code.forgejo.org/forgejo-helm/forgejo
-        version: 13.0.1
+        version: 14.0.2
       cnpg:
         source: https://cloudnative-pg.io/charts/
         version: 0.26.0

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -91,7 +91,7 @@ parameters:
       proxysql:
         registry: docker.io
         image: proxysql/proxysql
-        version: '2.7.1'
+        version: '3.0.2'
       collabora:
         registry: docker.io
         image: collabora/code

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -18,7 +18,7 @@ parameters:
         version: 5.4.0
       keycloak:
         source: https://codecentric.github.io/helm-charts
-        version: 7.0.1
+        version: 7.1.3
       nextcloud:
         source: https://nextcloud.github.io/helm/
         version: 8.0.1

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,7 +6,7 @@ parameters:
     charts:
       crossplane:
         source: https://charts.crossplane.io/stable
-        version: 1.19.1
+        version: 1.20.1
       redis:
         source: oci://registry-1.docker.io/bitnamicharts/redis
         version: 21.2.13

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,7 +9,7 @@ parameters:
         version: 1.20.1
       redis:
         source: oci://registry-1.docker.io/bitnamicharts/redis
-        version: 21.2.13
+        version: 22.0.7
       mariadb:
         source: oci://registry-1.docker.io/bitnamicharts/mariadb-galera
         version: 16.0.1

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -12,7 +12,7 @@ parameters:
         version: 21.2.13
       mariadb:
         source: oci://registry-1.docker.io/bitnamicharts/mariadb-galera
-        version: 15.0.3
+        version: 16.0.1
       minio:
         source: https://charts.min.io
         version: 5.4.0

--- a/tests/golden/control-plane/appcat/appcat/10_provider_helm.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_provider_helm.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-helm
   name: provider-helm
 spec:
-  package: ghcr.io/vshn/provider-helm:v0.21.0-vshn
+  package: ghcr.io/crossplane-contrib/provider-helm:v1.0.0
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-helm

--- a/tests/golden/control-plane/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: ghcr.io/vshn/provider-kubernetes:v0.18.0-vshn
+  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.0.0
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-kubernetes

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_forgejo.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_forgejo.yaml
@@ -31,7 +31,7 @@ spec:
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
           chartRepository: oci://code.forgejo.org/forgejo-helm/forgejo
-          chartVersion: 13.0.1
+          chartVersion: 14.0.2
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: small

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -31,7 +31,7 @@ spec:
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.0.1
+          chartVersion: 7.1.3
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-2

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -61,7 +61,7 @@ spec:
             "8Gi"}}}'
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:2.7.1
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.2
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -30,7 +30,7 @@ spec:
         data:
           bucketRegion: lpg
           chartRepository: oci://registry-1.docker.io/bitnamicharts/mariadb-galera
-          chartVersion: 15.0.3
+          chartVersion: 16.0.1
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-1

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_redis.yaml
@@ -34,7 +34,7 @@ spec:
         data:
           bucketRegion: lpg
           chartRepository: oci://registry-1.docker.io/bitnamicharts/redis
-          chartVersion: 21.2.13
+          chartVersion: 22.0.7
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-1

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
+    app.kubernetes.io/version: 1.20.1
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.19.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -77,7 +77,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -103,8 +103,10 @@ spec:
             tcpSocket:
               port: readyz
           volumeMounts:
-            - mountPath: /cache
+            - mountPath: /cache/xpkg
               name: package-cache
+            - mountPath: /cache/xfn
+              name: function-cache
             - mountPath: /tls/server
               name: tls-server-certs
             - mountPath: /tls/client
@@ -149,7 +151,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:
@@ -170,6 +172,10 @@ spec:
             medium: null
             sizeLimit: 20Mi
           name: package-cache
+        - emptyDir:
+            medium: null
+            sizeLimit: 512Mi
+          name: function-cache
         - name: tls-server-certs
           secret:
             secretName: crossplane-tls-server

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -165,8 +165,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -223,8 +223,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -281,8 +281,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -315,8 +315,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
+    app.kubernetes.io/version: 1.20.1
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.19.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -77,7 +77,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -103,8 +103,10 @@ spec:
             tcpSocket:
               port: readyz
           volumeMounts:
-            - mountPath: /cache
+            - mountPath: /cache/xpkg
               name: package-cache
+            - mountPath: /cache/xfn
+              name: function-cache
             - mountPath: /tls/server
               name: tls-server-certs
             - mountPath: /tls/client
@@ -149,7 +151,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:
@@ -170,6 +172,10 @@ spec:
             medium: null
             sizeLimit: 20Mi
           name: package-cache
+        - emptyDir:
+            medium: null
+            sizeLimit: 512Mi
+          name: function-cache
         - name: tls-server-certs
           secret:
             secretName: crossplane-tls-server

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -165,8 +165,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -223,8 +223,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -281,8 +281,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -315,8 +315,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/dev/appcat/appcat/10_provider_helm.yaml
+++ b/tests/golden/dev/appcat/appcat/10_provider_helm.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-helm
   name: provider-helm
 spec:
-  package: ghcr.io/vshn/provider-helm:v0.21.0-vshn
+  package: ghcr.io/crossplane-contrib/provider-helm:v1.0.0
   packagePullPolicy: Always
   runtimeConfigRef:
     name: provider-helm

--- a/tests/golden/dev/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/dev/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: ghcr.io/vshn/provider-kubernetes:v0.18.0-vshn
+  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.0.0
   packagePullPolicy: Always
   runtimeConfigRef:
     name: provider-kubernetes

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_forgejo.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_forgejo.yaml
@@ -31,7 +31,7 @@ spec:
           bucketRegion: rma
           busybox_image: dockerhub.vshn.net/library/busybox
           chartRepository: oci://code.forgejo.org/forgejo-helm/forgejo
-          chartVersion: 13.0.1
+          chartVersion: 14.0.2
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: small

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -31,7 +31,7 @@ spec:
           bucketRegion: rma
           busybox_image: dockerhub.vshn.net/library/busybox
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.0.1
+          chartVersion: 7.1.3
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-2

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -30,7 +30,7 @@ spec:
         data:
           bucketRegion: rma
           chartRepository: oci://registry-1.docker.io/bitnamicharts/mariadb-galera
-          chartVersion: 15.0.3
+          chartVersion: 16.0.1
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-1

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -62,7 +62,7 @@ spec:
           proxyEndpoint: 172.19.0.1:9443
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:2.7.1
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.2
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_redis.yaml
@@ -34,7 +34,7 @@ spec:
         data:
           bucketRegion: rma
           chartRepository: oci://registry-1.docker.io/bitnamicharts/redis
-          chartVersion: 21.2.13
+          chartVersion: 22.0.7
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-1

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
+    app.kubernetes.io/version: 1.20.1
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.19.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -77,7 +77,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: Always
           name: crossplane
           ports:
@@ -103,8 +103,10 @@ spec:
             tcpSocket:
               port: readyz
           volumeMounts:
-            - mountPath: /cache
+            - mountPath: /cache/xpkg
               name: package-cache
+            - mountPath: /cache/xfn
+              name: function-cache
             - mountPath: /tls/server
               name: tls-server-certs
             - mountPath: /tls/client
@@ -149,7 +151,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: Always
           name: crossplane-init
           resources:
@@ -170,6 +172,10 @@ spec:
             medium: null
             sizeLimit: 20Mi
           name: package-cache
+        - emptyDir:
+            medium: null
+            sizeLimit: 512Mi
+          name: function-cache
         - name: tls-server-certs
           secret:
             secretName: crossplane-tls-server

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: Always
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: Always
           name: crossplane-init
           resources:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -165,8 +165,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -223,8 +223,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -281,8 +281,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -315,8 +315,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/exodev/appcat/appcat/10_provider_helm.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_provider_helm.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-helm
   name: provider-helm
 spec:
-  package: ghcr.io/vshn/provider-helm:v0.21.0-vshn
+  package: ghcr.io/crossplane-contrib/provider-helm:v1.0.0
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-helm

--- a/tests/golden/exodev/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: ghcr.io/vshn/provider-kubernetes:v0.18.0-vshn
+  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.0.0
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-kubernetes

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
+    app.kubernetes.io/version: 1.20.1
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.19.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -77,7 +77,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -103,8 +103,10 @@ spec:
             tcpSocket:
               port: readyz
           volumeMounts:
-            - mountPath: /cache
+            - mountPath: /cache/xpkg
               name: package-cache
+            - mountPath: /cache/xfn
+              name: function-cache
             - mountPath: /tls/server
               name: tls-server-certs
             - mountPath: /tls/client
@@ -149,7 +151,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:
@@ -170,6 +172,10 @@ spec:
             medium: null
             sizeLimit: 20Mi
           name: package-cache
+        - emptyDir:
+            medium: null
+            sizeLimit: 512Mi
+          name: function-cache
         - name: tls-server-certs
           secret:
             secretName: crossplane-tls-server

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -165,8 +165,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -223,8 +223,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -281,8 +281,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -315,8 +315,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/10_provider_helm.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_provider_helm.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-helm
   name: provider-helm
 spec:
-  package: ghcr.io/vshn/provider-helm:v0.21.0-vshn
+  package: ghcr.io/crossplane-contrib/provider-helm:v1.0.0
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-helm

--- a/tests/golden/vshn-cloud/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: ghcr.io/vshn/provider-kubernetes:v0.18.0-vshn
+  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.0.0
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-kubernetes

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_forgejo.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_forgejo.yaml
@@ -31,7 +31,7 @@ spec:
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
           chartRepository: oci://code.forgejo.org/forgejo-helm/forgejo
-          chartVersion: 13.0.1
+          chartVersion: 14.0.2
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: small

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -31,7 +31,7 @@ spec:
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.0.1
+          chartVersion: 7.1.3
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-2

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -61,7 +61,7 @@ spec:
             "8Gi"}}}'
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:2.7.1
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.2
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -30,7 +30,7 @@ spec:
         data:
           bucketRegion: lpg
           chartRepository: oci://registry-1.docker.io/bitnamicharts/mariadb-galera
-          chartVersion: 15.0.3
+          chartVersion: 16.0.1
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-1

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_redis.yaml
@@ -34,7 +34,7 @@ spec:
         data:
           bucketRegion: lpg
           chartRepository: oci://registry-1.docker.io/bitnamicharts/redis
-          chartVersion: 21.2.13
+          chartVersion: 22.0.7
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-1

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
+    app.kubernetes.io/version: 1.20.1
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.19.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -77,7 +77,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -103,8 +103,10 @@ spec:
             tcpSocket:
               port: readyz
           volumeMounts:
-            - mountPath: /cache
+            - mountPath: /cache/xpkg
               name: package-cache
+            - mountPath: /cache/xfn
+              name: function-cache
             - mountPath: /tls/server
               name: tls-server-certs
             - mountPath: /tls/client
@@ -149,7 +151,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:
@@ -170,6 +172,10 @@ spec:
             medium: null
             sizeLimit: 20Mi
           name: package-cache
+        - emptyDir:
+            medium: null
+            sizeLimit: 512Mi
+          name: function-cache
         - name: tls-server-certs
           secret:
             secretName: crossplane-tls-server

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -165,8 +165,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -223,8 +223,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -281,8 +281,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -315,8 +315,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/10_provider_helm.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_provider_helm.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-helm
   name: provider-helm
 spec:
-  package: ghcr.io/vshn/provider-helm:v0.21.0-vshn
+  package: ghcr.io/crossplane-contrib/provider-helm:v1.0.0
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-helm

--- a/tests/golden/vshn-managed/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: ghcr.io/vshn/provider-kubernetes:v0.18.0-vshn
+  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.0.0
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-kubernetes

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_forgejo.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_forgejo.yaml
@@ -31,7 +31,7 @@ spec:
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
           chartRepository: oci://code.forgejo.org/forgejo-helm/forgejo
-          chartVersion: 13.0.1
+          chartVersion: 14.0.2
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: small

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -31,7 +31,7 @@ spec:
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.0.1
+          chartVersion: 7.1.3
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-2

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -61,7 +61,7 @@ spec:
             "8Gi"}}}'
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:2.7.1
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.2
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -30,7 +30,7 @@ spec:
         data:
           bucketRegion: lpg
           chartRepository: oci://registry-1.docker.io/bitnamicharts/mariadb-galera
-          chartVersion: 15.0.3
+          chartVersion: 16.0.1
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-1

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_redis.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_redis.yaml
@@ -34,7 +34,7 @@ spec:
         data:
           bucketRegion: lpg
           chartRepository: oci://registry-1.docker.io/bitnamicharts/redis
-          chartVersion: 21.2.13
+          chartVersion: 22.0.7
           controlNamespace: syn-appcat-control
           crossplaneNamespace: syn-crossplane
           defaultPlan: standard-1

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
+    app.kubernetes.io/version: 1.20.1
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.19.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -77,7 +77,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -103,8 +103,10 @@ spec:
             tcpSocket:
               port: readyz
           volumeMounts:
-            - mountPath: /cache
+            - mountPath: /cache/xpkg
               name: package-cache
+            - mountPath: /cache/xfn
+              name: function-cache
             - mountPath: /tls/server
               name: tls-server-certs
             - mountPath: /tls/client
@@ -149,7 +151,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:
@@ -170,6 +172,10 @@ spec:
             medium: null
             sizeLimit: 20Mi
           name: package-cache
+        - emptyDir:
+            medium: null
+            sizeLimit: 512Mi
+          name: function-cache
         - name: tls-server-certs
           secret:
             secretName: crossplane-tls-server

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.19.1
-        helm.sh/chart: crossplane-1.19.1
+        app.kubernetes.io/version: 1.20.1
+        helm.sh/chart: crossplane-1.20.1
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.upbound.io/crossplane/crossplane:v1.19.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -165,8 +165,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -223,8 +223,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -281,8 +281,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -315,8 +315,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.19.1
-    helm.sh/chart: crossplane-1.19.1
+    app.kubernetes.io/version: 1.20.1
+    helm.sh/chart: crossplane-1.20.1
   name: crossplane
   namespace: syn-crossplane


### PR DESCRIPTION
## Summary

- Updated crossplane to 1.20.1
- Updated keycloak to 7.1.3
- Updated forgejo to 14.0.2
- Updated mariadb to 16.0.1
- Updated redis to 22.0.7
- Updated provider helm to v1.0.0
- Updated provider kubernetes to v1.0.0
- Updated proxysql to 3.0.2

Everything has been thoroughly tested on kindev and lab.
https://github.com/vshn/component-appcat/actions/runs/17793137182/job/50574577039

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] I run `make e2e-test` against local kindev and all checks passed
- [x] Link this PR to related issues or PRs.
