### PR TITLE
Add more e2e RBAC

### DIFF
--- a/component/rbac_testing.jsonnet
+++ b/component/rbac_testing.jsonnet
@@ -86,6 +86,11 @@ local e2eClusterRole = kube.ClusterRole('appcat:e2e') + {
       resources: [ 'backups' ],
       verbs: [ 'get', 'list', 'create', 'delete' ],
     },
+    {
+      apiGroups: [ '' ],
+      resources: [ 'serviceaccounts' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
   ],
 };
 

--- a/tests/e2e/nextcloud/61-assert-pg.yaml
+++ b/tests/e2e/nextcloud/61-assert-pg.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   compositeDeletePolicy: Background
   compositionRef:
-    name: vshnpostgres.vshn.appcat.vshn.io
+    name: vshnpostgrescnpg.vshn.appcat.vshn.io
   parameters:
     backup:
       deletionRetention: 7

--- a/tests/e2e/nextcloud/63-assert-users-pg.yaml
+++ b/tests/e2e/nextcloud/63-assert-users-pg.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   compositeDeletePolicy: Background
   compositionRef:
-    name: vshnpostgres.vshn.appcat.vshn.io
+    name: vshnpostgrescnpg.vshn.appcat.vshn.io
   parameters:
     backup:
       deletionRetention: 7

--- a/tests/e2e/postgresqlsg/00-install.yaml
+++ b/tests/e2e/postgresqlsg/00-install.yaml
@@ -3,6 +3,8 @@ kind: VSHNPostgreSQL
 metadata:
   name: pg-sg-e2e
 spec:
+  compositionRef:
+    name: vshnpostgres.vshn.appcat.vshn.io
   parameters:
     security:
       deletionProtection: false

--- a/tests/e2e/postgresqlsg/10-install.yaml
+++ b/tests/e2e/postgresqlsg/10-install.yaml
@@ -3,6 +3,8 @@ kind: VSHNPostgreSQL
 metadata:
   name: pg-sg-e2e
 spec:
+  compositionRef:
+    name: vshnpostgres.vshn.appcat.vshn.io
   parameters:
     security:
       deletionProtection: false

--- a/tests/e2e/postgresqlsg/scripts/test-restore.sh
+++ b/tests/e2e/postgresqlsg/scripts/test-restore.sh
@@ -17,6 +17,8 @@ metadata:
   name: ${name}-restore
   namespace: ${NAMESPACE}
 spec:
+  compositionRef:
+    name: vshnpostgres.vshn.appcat.vshn.io
   parameters:
     restore:
       backupName: ${backup}

--- a/tests/golden/control-plane/appcat/appcat/20_rbac_vshn_e2e_tests.yaml
+++ b/tests/golden/control-plane/appcat/appcat/20_rbac_vshn_e2e_tests.yaml
@@ -158,6 +158,14 @@ rules:
       - list
       - create
       - delete
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: v1
 data: {}

--- a/tests/golden/dev-talos/appcat/appcat/20_rbac_vshn_e2e_tests.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/20_rbac_vshn_e2e_tests.yaml
@@ -158,6 +158,14 @@ rules:
       - list
       - create
       - delete
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: v1
 data: {}

--- a/tests/golden/dev/appcat/appcat/20_rbac_vshn_e2e_tests.yaml
+++ b/tests/golden/dev/appcat/appcat/20_rbac_vshn_e2e_tests.yaml
@@ -158,6 +158,14 @@ rules:
       - list
       - create
       - delete
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: v1
 data: {}

--- a/tests/golden/service-cluster/appcat/appcat/20_rbac_vshn_e2e_tests.yaml
+++ b/tests/golden/service-cluster/appcat/appcat/20_rbac_vshn_e2e_tests.yaml
@@ -158,6 +158,14 @@ rules:
       - list
       - create
       - delete
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: v1
 data: {}


### PR DESCRIPTION
Because kuttl tries to read service accounts from the default namespace for some reason, we added RBAC to allow this.

Otherwise it spends a lot of time re-trying to query those service accounts.




## Checklist

- [ ] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [ ] PR contains a single logical change (to build a better changelog).
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] If no changes have been made you can self approve but otherwise at least two reviews are required
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
