### PR TITLE
Bump provider exoscale to 1.0.2

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -63,7 +63,7 @@ parameters:
       provider-exoscale:
         registry: ghcr.io
         repository: vshn/provider-exoscale
-        tag: v1.0.1
+        tag: v1.0.2
       provider-cloudscale:
         registry: ghcr.io
         repository: vshn/provider-cloudscale

--- a/tests/golden/exodev/appcat/appcat/10_provider_exoscale.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_provider_exoscale.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-exoscale
   name: provider-exoscale
 spec:
-  package: ghcr.io/vshn/provider-exoscale:v1.0.1
+  package: ghcr.io/vshn/provider-exoscale:v1.0.2
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-exoscale

--- a/tests/golden/vshn-cloud/appcat/appcat/10_provider_exoscale.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_provider_exoscale.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-exoscale
   name: provider-exoscale
 spec:
-  package: ghcr.io/vshn/provider-exoscale:v1.0.1
+  package: ghcr.io/vshn/provider-exoscale:v1.0.2
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-exoscale

--- a/tests/golden/vshn-managed/appcat/appcat/10_provider_exoscale.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_provider_exoscale.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-exoscale
   name: provider-exoscale
 spec:
-  package: ghcr.io/vshn/provider-exoscale:v1.0.1
+  package: ghcr.io/vshn/provider-exoscale:v1.0.2
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-exoscale


### PR DESCRIPTION
## Summary

This bumps provider Exoscale to 1.0.2 which removes the location constraint for provisioning resources.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] If no changes have been made you can self approve but otherwise at least two reviews are required
- [ ] Link this PR to related issues or PRs.