### PR TITLE
Fix CNPG cluster spread alert

### DIFF
--- a/component/cnpg.jsonnet
+++ b/component/cnpg.jsonnet
@@ -217,7 +217,7 @@ local prometheusrule = std.prune(kube._Object('monitoring.coreos.com/v1', 'Prome
           },
           {
             alert: 'CNPGClusterZoneSpreadWarning',
-            expr: 'count by(namespace)(kube_pod_info{namespace=~"vshn-postgresql-.*", pod=~"postgresql-.*"}) > on(namespace) count by(namespace)(count by(namespace, label_topology_kubernetes_io_zone)(kube_pod_info{namespace=~"vshn-postgresql-.*", pod=~"postgresql-.*"} * on(node) group_left(label_topology_kubernetes_io_zone) kube_node_labels)) unless on(namespace) ALERTS{alertname="CNPGClusterInstancesOnSameNode", alertstate="firing"}',
+            expr: 'count by(namespace)(kube_pod_info{namespace=~"vshn-postgresql-.*", pod=~"postgresql-.*"} * on(pod,namespace) group_right(node) kube_pod_labels{label_cnpg_io_cluster=~".+"}) > on(namespace) count by(namespace)(count by(namespace, label_topology_kubernetes_io_zone)(kube_pod_info{namespace=~"vshn-postgresql-.*", pod=~"postgresql-.*"} * on(node) group_left(label_topology_kubernetes_io_zone) kube_node_labels)) unless on(namespace) ALERTS{alertname="CNPGClusterInstancesOnSameNode", alertstate="firing"}',
             'for': '5m',
             labels: {
               severity: 'warning',


### PR DESCRIPTION
The alert considers every pod starting with `postgresql-`. This includes all the backup pods as well. Since the backup pods are not cleared up immediately, this alert fires all the time.
Restricting the alert to only the cluster pods, solves the issue.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] If no changes have been made you can self approve but otherwise at least two reviews are required
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
