### PR TITLE
Bump provider versions

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -66,7 +66,7 @@ parameters:
       provider-exoscale:
         registry: ghcr.io
         repository: vshn/provider-exoscale
-        tag: v1.0.2
+        tag: v1.0.3
       provider-cloudscale:
         registry: ghcr.io
         repository: vshn/provider-cloudscale
@@ -82,7 +82,7 @@ parameters:
       provider-s3:
         registry: ghcr.io
         repository: vshn/provider-s3
-        tag: v0.0.1
+        tag: v0.0.2
       sloth:
         registry: ghcr.io
         image: slok/sloth

--- a/tests/golden/exodev/appcat/appcat/10_provider_exoscale.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_provider_exoscale.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-exoscale
   name: provider-exoscale
 spec:
-  package: ghcr.io/vshn/provider-exoscale:v1.0.2
+  package: ghcr.io/vshn/provider-exoscale:v1.0.3
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-exoscale

--- a/tests/golden/vshn-cloud/appcat/appcat/10_provider_exoscale.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_provider_exoscale.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-exoscale
   name: provider-exoscale
 spec:
-  package: ghcr.io/vshn/provider-exoscale:v1.0.2
+  package: ghcr.io/vshn/provider-exoscale:v1.0.3
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-exoscale

--- a/tests/golden/vshn-managed/appcat/appcat/10_provider_exoscale.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_provider_exoscale.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-exoscale
   name: provider-exoscale
 spec:
-  package: ghcr.io/vshn/provider-exoscale:v1.0.2
+  package: ghcr.io/vshn/provider-exoscale:v1.0.3
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-exoscale


### PR DESCRIPTION
## Summary

This PR updates the provider-exoscale and provider-s3 to the latest, which both fix a bug with silent listing failure in deleteAllObjects.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] If no changes have been made you can self approve but otherwise at least two reviews are required
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
