### PR TITLE
Bump Crossplane to v2.2.2

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,7 +6,7 @@ parameters:
     charts:
       crossplane:
         source: https://charts.crossplane.io/stable
-        version: 1.20.1
+        version: 2.2.0
       redis:
         source: oci://registry-1.docker.io/bitnamicharts/redis
         version: 23.2.1

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -248,7 +248,6 @@ parameters:
           - --enable-usages
           - --poll-interval=1h
           - --enable-realtime-compositions=false
-          - --registry=xpkg.upbound.io
         image:
           pullPolicy: ${appcat:pullPolicy}
         alpha:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,7 +6,7 @@ parameters:
     charts:
       crossplane:
         source: https://charts.crossplane.io/stable
-        version: 2.2.0
+        version: 2.2.2
       redis:
         source: oci://registry-1.docker.io/bitnamicharts/redis
         version: 23.2.1

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
+    app.kubernetes.io/version: 2.2.0
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.20.1
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:
@@ -73,8 +73,9 @@ rules:
       - '*'
   - apiGroups:
       - apiextensions.crossplane.io
+      - ops.crossplane.io
       - pkg.crossplane.io
-      - secrets.crossplane.io
+      - protection.crossplane.io
     resources:
       - '*'
     verbs:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.2.0
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -45,7 +45,6 @@ spec:
             - --enable-usages
             - --poll-interval=1h
             - --enable-realtime-compositions=false
-            - --registry=xpkg.upbound.io
           env:
             - name: GOMAXPROCS
               valueFrom:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.2.2
+        helm.sh/chart: crossplane-2.2.2
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.1
-        helm.sh/chart: crossplane-1.20.1
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -77,7 +77,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -116,6 +116,8 @@ spec:
         - args:
             - core
             - init
+            - --activation
+            - '*'
           env:
             - name: GOMAXPROCS
               valueFrom:
@@ -151,7 +153,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.2.2
+        helm.sh/chart: crossplane-2.2.2
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.1
-        helm.sh/chart: crossplane-1.20.1
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -152,6 +152,18 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -165,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -210,6 +222,18 @@ rules:
       - '*'
     verbs:
       - '*'
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -223,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -268,6 +292,22 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -281,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -315,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
+    app.kubernetes.io/version: 2.2.0
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.20.1
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:
@@ -73,8 +73,9 @@ rules:
       - '*'
   - apiGroups:
       - apiextensions.crossplane.io
+      - ops.crossplane.io
       - pkg.crossplane.io
-      - secrets.crossplane.io
+      - protection.crossplane.io
     resources:
       - '*'
     verbs:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.2.0
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -45,7 +45,6 @@ spec:
             - --enable-usages
             - --poll-interval=1h
             - --enable-realtime-compositions=false
-            - --registry=xpkg.upbound.io
           env:
             - name: GOMAXPROCS
               valueFrom:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.2.2
+        helm.sh/chart: crossplane-2.2.2
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.1
-        helm.sh/chart: crossplane-1.20.1
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -77,7 +77,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -116,6 +116,8 @@ spec:
         - args:
             - core
             - init
+            - --activation
+            - '*'
           env:
             - name: GOMAXPROCS
               valueFrom:
@@ -151,7 +153,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.2.2
+        helm.sh/chart: crossplane-2.2.2
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.1
-        helm.sh/chart: crossplane-1.20.1
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -152,6 +152,18 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -165,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -210,6 +222,18 @@ rules:
       - '*'
     verbs:
       - '*'
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -223,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -268,6 +292,22 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -281,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -315,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
+    app.kubernetes.io/version: 2.2.0
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.20.1
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:
@@ -73,8 +73,9 @@ rules:
       - '*'
   - apiGroups:
       - apiextensions.crossplane.io
+      - ops.crossplane.io
       - pkg.crossplane.io
-      - secrets.crossplane.io
+      - protection.crossplane.io
     resources:
       - '*'
     verbs:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.2.0
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -45,7 +45,6 @@ spec:
             - --enable-usages
             - --poll-interval=1h
             - --enable-realtime-compositions=false
-            - --registry=xpkg.upbound.io
           env:
             - name: GOMAXPROCS
               valueFrom:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.2.2
+        helm.sh/chart: crossplane-2.2.2
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.1
-        helm.sh/chart: crossplane-1.20.1
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -77,7 +77,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -116,6 +116,8 @@ spec:
         - args:
             - core
             - init
+            - --activation
+            - '*'
           env:
             - name: GOMAXPROCS
               valueFrom:
@@ -151,7 +153,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.2.2
+        helm.sh/chart: crossplane-2.2.2
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.1
-        helm.sh/chart: crossplane-1.20.1
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -152,6 +152,18 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -165,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -210,6 +222,18 @@ rules:
       - '*'
     verbs:
       - '*'
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -223,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -268,6 +292,22 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -281,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -315,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
+    app.kubernetes.io/version: 2.2.0
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.20.1
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:
@@ -73,8 +73,9 @@ rules:
       - '*'
   - apiGroups:
       - apiextensions.crossplane.io
+      - ops.crossplane.io
       - pkg.crossplane.io
-      - secrets.crossplane.io
+      - protection.crossplane.io
     resources:
       - '*'
     verbs:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.2.0
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -45,7 +45,6 @@ spec:
             - --enable-usages
             - --poll-interval=1h
             - --enable-realtime-compositions=false
-            - --registry=xpkg.upbound.io
           env:
             - name: GOMAXPROCS
               valueFrom:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.2.2
+        helm.sh/chart: crossplane-2.2.2
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.1
-        helm.sh/chart: crossplane-1.20.1
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -77,7 +77,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -116,6 +116,8 @@ spec:
         - args:
             - core
             - init
+            - --activation
+            - '*'
           env:
             - name: GOMAXPROCS
               valueFrom:
@@ -151,7 +153,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.2.2
+        helm.sh/chart: crossplane-2.2.2
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.1
-        helm.sh/chart: crossplane-1.20.1
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -152,6 +152,18 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -165,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -210,6 +222,18 @@ rules:
       - '*'
     verbs:
       - '*'
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -223,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -268,6 +292,22 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -281,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -315,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
+    app.kubernetes.io/version: 2.2.0
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.20.1
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:
@@ -73,8 +73,9 @@ rules:
       - '*'
   - apiGroups:
       - apiextensions.crossplane.io
+      - ops.crossplane.io
       - pkg.crossplane.io
-      - secrets.crossplane.io
+      - protection.crossplane.io
     resources:
       - '*'
     verbs:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.2.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.2.0
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -45,7 +45,6 @@ spec:
             - --enable-usages
             - --poll-interval=1h
             - --enable-realtime-compositions=false
-            - --registry=xpkg.upbound.io
           env:
             - name: GOMAXPROCS
               valueFrom:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.2.2
+        helm.sh/chart: crossplane-2.2.2
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.1
-        helm.sh/chart: crossplane-1.20.1
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -77,7 +77,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -116,6 +116,8 @@ spec:
         - args:
             - core
             - init
+            - --activation
+            - '*'
           env:
             - name: GOMAXPROCS
               valueFrom:
@@ -151,7 +153,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.2.2
+        helm.sh/chart: crossplane-2.2.2
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.1
-        helm.sh/chart: crossplane-1.20.1
+        app.kubernetes.io/version: 2.2.0
+        helm.sh/chart: crossplane-2.2.0
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v1.20.1
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -152,6 +152,18 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -165,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -210,6 +222,18 @@ rules:
       - '*'
     verbs:
       - '*'
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -223,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -268,6 +292,22 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - protection.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ops.crossplane.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -281,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -315,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.2.2
+    helm.sh/chart: crossplane-2.2.2
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.1
-    helm.sh/chart: crossplane-1.20.1
+    app.kubernetes.io/version: 2.2.0
+    helm.sh/chart: crossplane-2.2.0
   name: crossplane
   namespace: syn-crossplane


### PR DESCRIPTION
## Summary

This bumps Crossplane to v2.2.2 in the defaults, which allows us to unpin all clusters that are currently pinned to v2.2.0.
The regular monthly update PR will further update this to v2.3, but this will need more testing

## Checklist

- [ ] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [ ] PR contains a single logical change (to build a better changelog).