### PR TITLE
Use CNPG for Nextcloud by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1184,7 +1184,7 @@ parameters:
             nextcloud_image_repository: ${appcat:images:nextcloud:image}
             busybox_image: ${appcat:images:busybox:registry}/${appcat:images:busybox:image}
             kubectl_image: ${appcat:images:kubectl:registry}/${appcat:images:kubectl:image}:${appcat:images:kubectl:tag}
-            defaultPGComposition: vshnpostgres.vshn.appcat.vshn.io
+            defaultPGComposition: vshnpostgrescnpg.vshn.appcat.vshn.io
             busybox_image_tag: ${appcat:images:busybox:tag}
           openshiftTemplate:
             serviceName: nextcloudbyvshn

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           controlNamespace: syn-appcat-control
           crDeletionAfter: '180'
           crossplaneNamespace: syn-crossplane
-          defaultPGComposition: vshnpostgres.vshn.appcat.vshn.io
+          defaultPGComposition: vshnpostgrescnpg.vshn.appcat.vshn.io
           defaultPlan: standard-2
           emailAlertingEnabled: 'false'
           emailAlertingSecretName: mailgun-smtp-credentials

--- a/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           controlNamespace: syn-appcat-control
           crDeletionAfter: '180'
           crossplaneNamespace: syn-crossplane
-          defaultPGComposition: vshnpostgres.vshn.appcat.vshn.io
+          defaultPGComposition: vshnpostgrescnpg.vshn.appcat.vshn.io
           defaultPlan: standard-2
           emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           controlNamespace: syn-appcat-control
           crDeletionAfter: '180'
           crossplaneNamespace: syn-crossplane
-          defaultPGComposition: vshnpostgres.vshn.appcat.vshn.io
+          defaultPGComposition: vshnpostgrescnpg.vshn.appcat.vshn.io
           defaultPlan: standard-2
           emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           controlNamespace: syn-appcat-control
           crDeletionAfter: '180'
           crossplaneNamespace: syn-crossplane
-          defaultPGComposition: vshnpostgres.vshn.appcat.vshn.io
+          defaultPGComposition: vshnpostgrescnpg.vshn.appcat.vshn.io
           defaultPlan: standard-2
           emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -45,7 +45,7 @@ spec:
           controlNamespace: syn-appcat-control
           crDeletionAfter: '180'
           crossplaneNamespace: syn-crossplane
-          defaultPGComposition: vshnpostgres.vshn.appcat.vshn.io
+          defaultPGComposition: vshnpostgrescnpg.vshn.appcat.vshn.io
           defaultPlan: standard-2
           emailAlertingEnabled: 'true'
           emailAlertingSecretName: mailgun-smtp-credentials


### PR DESCRIPTION
This change will use CNPG for Nextcloud by default. Existing instances will be unaffected. Also Nextcloud instances with external databses.

All e2e tests run through successfully.




## Checklist

- [ ] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [ ] PR contains a single logical change (to build a better changelog).
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] If no changes have been made you can self approve but otherwise at least two reviews are required
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
