### PR TITLE
Dependency Updates April 2026

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -46,7 +46,7 @@ parameters:
       cnpgBarmanPlugin:
         # https://artifacthub.io/packages/helm/cloudnative-pg/plugin-barman-cloud
         source: https://cloudnative-pg.io/charts/
-        version: 0.5.0
+        version: 0.6.0
         chartName: plugin-barman-cloud
       garageOperator:
         source: oci://ghcr.io/rajsinghtech/charts/garage-operator
@@ -249,9 +249,6 @@ parameters:
           prometheus: platform
       helmValues:
         additionalEnv:
-          # Prevents rolling restarts of PostgreSQL instances during operator upgrades.
-          # Instead, the instance manager binary is hot-swapped in-place.
-          # https://cloudnative-pg.io/docs/1.29/installation_upgrade
           - name: ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES
             value: "true"
           - name: EXPIRING_CHECK_THRESHOLD

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -50,7 +50,7 @@ parameters:
         chartName: plugin-barman-cloud
       garageOperator:
         source: oci://ghcr.io/rajsinghtech/charts/garage-operator
-        version: 0.1.4
+        version: 0.3.3
     images:
       provider-kubernetes:
         registry: ghcr.io

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -21,7 +21,7 @@ parameters:
         version: 7.1.9
       nextcloud:
         source: https://nextcloud.github.io/helm/
-        version: 8.9.1
+        version: 9.0.5
       forgejo:
         source: https://charts.appcat.ch/
         version: 16.2.1-vshn.1

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -27,7 +27,7 @@ parameters:
         version: 16.2.1-vshn.1
       cnpg:
         source: https://cloudnative-pg.io/charts/
-        version: 0.27.1
+        version: 0.28.0
         # Be aware that the cnpg post-process filter will append "-ubiX" to the operator image.
         # The UBI version might increase with newer versions, so check with skopeo first:
         # skopeo list-tags docker://ghcr.io/cloudnative-pg/cloudnative-pg
@@ -249,6 +249,11 @@ parameters:
           prometheus: platform
       helmValues:
         additionalEnv:
+          # Prevents rolling restarts of PostgreSQL instances during operator upgrades.
+          # Instead, the instance manager binary is hot-swapped in-place.
+          # https://cloudnative-pg.io/docs/1.29/installation_upgrade
+          - name: ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES
+            value: "true"
           - name: EXPIRING_CHECK_THRESHOLD
             value: "15"
         resources:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -18,7 +18,7 @@ parameters:
         version: 5.4.0
       keycloak:
         source: https://codecentric.github.io/helm-charts
-        version: 7.1.8
+        version: 7.1.9
       nextcloud:
         source: https://nextcloud.github.io/helm/
         version: 8.9.1

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -111,7 +111,7 @@ parameters:
       proxysql:
         registry: docker.io
         image: proxysql/proxysql
-        version: "3.0.5"
+        version: "3.0.7"
       collabora:
         registry: docker.io
         image: collabora/code

--- a/tests/dev.yml
+++ b/tests/dev.yml
@@ -30,7 +30,7 @@ parameters:
   appcat:
     charts:
       crossplane:
-        version: 2.1.3
+        version: 2.2.0
         # garage:
         #   source: oci://registry.kube-system.svc.cluster.local:5000/vshngaragecluster/vshngaragecluster
         #   version: 0.0.0

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -33,7 +33,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.37'
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.1.8
+          chartVersion: 7.1.9
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           controlNamespace: syn-appcat-control

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -66,7 +66,7 @@ spec:
             "8Gi"}}}'
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:3.0.5
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.7
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -33,7 +33,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.37'
           chartRepository: https://nextcloud.github.io/helm/
-          chartVersion: 8.9.1
+          chartVersion: 9.0.5
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           collaboraCPULimit: '1'

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: backups.postgresql.cnpg.io
 spec:
@@ -346,6 +346,15 @@ spec:
                     type: string
                   description: A map containing the plugin metadata
                   type: object
+                reconciliationStartedAt:
+                  description: When the backup process was started by the operator
+                  format: date-time
+                  type: string
+                reconciliationTerminatedAt:
+                  description: When the reconciliation was terminated by the operator
+                    (either successfully or not)
+                  format: date-time
+                  type: string
                 s3Credentials:
                   description: The credentials to use to upload data to S3
                   properties:
@@ -441,11 +450,13 @@ spec:
                       type: array
                   type: object
                 startedAt:
-                  description: When the backup was started
+                  description: When the backup execution was started by the backup
+                    tool
                   format: date-time
                   type: string
                 stoppedAt:
-                  description: When the backup was terminated
+                  description: When the backup execution was terminated by the backup
+                    tool
                   format: date-time
                   type: string
                 tablespaceMapFile:
@@ -468,7 +479,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
@@ -517,6 +528,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -552,7 +669,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusters.postgresql.cnpg.io
 spec:
@@ -4905,6 +5022,82 @@ spec:
                           type: string
                       type: object
                   type: object
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs defines named pod label selectors that can be referenced
+                    in pg_hba rules using the ${podselector:NAME} syntax in the address field.
+                    The operator resolves matching pod IPs and the instance manager expands
+                    pg_hba lines accordingly. Only pods in the Cluster's own namespace are considered.
+                  items:
+                    description: |-
+                      PodSelectorRef defines a named pod label selector for use in pg_hba rules.
+                      Pods matching the selector in the Cluster's namespace will have their IPs
+                      resolved and made available for pg_hba address expansion via the
+                      `${podselector:NAME}` syntax.
+                    properties:
+                      name:
+                        description: |-
+                          Name is the identifier used to reference this selector in pg_hba rules
+                          via the ${podselector:NAME} syntax in the address field.
+                        minLength: 1
+                        pattern: ^[a-z]([a-z0-9_-]*[a-z0-9])?$
+                        type: string
+                      selector:
+                        description: |-
+                          Selector is a label selector that identifies the pods whose IPs
+                          should be resolved. Only pods in the Cluster's namespace are considered.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                      - name
+                      - selector
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 postgresGID:
                   default: 26
                   description: The GID of the `postgres` user inside the image, defaults
@@ -4934,6 +5127,13 @@ spec:
                           ExtensionConfiguration is the configuration used to add
                           PostgreSQL extensions to the Cluster.
                         properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
                           dynamic_library_path:
                             description: |-
                               The list of directories inside the image which should be added to dynamic_library_path.
@@ -4941,6 +5141,45 @@ spec:
                             items:
                               type: string
                             type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
                           extension_control_path:
                             description: |-
                               The list of directories inside the image which should be added to extension_control_path.
@@ -4949,7 +5188,7 @@ spec:
                               type: string
                             type: array
                           image:
-                            description: The image containing the extension, required
+                            description: The image containing the extension.
                             properties:
                               pullPolicy:
                                 description: |-
@@ -4969,9 +5208,6 @@ spec:
                                   container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                              - message: An image reference is required
-                                rule: has(self.reference)
                           ld_library_path:
                             description: The list of directories inside the image
                               which should be added to ld_library_path.
@@ -4984,10 +5220,12 @@ spec:
                             pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
                             type: string
                         required:
-                          - image
                           - name
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     ldap:
                       description: Options to specify LDAP configuration
                       properties:
@@ -5069,7 +5307,9 @@ spec:
                     pg_hba:
                       description: |-
                         PostgreSQL Host Based Authentication rules (lines to be appended
-                        to the pg_hba.conf file)
+                        to the pg_hba.conf file).
+                        Use the ${podselector:NAME} syntax to reference a pod selector;
+                        the rule will be expanded for each Pod IP matching that selector.
                       items:
                         type: string
                       type: array
@@ -6281,6 +6521,20 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the cluster.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple clusters (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the cluster name.
+                    Mutually exclusive with ServiceAccountTemplate.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceAccountTemplate:
                   description: Configure the generation of the service account
                   properties:
@@ -7558,6 +7812,110 @@ spec:
                   description: PGDataImageInfo contains the details of the latest
                     image that has run on the current data directory.
                   properties:
+                    extensions:
+                      description: Extensions contains the container image extensions
+                        available for the current Image
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image
+                              which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: The name of the extension, required
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
                     image:
                       description: Image is the image name
                       type: string
@@ -7631,6 +7989,31 @@ spec:
                       - version
                     type: object
                   type: array
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs contains the resolved pod IPs for each named selector
+                    defined in spec.podSelectorRefs.
+                  items:
+                    description: PodSelectorRefStatus contains the resolved pod IPs
+                      for a named selector.
+                    properties:
+                      ips:
+                        description: |-
+                          IPs is the list of pod IPs matching the selector.
+                          Each IP is a single address (no CIDR notation).
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Name corresponds to the name in the spec's PodSelectorRef.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 poolerIntegrations:
                   description: The integration needed by poolers referencing the cluster
                   properties:
@@ -7816,7 +8199,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: databases.postgresql.cnpg.io
 spec:
@@ -8415,7 +8798,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: failoverquorums.postgresql.cnpg.io
 spec:
@@ -8494,7 +8877,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: imagecatalogs.postgresql.cnpg.io
 spec:
@@ -8542,6 +8925,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -8577,7 +9066,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: poolers.postgresql.cnpg.io
 spec:
@@ -8976,6 +9465,19 @@ spec:
                         - name
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the pooler.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple poolers (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the pooler name.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceTemplate:
                   description: Template for the Service to be created
                   properties:
@@ -17966,7 +18468,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: publications.postgresql.cnpg.io
 spec:
@@ -18163,7 +18665,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: scheduledbackups.postgresql.cnpg.io
 spec:
@@ -18356,7 +18858,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: subscriptions.postgresql.cnpg.io
 spec:

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3bb18efd43492f64393e0b3a822d6112ac962d8075fddb3a3ad8893925b37752
-        checksum/monitoring-config: bc0322bcf7fedd5cc42cf396b5dacbb80696b4916865cf174119c71cca641e26
-        checksum/rbac: b6788fd81bfaea5bd26c64f1c94e4815e8d46f4cc66fcf6932b61327e430511a
+        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
+        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
+        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,16 +36,18 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: MONITORING_QUERIES_CONFIGMAP
               value: cnpg-default-monitoring
+            - name: ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES
+              value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
+    app.kubernetes.io/version: 1.29.0
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.27.1
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-role
   namespace: syn-cnpg-system
 rules:
@@ -53,8 +53,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-rolebinding
   namespace: syn-cnpg-system
 roleRef:

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.11.0
+  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.12.0
 kind: ConfigMap
 metadata:
   name: plugin-barman-cloud-config

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: objectstores.barmancloud.cnpg.io
 spec:

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 spec:
@@ -38,7 +38,7 @@ spec:
                 configMapKeyRef:
                   key: SIDECAR_IMAGE
                   name: plugin-barman-cloud-config
-          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.11.0
+          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.12.0
           name: barman-cloud
           ports:
             - containerPort: 9090

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 ---
@@ -91,8 +91,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0
     cnpg.io/pluginName: barman-cloud.cloudnative-pg.io
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: barman-cloud
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: backups.postgresql.cnpg.io
 spec:
@@ -346,6 +346,15 @@ spec:
                     type: string
                   description: A map containing the plugin metadata
                   type: object
+                reconciliationStartedAt:
+                  description: When the backup process was started by the operator
+                  format: date-time
+                  type: string
+                reconciliationTerminatedAt:
+                  description: When the reconciliation was terminated by the operator
+                    (either successfully or not)
+                  format: date-time
+                  type: string
                 s3Credentials:
                   description: The credentials to use to upload data to S3
                   properties:
@@ -441,11 +450,13 @@ spec:
                       type: array
                   type: object
                 startedAt:
-                  description: When the backup was started
+                  description: When the backup execution was started by the backup
+                    tool
                   format: date-time
                   type: string
                 stoppedAt:
-                  description: When the backup was terminated
+                  description: When the backup execution was terminated by the backup
+                    tool
                   format: date-time
                   type: string
                 tablespaceMapFile:
@@ -468,7 +479,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
@@ -517,6 +528,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -552,7 +669,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusters.postgresql.cnpg.io
 spec:
@@ -4905,6 +5022,82 @@ spec:
                           type: string
                       type: object
                   type: object
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs defines named pod label selectors that can be referenced
+                    in pg_hba rules using the ${podselector:NAME} syntax in the address field.
+                    The operator resolves matching pod IPs and the instance manager expands
+                    pg_hba lines accordingly. Only pods in the Cluster's own namespace are considered.
+                  items:
+                    description: |-
+                      PodSelectorRef defines a named pod label selector for use in pg_hba rules.
+                      Pods matching the selector in the Cluster's namespace will have their IPs
+                      resolved and made available for pg_hba address expansion via the
+                      `${podselector:NAME}` syntax.
+                    properties:
+                      name:
+                        description: |-
+                          Name is the identifier used to reference this selector in pg_hba rules
+                          via the ${podselector:NAME} syntax in the address field.
+                        minLength: 1
+                        pattern: ^[a-z]([a-z0-9_-]*[a-z0-9])?$
+                        type: string
+                      selector:
+                        description: |-
+                          Selector is a label selector that identifies the pods whose IPs
+                          should be resolved. Only pods in the Cluster's namespace are considered.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                      - name
+                      - selector
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 postgresGID:
                   default: 26
                   description: The GID of the `postgres` user inside the image, defaults
@@ -4934,6 +5127,13 @@ spec:
                           ExtensionConfiguration is the configuration used to add
                           PostgreSQL extensions to the Cluster.
                         properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
                           dynamic_library_path:
                             description: |-
                               The list of directories inside the image which should be added to dynamic_library_path.
@@ -4941,6 +5141,45 @@ spec:
                             items:
                               type: string
                             type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
                           extension_control_path:
                             description: |-
                               The list of directories inside the image which should be added to extension_control_path.
@@ -4949,7 +5188,7 @@ spec:
                               type: string
                             type: array
                           image:
-                            description: The image containing the extension, required
+                            description: The image containing the extension.
                             properties:
                               pullPolicy:
                                 description: |-
@@ -4969,9 +5208,6 @@ spec:
                                   container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                              - message: An image reference is required
-                                rule: has(self.reference)
                           ld_library_path:
                             description: The list of directories inside the image
                               which should be added to ld_library_path.
@@ -4984,10 +5220,12 @@ spec:
                             pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
                             type: string
                         required:
-                          - image
                           - name
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     ldap:
                       description: Options to specify LDAP configuration
                       properties:
@@ -5069,7 +5307,9 @@ spec:
                     pg_hba:
                       description: |-
                         PostgreSQL Host Based Authentication rules (lines to be appended
-                        to the pg_hba.conf file)
+                        to the pg_hba.conf file).
+                        Use the ${podselector:NAME} syntax to reference a pod selector;
+                        the rule will be expanded for each Pod IP matching that selector.
                       items:
                         type: string
                       type: array
@@ -6281,6 +6521,20 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the cluster.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple clusters (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the cluster name.
+                    Mutually exclusive with ServiceAccountTemplate.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceAccountTemplate:
                   description: Configure the generation of the service account
                   properties:
@@ -7558,6 +7812,110 @@ spec:
                   description: PGDataImageInfo contains the details of the latest
                     image that has run on the current data directory.
                   properties:
+                    extensions:
+                      description: Extensions contains the container image extensions
+                        available for the current Image
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image
+                              which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: The name of the extension, required
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
                     image:
                       description: Image is the image name
                       type: string
@@ -7631,6 +7989,31 @@ spec:
                       - version
                     type: object
                   type: array
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs contains the resolved pod IPs for each named selector
+                    defined in spec.podSelectorRefs.
+                  items:
+                    description: PodSelectorRefStatus contains the resolved pod IPs
+                      for a named selector.
+                    properties:
+                      ips:
+                        description: |-
+                          IPs is the list of pod IPs matching the selector.
+                          Each IP is a single address (no CIDR notation).
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Name corresponds to the name in the spec's PodSelectorRef.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 poolerIntegrations:
                   description: The integration needed by poolers referencing the cluster
                   properties:
@@ -7816,7 +8199,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: databases.postgresql.cnpg.io
 spec:
@@ -8415,7 +8798,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: failoverquorums.postgresql.cnpg.io
 spec:
@@ -8494,7 +8877,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: imagecatalogs.postgresql.cnpg.io
 spec:
@@ -8542,6 +8925,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -8577,7 +9066,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: poolers.postgresql.cnpg.io
 spec:
@@ -8976,6 +9465,19 @@ spec:
                         - name
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the pooler.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple poolers (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the pooler name.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceTemplate:
                   description: Template for the Service to be created
                   properties:
@@ -17966,7 +18468,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: publications.postgresql.cnpg.io
 spec:
@@ -18163,7 +18665,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: scheduledbackups.postgresql.cnpg.io
 spec:
@@ -18356,7 +18858,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: subscriptions.postgresql.cnpg.io
 spec:

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3bb18efd43492f64393e0b3a822d6112ac962d8075fddb3a3ad8893925b37752
-        checksum/monitoring-config: bc0322bcf7fedd5cc42cf396b5dacbb80696b4916865cf174119c71cca641e26
-        checksum/rbac: b6788fd81bfaea5bd26c64f1c94e4815e8d46f4cc66fcf6932b61327e430511a
+        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
+        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
+        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,16 +36,18 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: MONITORING_QUERIES_CONFIGMAP
               value: cnpg-default-monitoring
+            - name: ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES
+              value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
+    app.kubernetes.io/version: 1.29.0
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.27.1
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-role
   namespace: syn-cnpg-system
 rules:
@@ -53,8 +53,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-rolebinding
   namespace: syn-cnpg-system
 roleRef:

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.11.0
+  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.12.0
 kind: ConfigMap
 metadata:
   name: plugin-barman-cloud-config

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: objectstores.barmancloud.cnpg.io
 spec:

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 spec:
@@ -38,7 +38,7 @@ spec:
                 configMapKeyRef:
                   key: SIDECAR_IMAGE
                   name: plugin-barman-cloud-config
-          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.11.0
+          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.12.0
           name: barman-cloud
           ports:
             - containerPort: 9090

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 ---
@@ -91,8 +91,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0
     cnpg.io/pluginName: barman-cloud.cloudnative-pg.io
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: barman-cloud
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -33,7 +33,7 @@ spec:
           busybox_image: dockerhub.vshn.net/library/busybox
           busybox_image_tag: '1.37'
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.1.8
+          chartVersion: 7.1.9
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           controlNamespace: syn-appcat-control

--- a/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -66,7 +66,7 @@ spec:
             "8Gi"}}}'
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:3.0.5
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.7
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -33,7 +33,7 @@ spec:
           busybox_image: dockerhub.vshn.net/library/busybox
           busybox_image_tag: '1.37'
           chartRepository: https://nextcloud.github.io/helm/
-          chartVersion: 8.9.1
+          chartVersion: 9.0.5
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           collaboraCPULimit: '1'

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: backups.postgresql.cnpg.io
 spec:
@@ -346,6 +346,15 @@ spec:
                     type: string
                   description: A map containing the plugin metadata
                   type: object
+                reconciliationStartedAt:
+                  description: When the backup process was started by the operator
+                  format: date-time
+                  type: string
+                reconciliationTerminatedAt:
+                  description: When the reconciliation was terminated by the operator
+                    (either successfully or not)
+                  format: date-time
+                  type: string
                 s3Credentials:
                   description: The credentials to use to upload data to S3
                   properties:
@@ -441,11 +450,13 @@ spec:
                       type: array
                   type: object
                 startedAt:
-                  description: When the backup was started
+                  description: When the backup execution was started by the backup
+                    tool
                   format: date-time
                   type: string
                 stoppedAt:
-                  description: When the backup was terminated
+                  description: When the backup execution was terminated by the backup
+                    tool
                   format: date-time
                   type: string
                 tablespaceMapFile:
@@ -468,7 +479,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
@@ -517,6 +528,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -552,7 +669,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusters.postgresql.cnpg.io
 spec:
@@ -4905,6 +5022,82 @@ spec:
                           type: string
                       type: object
                   type: object
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs defines named pod label selectors that can be referenced
+                    in pg_hba rules using the ${podselector:NAME} syntax in the address field.
+                    The operator resolves matching pod IPs and the instance manager expands
+                    pg_hba lines accordingly. Only pods in the Cluster's own namespace are considered.
+                  items:
+                    description: |-
+                      PodSelectorRef defines a named pod label selector for use in pg_hba rules.
+                      Pods matching the selector in the Cluster's namespace will have their IPs
+                      resolved and made available for pg_hba address expansion via the
+                      `${podselector:NAME}` syntax.
+                    properties:
+                      name:
+                        description: |-
+                          Name is the identifier used to reference this selector in pg_hba rules
+                          via the ${podselector:NAME} syntax in the address field.
+                        minLength: 1
+                        pattern: ^[a-z]([a-z0-9_-]*[a-z0-9])?$
+                        type: string
+                      selector:
+                        description: |-
+                          Selector is a label selector that identifies the pods whose IPs
+                          should be resolved. Only pods in the Cluster's namespace are considered.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                      - name
+                      - selector
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 postgresGID:
                   default: 26
                   description: The GID of the `postgres` user inside the image, defaults
@@ -4934,6 +5127,13 @@ spec:
                           ExtensionConfiguration is the configuration used to add
                           PostgreSQL extensions to the Cluster.
                         properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
                           dynamic_library_path:
                             description: |-
                               The list of directories inside the image which should be added to dynamic_library_path.
@@ -4941,6 +5141,45 @@ spec:
                             items:
                               type: string
                             type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
                           extension_control_path:
                             description: |-
                               The list of directories inside the image which should be added to extension_control_path.
@@ -4949,7 +5188,7 @@ spec:
                               type: string
                             type: array
                           image:
-                            description: The image containing the extension, required
+                            description: The image containing the extension.
                             properties:
                               pullPolicy:
                                 description: |-
@@ -4969,9 +5208,6 @@ spec:
                                   container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                              - message: An image reference is required
-                                rule: has(self.reference)
                           ld_library_path:
                             description: The list of directories inside the image
                               which should be added to ld_library_path.
@@ -4984,10 +5220,12 @@ spec:
                             pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
                             type: string
                         required:
-                          - image
                           - name
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     ldap:
                       description: Options to specify LDAP configuration
                       properties:
@@ -5069,7 +5307,9 @@ spec:
                     pg_hba:
                       description: |-
                         PostgreSQL Host Based Authentication rules (lines to be appended
-                        to the pg_hba.conf file)
+                        to the pg_hba.conf file).
+                        Use the ${podselector:NAME} syntax to reference a pod selector;
+                        the rule will be expanded for each Pod IP matching that selector.
                       items:
                         type: string
                       type: array
@@ -6281,6 +6521,20 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the cluster.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple clusters (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the cluster name.
+                    Mutually exclusive with ServiceAccountTemplate.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceAccountTemplate:
                   description: Configure the generation of the service account
                   properties:
@@ -7558,6 +7812,110 @@ spec:
                   description: PGDataImageInfo contains the details of the latest
                     image that has run on the current data directory.
                   properties:
+                    extensions:
+                      description: Extensions contains the container image extensions
+                        available for the current Image
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image
+                              which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: The name of the extension, required
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
                     image:
                       description: Image is the image name
                       type: string
@@ -7631,6 +7989,31 @@ spec:
                       - version
                     type: object
                   type: array
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs contains the resolved pod IPs for each named selector
+                    defined in spec.podSelectorRefs.
+                  items:
+                    description: PodSelectorRefStatus contains the resolved pod IPs
+                      for a named selector.
+                    properties:
+                      ips:
+                        description: |-
+                          IPs is the list of pod IPs matching the selector.
+                          Each IP is a single address (no CIDR notation).
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Name corresponds to the name in the spec's PodSelectorRef.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 poolerIntegrations:
                   description: The integration needed by poolers referencing the cluster
                   properties:
@@ -7816,7 +8199,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: databases.postgresql.cnpg.io
 spec:
@@ -8415,7 +8798,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: failoverquorums.postgresql.cnpg.io
 spec:
@@ -8494,7 +8877,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: imagecatalogs.postgresql.cnpg.io
 spec:
@@ -8542,6 +8925,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -8577,7 +9066,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: poolers.postgresql.cnpg.io
 spec:
@@ -8976,6 +9465,19 @@ spec:
                         - name
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the pooler.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple poolers (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the pooler name.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceTemplate:
                   description: Template for the Service to be created
                   properties:
@@ -17966,7 +18468,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: publications.postgresql.cnpg.io
 spec:
@@ -18163,7 +18665,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: scheduledbackups.postgresql.cnpg.io
 spec:
@@ -18356,7 +18858,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: subscriptions.postgresql.cnpg.io
 spec:

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3bb18efd43492f64393e0b3a822d6112ac962d8075fddb3a3ad8893925b37752
-        checksum/monitoring-config: bc0322bcf7fedd5cc42cf396b5dacbb80696b4916865cf174119c71cca641e26
-        checksum/rbac: b6788fd81bfaea5bd26c64f1c94e4815e8d46f4cc66fcf6932b61327e430511a
+        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
+        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
+        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,16 +36,18 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: MONITORING_QUERIES_CONFIGMAP
               value: cnpg-default-monitoring
+            - name: ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES
+              value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
+    app.kubernetes.io/version: 1.29.0
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.27.1
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-role
   namespace: syn-cnpg-system
 rules:
@@ -53,8 +53,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-rolebinding
   namespace: syn-cnpg-system
 roleRef:

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.11.0
+  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.12.0
 kind: ConfigMap
 metadata:
   name: plugin-barman-cloud-config

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: objectstores.barmancloud.cnpg.io
 spec:

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 spec:
@@ -38,7 +38,7 @@ spec:
                 configMapKeyRef:
                   key: SIDECAR_IMAGE
                   name: plugin-barman-cloud-config
-          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.11.0
+          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.12.0
           name: barman-cloud
           ports:
             - containerPort: 9090

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 ---
@@ -91,8 +91,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0
     cnpg.io/pluginName: barman-cloud.cloudnative-pg.io
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: barman-cloud
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -33,7 +33,7 @@ spec:
           busybox_image: dockerhub.vshn.net/library/busybox
           busybox_image_tag: '1.37'
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.1.8
+          chartVersion: 7.1.9
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           controlNamespace: syn-appcat-control

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -67,7 +67,7 @@ spec:
           proxyEndpoint: 172.18.0.1:9443
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:3.0.5
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.7
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -33,7 +33,7 @@ spec:
           busybox_image: dockerhub.vshn.net/library/busybox
           busybox_image_tag: '1.37'
           chartRepository: https://nextcloud.github.io/helm/
-          chartVersion: 8.9.1
+          chartVersion: 9.0.5
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           collaboraCPULimit: '1'

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: backups.postgresql.cnpg.io
 spec:
@@ -346,6 +346,15 @@ spec:
                     type: string
                   description: A map containing the plugin metadata
                   type: object
+                reconciliationStartedAt:
+                  description: When the backup process was started by the operator
+                  format: date-time
+                  type: string
+                reconciliationTerminatedAt:
+                  description: When the reconciliation was terminated by the operator
+                    (either successfully or not)
+                  format: date-time
+                  type: string
                 s3Credentials:
                   description: The credentials to use to upload data to S3
                   properties:
@@ -441,11 +450,13 @@ spec:
                       type: array
                   type: object
                 startedAt:
-                  description: When the backup was started
+                  description: When the backup execution was started by the backup
+                    tool
                   format: date-time
                   type: string
                 stoppedAt:
-                  description: When the backup was terminated
+                  description: When the backup execution was terminated by the backup
+                    tool
                   format: date-time
                   type: string
                 tablespaceMapFile:
@@ -468,7 +479,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
@@ -517,6 +528,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -552,7 +669,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusters.postgresql.cnpg.io
 spec:
@@ -4905,6 +5022,82 @@ spec:
                           type: string
                       type: object
                   type: object
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs defines named pod label selectors that can be referenced
+                    in pg_hba rules using the ${podselector:NAME} syntax in the address field.
+                    The operator resolves matching pod IPs and the instance manager expands
+                    pg_hba lines accordingly. Only pods in the Cluster's own namespace are considered.
+                  items:
+                    description: |-
+                      PodSelectorRef defines a named pod label selector for use in pg_hba rules.
+                      Pods matching the selector in the Cluster's namespace will have their IPs
+                      resolved and made available for pg_hba address expansion via the
+                      `${podselector:NAME}` syntax.
+                    properties:
+                      name:
+                        description: |-
+                          Name is the identifier used to reference this selector in pg_hba rules
+                          via the ${podselector:NAME} syntax in the address field.
+                        minLength: 1
+                        pattern: ^[a-z]([a-z0-9_-]*[a-z0-9])?$
+                        type: string
+                      selector:
+                        description: |-
+                          Selector is a label selector that identifies the pods whose IPs
+                          should be resolved. Only pods in the Cluster's namespace are considered.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                      - name
+                      - selector
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 postgresGID:
                   default: 26
                   description: The GID of the `postgres` user inside the image, defaults
@@ -4934,6 +5127,13 @@ spec:
                           ExtensionConfiguration is the configuration used to add
                           PostgreSQL extensions to the Cluster.
                         properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
                           dynamic_library_path:
                             description: |-
                               The list of directories inside the image which should be added to dynamic_library_path.
@@ -4941,6 +5141,45 @@ spec:
                             items:
                               type: string
                             type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
                           extension_control_path:
                             description: |-
                               The list of directories inside the image which should be added to extension_control_path.
@@ -4949,7 +5188,7 @@ spec:
                               type: string
                             type: array
                           image:
-                            description: The image containing the extension, required
+                            description: The image containing the extension.
                             properties:
                               pullPolicy:
                                 description: |-
@@ -4969,9 +5208,6 @@ spec:
                                   container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                              - message: An image reference is required
-                                rule: has(self.reference)
                           ld_library_path:
                             description: The list of directories inside the image
                               which should be added to ld_library_path.
@@ -4984,10 +5220,12 @@ spec:
                             pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
                             type: string
                         required:
-                          - image
                           - name
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     ldap:
                       description: Options to specify LDAP configuration
                       properties:
@@ -5069,7 +5307,9 @@ spec:
                     pg_hba:
                       description: |-
                         PostgreSQL Host Based Authentication rules (lines to be appended
-                        to the pg_hba.conf file)
+                        to the pg_hba.conf file).
+                        Use the ${podselector:NAME} syntax to reference a pod selector;
+                        the rule will be expanded for each Pod IP matching that selector.
                       items:
                         type: string
                       type: array
@@ -6281,6 +6521,20 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the cluster.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple clusters (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the cluster name.
+                    Mutually exclusive with ServiceAccountTemplate.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceAccountTemplate:
                   description: Configure the generation of the service account
                   properties:
@@ -7558,6 +7812,110 @@ spec:
                   description: PGDataImageInfo contains the details of the latest
                     image that has run on the current data directory.
                   properties:
+                    extensions:
+                      description: Extensions contains the container image extensions
+                        available for the current Image
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image
+                              which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: The name of the extension, required
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
                     image:
                       description: Image is the image name
                       type: string
@@ -7631,6 +7989,31 @@ spec:
                       - version
                     type: object
                   type: array
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs contains the resolved pod IPs for each named selector
+                    defined in spec.podSelectorRefs.
+                  items:
+                    description: PodSelectorRefStatus contains the resolved pod IPs
+                      for a named selector.
+                    properties:
+                      ips:
+                        description: |-
+                          IPs is the list of pod IPs matching the selector.
+                          Each IP is a single address (no CIDR notation).
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Name corresponds to the name in the spec's PodSelectorRef.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 poolerIntegrations:
                   description: The integration needed by poolers referencing the cluster
                   properties:
@@ -7816,7 +8199,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: databases.postgresql.cnpg.io
 spec:
@@ -8415,7 +8798,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: failoverquorums.postgresql.cnpg.io
 spec:
@@ -8494,7 +8877,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: imagecatalogs.postgresql.cnpg.io
 spec:
@@ -8542,6 +8925,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -8577,7 +9066,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: poolers.postgresql.cnpg.io
 spec:
@@ -8976,6 +9465,19 @@ spec:
                         - name
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the pooler.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple poolers (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the pooler name.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceTemplate:
                   description: Template for the Service to be created
                   properties:
@@ -17966,7 +18468,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: publications.postgresql.cnpg.io
 spec:
@@ -18163,7 +18665,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: scheduledbackups.postgresql.cnpg.io
 spec:
@@ -18356,7 +18858,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: subscriptions.postgresql.cnpg.io
 spec:

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3bb18efd43492f64393e0b3a822d6112ac962d8075fddb3a3ad8893925b37752
-        checksum/monitoring-config: bc0322bcf7fedd5cc42cf396b5dacbb80696b4916865cf174119c71cca641e26
-        checksum/rbac: b6788fd81bfaea5bd26c64f1c94e4815e8d46f4cc66fcf6932b61327e430511a
+        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
+        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
+        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,16 +36,18 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: MONITORING_QUERIES_CONFIGMAP
               value: cnpg-default-monitoring
+            - name: ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES
+              value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
+    app.kubernetes.io/version: 1.29.0
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.27.1
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-role
   namespace: syn-cnpg-system
 rules:
@@ -53,8 +53,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-rolebinding
   namespace: syn-cnpg-system
 roleRef:

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.11.0
+  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.12.0
 kind: ConfigMap
 metadata:
   name: plugin-barman-cloud-config

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: objectstores.barmancloud.cnpg.io
 spec:

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 spec:
@@ -38,7 +38,7 @@ spec:
                 configMapKeyRef:
                   key: SIDECAR_IMAGE
                   name: plugin-barman-cloud-config
-          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.11.0
+          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.12.0
           name: barman-cloud
           ports:
             - containerPort: 9090

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 ---
@@ -91,8 +91,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0
     cnpg.io/pluginName: barman-cloud.cloudnative-pg.io
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: barman-cloud
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
+    app.kubernetes.io/version: 2.2.0
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.1.3
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.1.3
-        helm.sh/chart: crossplane-2.1.3
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.1.3
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: Always
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.1.3
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: Always
           name: crossplane-init
           resources:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.1.3
-        helm.sh/chart: crossplane-2.1.3
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.1.3
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: Always
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.1.3
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: Always
           name: crossplane-init
           resources:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.1.3
-    helm.sh/chart: crossplane-2.1.3
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/clusterrole.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/clusterrole.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: appcat-garage-operator-manager-role
 rules:
   - apiGroups:
@@ -109,3 +109,15 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/clusterrolebinding.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/clusterrolebinding.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: appcat-garage-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/crds.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/crds.yaml
@@ -8,9 +8,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: garageadmintokens.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info
@@ -283,9 +283,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: garagebuckets.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info
@@ -693,9 +693,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: garageclusters.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info
@@ -2420,6 +2420,27 @@ spec:
                       description: Syslog enables logging to syslog (requires Garage
                         built with syslog feature)
                       type: boolean
+                  type: object
+                monitoring:
+                  description: Monitoring configures Prometheus integration for this
+                    cluster.
+                  properties:
+                    additionalLabels:
+                      additionalProperties:
+                        type: string
+                      description: AdditionalLabels are added to the ServiceMonitor
+                        metadata.
+                      type: object
+                    enabled:
+                      description: |-
+                        Enabled creates a ServiceMonitor targeting the admin API /metrics endpoint.
+                        Requires prometheus-operator to be installed in the cluster.
+                      type: boolean
+                    interval:
+                      description: |-
+                        Interval is the Prometheus scrape interval (e.g. "30s", "1m").
+                        Defaults to the Prometheus global scrape interval when unset.
+                      type: string
                   type: object
                 network:
                   description: Network configures RPC and API networking
@@ -4755,9 +4776,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: garagekeys.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info
@@ -5244,9 +5265,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: garagenodes.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/deployment.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: appcat-garage-operator
   namespace: syn-garage-operator
 spec:
@@ -33,7 +33,7 @@ spec:
             - --health-probe-bind-address=:8081
           command:
             - /manager
-          image: ghcr.io/rajsinghtech/garage-operator:v0.1.4
+          image: ghcr.io/rajsinghtech/garage-operator:v0.3.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/metrics-rbac.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/metrics-rbac.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: appcat-garage-operator-metrics-auth-role
 rules:
   - apiGroups:
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: appcat-garage-operator-metrics-reader
 rules:
   - nonResourceURLs:
@@ -47,9 +47,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: appcat-garage-operator-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/role.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/role.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: appcat-garage-operator-leader-election-role
   namespace: syn-garage-operator
 rules:

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/rolebinding.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/rolebinding.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: appcat-garage-operator-leader-election-rolebinding
   namespace: syn-garage-operator
 roleRef:

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/service.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/service.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: appcat-garage-operator-metrics
   namespace: syn-garage-operator
 spec:

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/serviceaccount.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.1.4
+    app.kubernetes.io/version: 0.3.3
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.1.4
+    helm.sh/chart: garage-operator-0.3.3
   name: appcat-garage-operator
   namespace: syn-garage-operator

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: backups.postgresql.cnpg.io
 spec:
@@ -346,6 +346,15 @@ spec:
                     type: string
                   description: A map containing the plugin metadata
                   type: object
+                reconciliationStartedAt:
+                  description: When the backup process was started by the operator
+                  format: date-time
+                  type: string
+                reconciliationTerminatedAt:
+                  description: When the reconciliation was terminated by the operator
+                    (either successfully or not)
+                  format: date-time
+                  type: string
                 s3Credentials:
                   description: The credentials to use to upload data to S3
                   properties:
@@ -441,11 +450,13 @@ spec:
                       type: array
                   type: object
                 startedAt:
-                  description: When the backup was started
+                  description: When the backup execution was started by the backup
+                    tool
                   format: date-time
                   type: string
                 stoppedAt:
-                  description: When the backup was terminated
+                  description: When the backup execution was terminated by the backup
+                    tool
                   format: date-time
                   type: string
                 tablespaceMapFile:
@@ -468,7 +479,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
@@ -517,6 +528,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -552,7 +669,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusters.postgresql.cnpg.io
 spec:
@@ -4905,6 +5022,82 @@ spec:
                           type: string
                       type: object
                   type: object
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs defines named pod label selectors that can be referenced
+                    in pg_hba rules using the ${podselector:NAME} syntax in the address field.
+                    The operator resolves matching pod IPs and the instance manager expands
+                    pg_hba lines accordingly. Only pods in the Cluster's own namespace are considered.
+                  items:
+                    description: |-
+                      PodSelectorRef defines a named pod label selector for use in pg_hba rules.
+                      Pods matching the selector in the Cluster's namespace will have their IPs
+                      resolved and made available for pg_hba address expansion via the
+                      `${podselector:NAME}` syntax.
+                    properties:
+                      name:
+                        description: |-
+                          Name is the identifier used to reference this selector in pg_hba rules
+                          via the ${podselector:NAME} syntax in the address field.
+                        minLength: 1
+                        pattern: ^[a-z]([a-z0-9_-]*[a-z0-9])?$
+                        type: string
+                      selector:
+                        description: |-
+                          Selector is a label selector that identifies the pods whose IPs
+                          should be resolved. Only pods in the Cluster's namespace are considered.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                      - name
+                      - selector
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 postgresGID:
                   default: 26
                   description: The GID of the `postgres` user inside the image, defaults
@@ -4934,6 +5127,13 @@ spec:
                           ExtensionConfiguration is the configuration used to add
                           PostgreSQL extensions to the Cluster.
                         properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
                           dynamic_library_path:
                             description: |-
                               The list of directories inside the image which should be added to dynamic_library_path.
@@ -4941,6 +5141,45 @@ spec:
                             items:
                               type: string
                             type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
                           extension_control_path:
                             description: |-
                               The list of directories inside the image which should be added to extension_control_path.
@@ -4949,7 +5188,7 @@ spec:
                               type: string
                             type: array
                           image:
-                            description: The image containing the extension, required
+                            description: The image containing the extension.
                             properties:
                               pullPolicy:
                                 description: |-
@@ -4969,9 +5208,6 @@ spec:
                                   container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                              - message: An image reference is required
-                                rule: has(self.reference)
                           ld_library_path:
                             description: The list of directories inside the image
                               which should be added to ld_library_path.
@@ -4984,10 +5220,12 @@ spec:
                             pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
                             type: string
                         required:
-                          - image
                           - name
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     ldap:
                       description: Options to specify LDAP configuration
                       properties:
@@ -5069,7 +5307,9 @@ spec:
                     pg_hba:
                       description: |-
                         PostgreSQL Host Based Authentication rules (lines to be appended
-                        to the pg_hba.conf file)
+                        to the pg_hba.conf file).
+                        Use the ${podselector:NAME} syntax to reference a pod selector;
+                        the rule will be expanded for each Pod IP matching that selector.
                       items:
                         type: string
                       type: array
@@ -6281,6 +6521,20 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the cluster.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple clusters (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the cluster name.
+                    Mutually exclusive with ServiceAccountTemplate.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceAccountTemplate:
                   description: Configure the generation of the service account
                   properties:
@@ -7558,6 +7812,110 @@ spec:
                   description: PGDataImageInfo contains the details of the latest
                     image that has run on the current data directory.
                   properties:
+                    extensions:
+                      description: Extensions contains the container image extensions
+                        available for the current Image
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image
+                              which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: The name of the extension, required
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
                     image:
                       description: Image is the image name
                       type: string
@@ -7631,6 +7989,31 @@ spec:
                       - version
                     type: object
                   type: array
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs contains the resolved pod IPs for each named selector
+                    defined in spec.podSelectorRefs.
+                  items:
+                    description: PodSelectorRefStatus contains the resolved pod IPs
+                      for a named selector.
+                    properties:
+                      ips:
+                        description: |-
+                          IPs is the list of pod IPs matching the selector.
+                          Each IP is a single address (no CIDR notation).
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Name corresponds to the name in the spec's PodSelectorRef.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 poolerIntegrations:
                   description: The integration needed by poolers referencing the cluster
                   properties:
@@ -7816,7 +8199,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: databases.postgresql.cnpg.io
 spec:
@@ -8415,7 +8798,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: failoverquorums.postgresql.cnpg.io
 spec:
@@ -8494,7 +8877,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: imagecatalogs.postgresql.cnpg.io
 spec:
@@ -8542,6 +8925,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -8577,7 +9066,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: poolers.postgresql.cnpg.io
 spec:
@@ -8976,6 +9465,19 @@ spec:
                         - name
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the pooler.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple poolers (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the pooler name.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceTemplate:
                   description: Template for the Service to be created
                   properties:
@@ -17966,7 +18468,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: publications.postgresql.cnpg.io
 spec:
@@ -18163,7 +18665,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: scheduledbackups.postgresql.cnpg.io
 spec:
@@ -18356,7 +18858,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: subscriptions.postgresql.cnpg.io
 spec:

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3bb18efd43492f64393e0b3a822d6112ac962d8075fddb3a3ad8893925b37752
-        checksum/monitoring-config: bc0322bcf7fedd5cc42cf396b5dacbb80696b4916865cf174119c71cca641e26
-        checksum/rbac: b6788fd81bfaea5bd26c64f1c94e4815e8d46f4cc66fcf6932b61327e430511a
+        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
+        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
+        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,16 +36,18 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: MONITORING_QUERIES_CONFIGMAP
               value: cnpg-default-monitoring
+            - name: ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES
+              value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
+    app.kubernetes.io/version: 1.29.0
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.27.1
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-role
   namespace: syn-cnpg-system
 rules:
@@ -53,8 +53,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-rolebinding
   namespace: syn-cnpg-system
 roleRef:

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.11.0
+  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.12.0
 kind: ConfigMap
 metadata:
   name: plugin-barman-cloud-config

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: objectstores.barmancloud.cnpg.io
 spec:

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 spec:
@@ -38,7 +38,7 @@ spec:
                 configMapKeyRef:
                   key: SIDECAR_IMAGE
                   name: plugin-barman-cloud-config
-          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.11.0
+          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.12.0
           name: barman-cloud
           ports:
             - containerPort: 9090

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 ---
@@ -91,8 +91,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0
     cnpg.io/pluginName: barman-cloud.cloudnative-pg.io
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: barman-cloud
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -33,7 +33,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.37'
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.1.8
+          chartVersion: 7.1.9
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           controlNamespace: syn-appcat-control

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -66,7 +66,7 @@ spec:
             "8Gi"}}}'
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:3.0.5
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.7
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -33,7 +33,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.37'
           chartRepository: https://nextcloud.github.io/helm/
-          chartVersion: 8.9.1
+          chartVersion: 9.0.5
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           collaboraCPULimit: '1'

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: backups.postgresql.cnpg.io
 spec:
@@ -346,6 +346,15 @@ spec:
                     type: string
                   description: A map containing the plugin metadata
                   type: object
+                reconciliationStartedAt:
+                  description: When the backup process was started by the operator
+                  format: date-time
+                  type: string
+                reconciliationTerminatedAt:
+                  description: When the reconciliation was terminated by the operator
+                    (either successfully or not)
+                  format: date-time
+                  type: string
                 s3Credentials:
                   description: The credentials to use to upload data to S3
                   properties:
@@ -441,11 +450,13 @@ spec:
                       type: array
                   type: object
                 startedAt:
-                  description: When the backup was started
+                  description: When the backup execution was started by the backup
+                    tool
                   format: date-time
                   type: string
                 stoppedAt:
-                  description: When the backup was terminated
+                  description: When the backup execution was terminated by the backup
+                    tool
                   format: date-time
                   type: string
                 tablespaceMapFile:
@@ -468,7 +479,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
@@ -517,6 +528,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -552,7 +669,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusters.postgresql.cnpg.io
 spec:
@@ -4905,6 +5022,82 @@ spec:
                           type: string
                       type: object
                   type: object
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs defines named pod label selectors that can be referenced
+                    in pg_hba rules using the ${podselector:NAME} syntax in the address field.
+                    The operator resolves matching pod IPs and the instance manager expands
+                    pg_hba lines accordingly. Only pods in the Cluster's own namespace are considered.
+                  items:
+                    description: |-
+                      PodSelectorRef defines a named pod label selector for use in pg_hba rules.
+                      Pods matching the selector in the Cluster's namespace will have their IPs
+                      resolved and made available for pg_hba address expansion via the
+                      `${podselector:NAME}` syntax.
+                    properties:
+                      name:
+                        description: |-
+                          Name is the identifier used to reference this selector in pg_hba rules
+                          via the ${podselector:NAME} syntax in the address field.
+                        minLength: 1
+                        pattern: ^[a-z]([a-z0-9_-]*[a-z0-9])?$
+                        type: string
+                      selector:
+                        description: |-
+                          Selector is a label selector that identifies the pods whose IPs
+                          should be resolved. Only pods in the Cluster's namespace are considered.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                      - name
+                      - selector
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 postgresGID:
                   default: 26
                   description: The GID of the `postgres` user inside the image, defaults
@@ -4934,6 +5127,13 @@ spec:
                           ExtensionConfiguration is the configuration used to add
                           PostgreSQL extensions to the Cluster.
                         properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
                           dynamic_library_path:
                             description: |-
                               The list of directories inside the image which should be added to dynamic_library_path.
@@ -4941,6 +5141,45 @@ spec:
                             items:
                               type: string
                             type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
                           extension_control_path:
                             description: |-
                               The list of directories inside the image which should be added to extension_control_path.
@@ -4949,7 +5188,7 @@ spec:
                               type: string
                             type: array
                           image:
-                            description: The image containing the extension, required
+                            description: The image containing the extension.
                             properties:
                               pullPolicy:
                                 description: |-
@@ -4969,9 +5208,6 @@ spec:
                                   container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                              - message: An image reference is required
-                                rule: has(self.reference)
                           ld_library_path:
                             description: The list of directories inside the image
                               which should be added to ld_library_path.
@@ -4984,10 +5220,12 @@ spec:
                             pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
                             type: string
                         required:
-                          - image
                           - name
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     ldap:
                       description: Options to specify LDAP configuration
                       properties:
@@ -5069,7 +5307,9 @@ spec:
                     pg_hba:
                       description: |-
                         PostgreSQL Host Based Authentication rules (lines to be appended
-                        to the pg_hba.conf file)
+                        to the pg_hba.conf file).
+                        Use the ${podselector:NAME} syntax to reference a pod selector;
+                        the rule will be expanded for each Pod IP matching that selector.
                       items:
                         type: string
                       type: array
@@ -6281,6 +6521,20 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the cluster.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple clusters (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the cluster name.
+                    Mutually exclusive with ServiceAccountTemplate.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceAccountTemplate:
                   description: Configure the generation of the service account
                   properties:
@@ -7558,6 +7812,110 @@ spec:
                   description: PGDataImageInfo contains the details of the latest
                     image that has run on the current data directory.
                   properties:
+                    extensions:
+                      description: Extensions contains the container image extensions
+                        available for the current Image
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image
+                              which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: The name of the extension, required
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
                     image:
                       description: Image is the image name
                       type: string
@@ -7631,6 +7989,31 @@ spec:
                       - version
                     type: object
                   type: array
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs contains the resolved pod IPs for each named selector
+                    defined in spec.podSelectorRefs.
+                  items:
+                    description: PodSelectorRefStatus contains the resolved pod IPs
+                      for a named selector.
+                    properties:
+                      ips:
+                        description: |-
+                          IPs is the list of pod IPs matching the selector.
+                          Each IP is a single address (no CIDR notation).
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Name corresponds to the name in the spec's PodSelectorRef.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 poolerIntegrations:
                   description: The integration needed by poolers referencing the cluster
                   properties:
@@ -7816,7 +8199,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: databases.postgresql.cnpg.io
 spec:
@@ -8415,7 +8798,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: failoverquorums.postgresql.cnpg.io
 spec:
@@ -8494,7 +8877,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: imagecatalogs.postgresql.cnpg.io
 spec:
@@ -8542,6 +8925,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -8577,7 +9066,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: poolers.postgresql.cnpg.io
 spec:
@@ -8976,6 +9465,19 @@ spec:
                         - name
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the pooler.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple poolers (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the pooler name.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceTemplate:
                   description: Template for the Service to be created
                   properties:
@@ -17966,7 +18468,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: publications.postgresql.cnpg.io
 spec:
@@ -18163,7 +18665,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: scheduledbackups.postgresql.cnpg.io
 spec:
@@ -18356,7 +18858,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: subscriptions.postgresql.cnpg.io
 spec:

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3bb18efd43492f64393e0b3a822d6112ac962d8075fddb3a3ad8893925b37752
-        checksum/monitoring-config: bc0322bcf7fedd5cc42cf396b5dacbb80696b4916865cf174119c71cca641e26
-        checksum/rbac: b6788fd81bfaea5bd26c64f1c94e4815e8d46f4cc66fcf6932b61327e430511a
+        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
+        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
+        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,16 +36,18 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1-ubi9
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0-ubi9
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: MONITORING_QUERIES_CONFIGMAP
               value: cnpg-default-monitoring
+            - name: ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES
+              value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1-ubi9
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0-ubi9
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
+    app.kubernetes.io/version: 1.29.0
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.27.1
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-role
   namespace: syn-cnpg-system
 rules:
@@ -53,8 +53,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-rolebinding
   namespace: syn-cnpg-system
 roleRef:

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.11.0
+  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.12.0
 kind: ConfigMap
 metadata:
   name: plugin-barman-cloud-config

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: objectstores.barmancloud.cnpg.io
 spec:

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 spec:
@@ -38,7 +38,7 @@ spec:
                 configMapKeyRef:
                   key: SIDECAR_IMAGE
                   name: plugin-barman-cloud-config
-          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.11.0
+          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.12.0
           name: barman-cloud
           ports:
             - containerPort: 9090

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 ---
@@ -91,8 +91,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0
     cnpg.io/pluginName: barman-cloud.cloudnative-pg.io
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: barman-cloud
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -33,7 +33,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.37'
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.1.8
+          chartVersion: 7.1.9
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           controlNamespace: syn-appcat-control

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -66,7 +66,7 @@ spec:
             "8Gi"}}}'
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:3.0.5
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.7
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -33,7 +33,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.37'
           chartRepository: https://nextcloud.github.io/helm/
-          chartVersion: 8.9.1
+          chartVersion: 9.0.5
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           collaboraCPULimit: '1'

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: backups.postgresql.cnpg.io
 spec:
@@ -346,6 +346,15 @@ spec:
                     type: string
                   description: A map containing the plugin metadata
                   type: object
+                reconciliationStartedAt:
+                  description: When the backup process was started by the operator
+                  format: date-time
+                  type: string
+                reconciliationTerminatedAt:
+                  description: When the reconciliation was terminated by the operator
+                    (either successfully or not)
+                  format: date-time
+                  type: string
                 s3Credentials:
                   description: The credentials to use to upload data to S3
                   properties:
@@ -441,11 +450,13 @@ spec:
                       type: array
                   type: object
                 startedAt:
-                  description: When the backup was started
+                  description: When the backup execution was started by the backup
+                    tool
                   format: date-time
                   type: string
                 stoppedAt:
-                  description: When the backup was terminated
+                  description: When the backup execution was terminated by the backup
+                    tool
                   format: date-time
                   type: string
                 tablespaceMapFile:
@@ -468,7 +479,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
@@ -517,6 +528,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -552,7 +669,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusters.postgresql.cnpg.io
 spec:
@@ -4905,6 +5022,82 @@ spec:
                           type: string
                       type: object
                   type: object
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs defines named pod label selectors that can be referenced
+                    in pg_hba rules using the ${podselector:NAME} syntax in the address field.
+                    The operator resolves matching pod IPs and the instance manager expands
+                    pg_hba lines accordingly. Only pods in the Cluster's own namespace are considered.
+                  items:
+                    description: |-
+                      PodSelectorRef defines a named pod label selector for use in pg_hba rules.
+                      Pods matching the selector in the Cluster's namespace will have their IPs
+                      resolved and made available for pg_hba address expansion via the
+                      `${podselector:NAME}` syntax.
+                    properties:
+                      name:
+                        description: |-
+                          Name is the identifier used to reference this selector in pg_hba rules
+                          via the ${podselector:NAME} syntax in the address field.
+                        minLength: 1
+                        pattern: ^[a-z]([a-z0-9_-]*[a-z0-9])?$
+                        type: string
+                      selector:
+                        description: |-
+                          Selector is a label selector that identifies the pods whose IPs
+                          should be resolved. Only pods in the Cluster's namespace are considered.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                      - name
+                      - selector
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 postgresGID:
                   default: 26
                   description: The GID of the `postgres` user inside the image, defaults
@@ -4934,6 +5127,13 @@ spec:
                           ExtensionConfiguration is the configuration used to add
                           PostgreSQL extensions to the Cluster.
                         properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
                           dynamic_library_path:
                             description: |-
                               The list of directories inside the image which should be added to dynamic_library_path.
@@ -4941,6 +5141,45 @@ spec:
                             items:
                               type: string
                             type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
                           extension_control_path:
                             description: |-
                               The list of directories inside the image which should be added to extension_control_path.
@@ -4949,7 +5188,7 @@ spec:
                               type: string
                             type: array
                           image:
-                            description: The image containing the extension, required
+                            description: The image containing the extension.
                             properties:
                               pullPolicy:
                                 description: |-
@@ -4969,9 +5208,6 @@ spec:
                                   container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                              - message: An image reference is required
-                                rule: has(self.reference)
                           ld_library_path:
                             description: The list of directories inside the image
                               which should be added to ld_library_path.
@@ -4984,10 +5220,12 @@ spec:
                             pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
                             type: string
                         required:
-                          - image
                           - name
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     ldap:
                       description: Options to specify LDAP configuration
                       properties:
@@ -5069,7 +5307,9 @@ spec:
                     pg_hba:
                       description: |-
                         PostgreSQL Host Based Authentication rules (lines to be appended
-                        to the pg_hba.conf file)
+                        to the pg_hba.conf file).
+                        Use the ${podselector:NAME} syntax to reference a pod selector;
+                        the rule will be expanded for each Pod IP matching that selector.
                       items:
                         type: string
                       type: array
@@ -6281,6 +6521,20 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the cluster.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple clusters (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the cluster name.
+                    Mutually exclusive with ServiceAccountTemplate.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceAccountTemplate:
                   description: Configure the generation of the service account
                   properties:
@@ -7558,6 +7812,110 @@ spec:
                   description: PGDataImageInfo contains the details of the latest
                     image that has run on the current data directory.
                   properties:
+                    extensions:
+                      description: Extensions contains the container image extensions
+                        available for the current Image
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image
+                              which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: The name of the extension, required
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
                     image:
                       description: Image is the image name
                       type: string
@@ -7631,6 +7989,31 @@ spec:
                       - version
                     type: object
                   type: array
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs contains the resolved pod IPs for each named selector
+                    defined in spec.podSelectorRefs.
+                  items:
+                    description: PodSelectorRefStatus contains the resolved pod IPs
+                      for a named selector.
+                    properties:
+                      ips:
+                        description: |-
+                          IPs is the list of pod IPs matching the selector.
+                          Each IP is a single address (no CIDR notation).
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Name corresponds to the name in the spec's PodSelectorRef.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 poolerIntegrations:
                   description: The integration needed by poolers referencing the cluster
                   properties:
@@ -7816,7 +8199,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: databases.postgresql.cnpg.io
 spec:
@@ -8415,7 +8798,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: failoverquorums.postgresql.cnpg.io
 spec:
@@ -8494,7 +8877,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: imagecatalogs.postgresql.cnpg.io
 spec:
@@ -8542,6 +8925,112 @@ spec:
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image
+                                which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string
@@ -8577,7 +9066,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: poolers.postgresql.cnpg.io
 spec:
@@ -8976,6 +9465,19 @@ spec:
                         - name
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the pooler.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple poolers (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the pooler name.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceTemplate:
                   description: Template for the Service to be created
                   properties:
@@ -17966,7 +18468,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: publications.postgresql.cnpg.io
 spec:
@@ -18163,7 +18665,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: scheduledbackups.postgresql.cnpg.io
 spec:
@@ -18356,7 +18858,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: subscriptions.postgresql.cnpg.io
 spec:

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3bb18efd43492f64393e0b3a822d6112ac962d8075fddb3a3ad8893925b37752
-        checksum/monitoring-config: bc0322bcf7fedd5cc42cf396b5dacbb80696b4916865cf174119c71cca641e26
-        checksum/rbac: b6788fd81bfaea5bd26c64f1c94e4815e8d46f4cc66fcf6932b61327e430511a
+        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
+        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
+        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,16 +36,18 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1-ubi9
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0-ubi9
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: MONITORING_QUERIES_CONFIGMAP
               value: cnpg-default-monitoring
+            - name: ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES
+              value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.1-ubi9
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0-ubi9
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
+    app.kubernetes.io/version: 1.29.0
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.27.1
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.28.1
-    helm.sh/chart: cloudnative-pg-0.27.1
+    app.kubernetes.io/version: 1.29.0
+    helm.sh/chart: cloudnative-pg-0.28.0
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/additional-rbac/leader_election.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-role
   namespace: syn-cnpg-system
 rules:
@@ -53,8 +53,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-leader-election-rolebinding
   namespace: syn-cnpg-system
 roleRef:

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.11.0
+  SIDECAR_IMAGE: ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.12.0
 kind: ConfigMap
 metadata:
   name: plugin-barman-cloud-config

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: objectstores.barmancloud.cnpg.io
 spec:

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 spec:
@@ -38,7 +38,7 @@ spec:
                 configMapKeyRef:
                   key: SIDECAR_IMAGE
                   name: plugin-barman-cloud-config
-          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.11.0
+          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.12.0
           name: barman-cloud
           ports:
             - containerPort: 9090

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud
   namespace: syn-cnpg-system
 ---
@@ -91,8 +91,8 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    app.kubernetes.io/version: v0.12.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: plugin-barman-cloud-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/plugin-barman-cloud/templates/service.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: plugin-barman-cloud
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: plugin-barman-cloud
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0
     cnpg.io/pluginName: barman-cloud.cloudnative-pg.io
-    helm.sh/chart: plugin-barman-cloud-0.5.0
+    helm.sh/chart: plugin-barman-cloud-0.6.0
   name: barman-cloud
   namespace: syn-cnpg-system
 spec:


### PR DESCRIPTION
## Summary

This updates AppCat dependencies to their latest version:

- Crossplane v2.2.0 on Kindev
- CNPG operator 0.28.0
- Plugin Barman Cloud 0.6.0
- Proxysql 3.0.7
- Garage operator 0.3.3
- Keycloak chart 7.1.9
- NextCloud chart 9.0.5

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] If no changes have been made you can self approve but otherwise at least two reviews are required
- [ ] Link this PR to related issues or PRs.