### PR TITLE
Dependency Updates June 2026

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -27,7 +27,7 @@ parameters:
         version: 16.2.1-vshn.1
       cnpg:
         source: https://cloudnative-pg.io/charts/
-        version: 0.28.0
+        version: 0.28.2
         # Be aware that the cnpg post-process filter will append "-ubiX" to the operator image.
         # The UBI version might increase with newer versions, so check with skopeo first:
         # skopeo list-tags docker://ghcr.io/cloudnative-pg/cloudnative-pg

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -58,7 +58,7 @@ parameters:
       provider-kubernetes:
         registry: ghcr.io
         repository: crossplane-contrib/provider-kubernetes
-        tag: v1.1.0
+        tag: v1.2.1
       provider-helm:
         registry: ghcr.io
         repository: crossplane-contrib/provider-helm

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -118,7 +118,7 @@ parameters:
       proxysql:
         registry: docker.io
         image: proxysql/proxysql
-        version: "3.0.7"
+        version: "3.0.9"
       collabora:
         registry: docker.io
         image: collabora/code

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -132,7 +132,7 @@ parameters:
       busybox:
         registry: docker.io
         image: library/busybox
-        tag: "1.37"
+        tag: "1.38"
       forgejo:
         registry: code.forgejo.org
         maintenanceURL: "https://codeberg.org/v2/forgejo/forgejo/tags/list?page_size=100"

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -18,7 +18,7 @@ parameters:
         version: 5.4.0
       keycloak:
         source: https://codecentric.github.io/helm-charts
-        version: 7.1.9
+        version: 7.2.0
       nextcloud:
         source: https://nextcloud.github.io/helm/
         version: 9.0.5

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,7 +6,7 @@ parameters:
     charts:
       crossplane:
         source: https://charts.crossplane.io/stable
-        version: 2.2.2
+        version: 2.3.2
       redis:
         source: oci://registry-1.docker.io/bitnamicharts/redis
         version: 23.2.1

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -21,7 +21,7 @@ parameters:
         version: 7.2.0
       nextcloud:
         source: https://nextcloud.github.io/helm/
-        version: 9.0.5
+        version: 9.1.3
       forgejo:
         source: https://charts.appcat.ch/
         version: 16.2.1-vshn.1

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -50,7 +50,7 @@ parameters:
         chartName: plugin-barman-cloud
       garageOperator:
         source: oci://ghcr.io/rajsinghtech/charts/garage-operator
-        version: 0.4.10
+        version: 0.6.15
       openbao:
         source: https://openbao.github.io/openbao-helm
         version: 0.19.3

--- a/tests/dev.yml
+++ b/tests/dev.yml
@@ -30,7 +30,7 @@ parameters:
   appcat:
     charts:
       crossplane:
-        version: 2.2.0
+        version: 2.3.2
         # garage:
         #   source: oci://registry.kube-system.svc.cluster.local:5000/vshngaragecluster/vshngaragecluster
         #   version: 0.0.0

--- a/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-master-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:v4.189.0-func
+  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-master-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
+  package: ghcr.io/vshn/appcat:v4.189.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/control-plane/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/control-plane/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.1.0
+  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.2.1
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-kubernetes

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -37,7 +37,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.38'
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.1.9
+          chartVersion: 7.2.0
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           controlNamespace: syn-appcat-control

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -35,7 +35,7 @@ spec:
           billingEnabled: 'false'
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
-          busybox_image_tag: '1.37'
+          busybox_image_tag: '1.38'
           chartRepository: https://codecentric.github.io/helm-charts
           chartVersion: 7.1.9
           cloudProvider: cloudscale

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -69,7 +69,7 @@ spec:
             "8Gi"}}}'
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:3.0.7
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.9
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -34,7 +34,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.38'
           chartRepository: https://nextcloud.github.io/helm/
-          chartVersion: 9.0.5
+          chartVersion: 9.1.3
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           collaboraCPULimit: '1'

--- a/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/control-plane/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -32,7 +32,7 @@ spec:
           billingEnabled: 'false'
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
-          busybox_image_tag: '1.37'
+          busybox_image_tag: '1.38'
           chartRepository: https://nextcloud.github.io/helm/
           chartVersion: 9.0.5
           cloudProvider: cloudscale

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -6401,7 +6401,6 @@ spec:
                         procMount denotes the type of proc mount to use for the containers.
                         The default value is Default which uses the container runtime defaults for
                         readonly paths and masked paths.
-                        This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
@@ -11943,7 +11942,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -13517,7 +13515,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -14002,7 +13999,6 @@ spec:
                             When set to false, a new userns is created for the pod. Setting false is useful for
                             mitigating container breakout vulnerabilities even allowing users to run their
                             containers as root without actually having root privileges on the host.
-                            This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                           type: boolean
                         hostname:
                           description: |-
@@ -15173,7 +15169,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -15742,6 +15737,14 @@ spec:
 
                               It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                               Containers that need access to the ResourceClaim reference it with this name.
+
+                              When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                              belongs to a PodGroup, a PodResourceClaim is matched to a
+                              PodGroupResourceClaim if all of their fields are equal (Name,
+                              ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                              a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                              the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                              Pods.
                             properties:
                               name:
                                 description: |-
@@ -15766,6 +15769,16 @@ spec:
                                   will also be deleted. The pod name and resource name, along with a
                                   generated component, will be used to form a unique name for the
                                   ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                  belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                  Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                  ResourceClaim generated for the PodGroup. All pods in the group that
+                                  define an equivalent PodResourceClaim matching the
+                                  PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                  generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                  owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                  instead of any individual pod.
 
                                   This field is immutable and no changes will be made to the
                                   corresponding ResourceClaim by the control plane after creating the
@@ -15893,6 +15906,28 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        schedulingGroup:
+                          description: |-
+                            SchedulingGroup provides a reference to the immediate scheduling runtime
+                            grouping object that this Pod belongs to.
+                            This field is used by the scheduler to identify the group and apply the
+                            correct group scheduling policies. The association with a group also
+                            impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                            of scheduling like preemption, resource attachment, etc. If not specified,
+                            the Pod is treated as a single unit in all of these aspects.
+                            The group object referenced by this field may not exist at the time the
+                            Pod is created.
+                            This field is immutable, but a group object with the same name may be
+                            recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            podGroupName:
+                              description: |-
+                                PodGroupName specifies the name of the standalone PodGroup object
+                                that represents the runtime instance of this group.
+                                Must be a DNS subdomain.
+                              type: string
+                          type: object
                         securityContext:
                           description: |-
                             SecurityContext holds pod-level security attributes and common container settings.
@@ -17326,7 +17361,7 @@ spec:
                                   A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                   The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                   The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  The volume will be mounted read-only (ro).
                                   Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                   The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                 properties:
@@ -17499,8 +17534,7 @@ spec:
                                 description: |-
                                   portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                   Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                  are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                  is on.
+                                  are redirected to the pxd.portworx.com CSI driver.
                                 properties:
                                   fsType:
                                     description: |-
@@ -18330,42 +18364,6 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
-                        workloadRef:
-                          description: |-
-                            WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                            This field is used by the scheduler to identify the PodGroup and apply the
-                            correct group scheduling policies. The Workload object referenced
-                            by this field may not exist at the time the Pod is created.
-                            This field is immutable, but a Workload object with the same name
-                            may be recreated with different policies. Doing this during pod scheduling
-                            may result in the placement not conforming to the expected policies.
-                          properties:
-                            name:
-                              description: |-
-                                Name defines the name of the Workload object this Pod belongs to.
-                                Workload must be in the same namespace as the Pod.
-                                If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                until a Workload object is created and observed by the kube-scheduler.
-                                It must be a DNS subdomain.
-                              type: string
-                            podGroup:
-                              description: |-
-                                PodGroup is the name of the PodGroup within the Workload that this Pod
-                                belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                the Pod will remain unschedulable until the Workload object is recreated
-                                and observed by the kube-scheduler. It must be a DNS label.
-                              type: string
-                            podGroupReplicaKey:
-                              description: |-
-                                PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                Pod belongs. It is used to distinguish pods belonging to different replicas
-                                of the same pod group. The pod group policy is applied separately to each replica.
-                                When set, it must be a DNS label.
-                              type: string
-                          required:
-                            - name
-                            - podGroup
-                          type: object
                       required:
                         - containers
                       type: object

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
-        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
-        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
+        checksum/config: e8a7810ca1b5a05169150af99605e9c4d990a21fad6d5f33111074c7c329afb1
+        checksum/monitoring-config: 69d7106d91691ffded680b977394afab7b1c004594ce5a197c9d4ff094a31ed1
+        checksum/rbac: de28f52a82bc0ae7bedd16f87c0eddaa9df54204697ff0e218ac9f984a9a3bbf
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,7 +36,7 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -47,7 +47,7 @@ spec:
               value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -21,11 +21,11 @@ data:
             , state
             , usename
             , COALESCE(application_name, '') AS application_name
-            , COUNT(*)
-            , COALESCE(EXTRACT (EPOCH FROM (max(now() - xact_start))), 0) AS max_tx_secs
+            , pg_catalog.count(*)
+            , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs
           FROM pg_catalog.pg_stat_activity
           GROUP BY datname, state, usename, application_name
-        ) sa ON states.state = sa.state
+        ) sa ON states.state OPERATOR(pg_catalog.=) sa.state
         WHERE sa.usename IS NOT NULL
       metrics:
         - datname:
@@ -49,10 +49,10 @@ data:
 
     backends_waiting:
       query: |
-        SELECT count(*) AS total
+        SELECT pg_catalog.count(*) AS total
         FROM pg_catalog.pg_locks blocked_locks
         JOIN pg_catalog.pg_locks blocking_locks
-          ON blocking_locks.locktype = blocked_locks.locktype
+          ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype
           AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
           AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
           AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
@@ -62,8 +62,8 @@ data:
           AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
           AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
           AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
-          AND blocking_locks.pid != blocked_locks.pid
-        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+          AND blocking_locks.pid OPERATOR(pg_catalog.<>) blocked_locks.pid
+        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid
         WHERE NOT blocked_locks.granted
       metrics:
         - total:
@@ -105,14 +105,14 @@ data:
       query: |
         SELECT CASE WHEN (
             NOT pg_catalog.pg_is_in_recovery()
-            OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
+            OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())
           THEN 0
           ELSE GREATEST (0,
-            EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
+            EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))
           END AS lag,
           pg_catalog.pg_is_in_recovery() AS in_recovery,
-          EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-          (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
+          EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,
+          (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
       metrics:
         - lag:
             usage: "GAUGE"
@@ -160,17 +160,17 @@ data:
       query: |
         SELECT archived_count
           , failed_count
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_archived_time)), -1) AS seconds_since_last_archival
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_failed_time)), -1) AS seconds_since_last_failure
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure
           , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time
           , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
           , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
         FROM pg_catalog.pg_stat_archiver
       predicate_query: |
         SELECT NOT pg_catalog.pg_is_in_recovery()
-          OR pg_catalog.current_setting('archive_mode') = 'always'
+          OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'
       metrics:
         - archived_count:
             usage: "COUNTER"
@@ -456,12 +456,12 @@ data:
     pg_extensions:
       query: |
         SELECT
-          current_database() as datname,
+          pg_catalog.current_database() as datname,
           name as extname,
           default_version,
           installed_version,
           CASE
-            WHEN default_version = installed_version THEN 0
+            WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0
             ELSE 1
         END AS update_available
         FROM pg_catalog.pg_available_extensions
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
+    app.kubernetes.io/version: 1.29.1
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.28.0
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/control-plane/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
+    app.kubernetes.io/version: 2.3.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.2.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: crossplane-2.2.2
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: crossplane-2.2.2
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/control-plane/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-master-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:v4.189.0-func
+  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/defaults/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-master-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
+  package: ghcr.io/vshn/appcat:v4.189.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -6401,7 +6401,6 @@ spec:
                         procMount denotes the type of proc mount to use for the containers.
                         The default value is Default which uses the container runtime defaults for
                         readonly paths and masked paths.
-                        This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
@@ -11943,7 +11942,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -13517,7 +13515,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -14002,7 +13999,6 @@ spec:
                             When set to false, a new userns is created for the pod. Setting false is useful for
                             mitigating container breakout vulnerabilities even allowing users to run their
                             containers as root without actually having root privileges on the host.
-                            This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                           type: boolean
                         hostname:
                           description: |-
@@ -15173,7 +15169,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -15742,6 +15737,14 @@ spec:
 
                               It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                               Containers that need access to the ResourceClaim reference it with this name.
+
+                              When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                              belongs to a PodGroup, a PodResourceClaim is matched to a
+                              PodGroupResourceClaim if all of their fields are equal (Name,
+                              ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                              a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                              the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                              Pods.
                             properties:
                               name:
                                 description: |-
@@ -15766,6 +15769,16 @@ spec:
                                   will also be deleted. The pod name and resource name, along with a
                                   generated component, will be used to form a unique name for the
                                   ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                  belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                  Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                  ResourceClaim generated for the PodGroup. All pods in the group that
+                                  define an equivalent PodResourceClaim matching the
+                                  PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                  generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                  owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                  instead of any individual pod.
 
                                   This field is immutable and no changes will be made to the
                                   corresponding ResourceClaim by the control plane after creating the
@@ -15893,6 +15906,28 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        schedulingGroup:
+                          description: |-
+                            SchedulingGroup provides a reference to the immediate scheduling runtime
+                            grouping object that this Pod belongs to.
+                            This field is used by the scheduler to identify the group and apply the
+                            correct group scheduling policies. The association with a group also
+                            impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                            of scheduling like preemption, resource attachment, etc. If not specified,
+                            the Pod is treated as a single unit in all of these aspects.
+                            The group object referenced by this field may not exist at the time the
+                            Pod is created.
+                            This field is immutable, but a group object with the same name may be
+                            recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            podGroupName:
+                              description: |-
+                                PodGroupName specifies the name of the standalone PodGroup object
+                                that represents the runtime instance of this group.
+                                Must be a DNS subdomain.
+                              type: string
+                          type: object
                         securityContext:
                           description: |-
                             SecurityContext holds pod-level security attributes and common container settings.
@@ -17326,7 +17361,7 @@ spec:
                                   A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                   The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                   The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  The volume will be mounted read-only (ro).
                                   Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                   The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                 properties:
@@ -17499,8 +17534,7 @@ spec:
                                 description: |-
                                   portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                   Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                  are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                  is on.
+                                  are redirected to the pxd.portworx.com CSI driver.
                                 properties:
                                   fsType:
                                     description: |-
@@ -18330,42 +18364,6 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
-                        workloadRef:
-                          description: |-
-                            WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                            This field is used by the scheduler to identify the PodGroup and apply the
-                            correct group scheduling policies. The Workload object referenced
-                            by this field may not exist at the time the Pod is created.
-                            This field is immutable, but a Workload object with the same name
-                            may be recreated with different policies. Doing this during pod scheduling
-                            may result in the placement not conforming to the expected policies.
-                          properties:
-                            name:
-                              description: |-
-                                Name defines the name of the Workload object this Pod belongs to.
-                                Workload must be in the same namespace as the Pod.
-                                If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                until a Workload object is created and observed by the kube-scheduler.
-                                It must be a DNS subdomain.
-                              type: string
-                            podGroup:
-                              description: |-
-                                PodGroup is the name of the PodGroup within the Workload that this Pod
-                                belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                the Pod will remain unschedulable until the Workload object is recreated
-                                and observed by the kube-scheduler. It must be a DNS label.
-                              type: string
-                            podGroupReplicaKey:
-                              description: |-
-                                PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                Pod belongs. It is used to distinguish pods belonging to different replicas
-                                of the same pod group. The pod group policy is applied separately to each replica.
-                                When set, it must be a DNS label.
-                              type: string
-                          required:
-                            - name
-                            - podGroup
-                          type: object
                       required:
                         - containers
                       type: object

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
-        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
-        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
+        checksum/config: e8a7810ca1b5a05169150af99605e9c4d990a21fad6d5f33111074c7c329afb1
+        checksum/monitoring-config: 69d7106d91691ffded680b977394afab7b1c004594ce5a197c9d4ff094a31ed1
+        checksum/rbac: de28f52a82bc0ae7bedd16f87c0eddaa9df54204697ff0e218ac9f984a9a3bbf
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,7 +36,7 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -47,7 +47,7 @@ spec:
               value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -21,11 +21,11 @@ data:
             , state
             , usename
             , COALESCE(application_name, '') AS application_name
-            , COUNT(*)
-            , COALESCE(EXTRACT (EPOCH FROM (max(now() - xact_start))), 0) AS max_tx_secs
+            , pg_catalog.count(*)
+            , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs
           FROM pg_catalog.pg_stat_activity
           GROUP BY datname, state, usename, application_name
-        ) sa ON states.state = sa.state
+        ) sa ON states.state OPERATOR(pg_catalog.=) sa.state
         WHERE sa.usename IS NOT NULL
       metrics:
         - datname:
@@ -49,10 +49,10 @@ data:
 
     backends_waiting:
       query: |
-        SELECT count(*) AS total
+        SELECT pg_catalog.count(*) AS total
         FROM pg_catalog.pg_locks blocked_locks
         JOIN pg_catalog.pg_locks blocking_locks
-          ON blocking_locks.locktype = blocked_locks.locktype
+          ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype
           AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
           AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
           AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
@@ -62,8 +62,8 @@ data:
           AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
           AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
           AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
-          AND blocking_locks.pid != blocked_locks.pid
-        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+          AND blocking_locks.pid OPERATOR(pg_catalog.<>) blocked_locks.pid
+        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid
         WHERE NOT blocked_locks.granted
       metrics:
         - total:
@@ -105,14 +105,14 @@ data:
       query: |
         SELECT CASE WHEN (
             NOT pg_catalog.pg_is_in_recovery()
-            OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
+            OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())
           THEN 0
           ELSE GREATEST (0,
-            EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
+            EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))
           END AS lag,
           pg_catalog.pg_is_in_recovery() AS in_recovery,
-          EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-          (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
+          EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,
+          (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
       metrics:
         - lag:
             usage: "GAUGE"
@@ -160,17 +160,17 @@ data:
       query: |
         SELECT archived_count
           , failed_count
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_archived_time)), -1) AS seconds_since_last_archival
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_failed_time)), -1) AS seconds_since_last_failure
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure
           , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time
           , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
           , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
         FROM pg_catalog.pg_stat_archiver
       predicate_query: |
         SELECT NOT pg_catalog.pg_is_in_recovery()
-          OR pg_catalog.current_setting('archive_mode') = 'always'
+          OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'
       metrics:
         - archived_count:
             usage: "COUNTER"
@@ -456,12 +456,12 @@ data:
     pg_extensions:
       query: |
         SELECT
-          current_database() as datname,
+          pg_catalog.current_database() as datname,
           name as extname,
           default_version,
           installed_version,
           CASE
-            WHEN default_version = installed_version THEN 0
+            WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0
             ELSE 1
         END AS update_available
         FROM pg_catalog.pg_available_extensions
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
+    app.kubernetes.io/version: 1.29.1
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.28.0
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/defaults/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
+    app.kubernetes.io/version: 2.3.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.2.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: crossplane-2.2.2
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: crossplane-2.2.2
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/defaults/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/dev-talos/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-debug-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
+  package: ghcr.io/vshn/appcat:v4.189.0-func
   packagePullPolicy: Always
   runtimeConfigRef:
     name: enable-proxy

--- a/tests/golden/dev-talos/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-debug-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:v4.189.0-func
+  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
   packagePullPolicy: Always
   runtimeConfigRef:
     name: enable-proxy

--- a/tests/golden/dev-talos/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.1.0
+  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.2.1
   packagePullPolicy: Always
   runtimeConfigRef:
     name: provider-kubernetes

--- a/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -35,7 +35,7 @@ spec:
           billingEnabled: 'false'
           bucketRegion: rma
           busybox_image: dockerhub.vshn.net/library/busybox
-          busybox_image_tag: '1.37'
+          busybox_image_tag: '1.38'
           chartRepository: https://codecentric.github.io/helm-charts
           chartVersion: 7.1.9
           cloudProvider: cloudscale

--- a/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -37,7 +37,7 @@ spec:
           busybox_image: dockerhub.vshn.net/library/busybox
           busybox_image_tag: '1.38'
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.1.9
+          chartVersion: 7.2.0
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           controlNamespace: syn-appcat-control

--- a/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -70,7 +70,7 @@ spec:
           proxyEndpoint: 10.5.0.1:9443
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:3.0.7
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.9
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -32,7 +32,7 @@ spec:
           billingEnabled: 'false'
           bucketRegion: rma
           busybox_image: dockerhub.vshn.net/library/busybox
-          busybox_image_tag: '1.37'
+          busybox_image_tag: '1.38'
           chartRepository: https://nextcloud.github.io/helm/
           chartVersion: 9.0.5
           cloudProvider: cloudscale

--- a/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -34,7 +34,7 @@ spec:
           busybox_image: dockerhub.vshn.net/library/busybox
           busybox_image_tag: '1.38'
           chartRepository: https://nextcloud.github.io/helm/
-          chartVersion: 9.0.5
+          chartVersion: 9.1.3
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           collaboraCPULimit: '1'

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -6401,7 +6401,6 @@ spec:
                         procMount denotes the type of proc mount to use for the containers.
                         The default value is Default which uses the container runtime defaults for
                         readonly paths and masked paths.
-                        This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
@@ -11943,7 +11942,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -13517,7 +13515,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -14002,7 +13999,6 @@ spec:
                             When set to false, a new userns is created for the pod. Setting false is useful for
                             mitigating container breakout vulnerabilities even allowing users to run their
                             containers as root without actually having root privileges on the host.
-                            This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                           type: boolean
                         hostname:
                           description: |-
@@ -15173,7 +15169,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -15742,6 +15737,14 @@ spec:
 
                               It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                               Containers that need access to the ResourceClaim reference it with this name.
+
+                              When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                              belongs to a PodGroup, a PodResourceClaim is matched to a
+                              PodGroupResourceClaim if all of their fields are equal (Name,
+                              ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                              a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                              the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                              Pods.
                             properties:
                               name:
                                 description: |-
@@ -15766,6 +15769,16 @@ spec:
                                   will also be deleted. The pod name and resource name, along with a
                                   generated component, will be used to form a unique name for the
                                   ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                  belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                  Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                  ResourceClaim generated for the PodGroup. All pods in the group that
+                                  define an equivalent PodResourceClaim matching the
+                                  PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                  generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                  owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                  instead of any individual pod.
 
                                   This field is immutable and no changes will be made to the
                                   corresponding ResourceClaim by the control plane after creating the
@@ -15893,6 +15906,28 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        schedulingGroup:
+                          description: |-
+                            SchedulingGroup provides a reference to the immediate scheduling runtime
+                            grouping object that this Pod belongs to.
+                            This field is used by the scheduler to identify the group and apply the
+                            correct group scheduling policies. The association with a group also
+                            impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                            of scheduling like preemption, resource attachment, etc. If not specified,
+                            the Pod is treated as a single unit in all of these aspects.
+                            The group object referenced by this field may not exist at the time the
+                            Pod is created.
+                            This field is immutable, but a group object with the same name may be
+                            recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            podGroupName:
+                              description: |-
+                                PodGroupName specifies the name of the standalone PodGroup object
+                                that represents the runtime instance of this group.
+                                Must be a DNS subdomain.
+                              type: string
+                          type: object
                         securityContext:
                           description: |-
                             SecurityContext holds pod-level security attributes and common container settings.
@@ -17326,7 +17361,7 @@ spec:
                                   A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                   The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                   The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  The volume will be mounted read-only (ro).
                                   Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                   The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                 properties:
@@ -17499,8 +17534,7 @@ spec:
                                 description: |-
                                   portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                   Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                  are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                  is on.
+                                  are redirected to the pxd.portworx.com CSI driver.
                                 properties:
                                   fsType:
                                     description: |-
@@ -18330,42 +18364,6 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
-                        workloadRef:
-                          description: |-
-                            WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                            This field is used by the scheduler to identify the PodGroup and apply the
-                            correct group scheduling policies. The Workload object referenced
-                            by this field may not exist at the time the Pod is created.
-                            This field is immutable, but a Workload object with the same name
-                            may be recreated with different policies. Doing this during pod scheduling
-                            may result in the placement not conforming to the expected policies.
-                          properties:
-                            name:
-                              description: |-
-                                Name defines the name of the Workload object this Pod belongs to.
-                                Workload must be in the same namespace as the Pod.
-                                If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                until a Workload object is created and observed by the kube-scheduler.
-                                It must be a DNS subdomain.
-                              type: string
-                            podGroup:
-                              description: |-
-                                PodGroup is the name of the PodGroup within the Workload that this Pod
-                                belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                the Pod will remain unschedulable until the Workload object is recreated
-                                and observed by the kube-scheduler. It must be a DNS label.
-                              type: string
-                            podGroupReplicaKey:
-                              description: |-
-                                PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                Pod belongs. It is used to distinguish pods belonging to different replicas
-                                of the same pod group. The pod group policy is applied separately to each replica.
-                                When set, it must be a DNS label.
-                              type: string
-                          required:
-                            - name
-                            - podGroup
-                          type: object
                       required:
                         - containers
                       type: object

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
-        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
-        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
+        checksum/config: e8a7810ca1b5a05169150af99605e9c4d990a21fad6d5f33111074c7c329afb1
+        checksum/monitoring-config: 69d7106d91691ffded680b977394afab7b1c004594ce5a197c9d4ff094a31ed1
+        checksum/rbac: de28f52a82bc0ae7bedd16f87c0eddaa9df54204697ff0e218ac9f984a9a3bbf
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,7 +36,7 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -47,7 +47,7 @@ spec:
               value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -21,11 +21,11 @@ data:
             , state
             , usename
             , COALESCE(application_name, '') AS application_name
-            , COUNT(*)
-            , COALESCE(EXTRACT (EPOCH FROM (max(now() - xact_start))), 0) AS max_tx_secs
+            , pg_catalog.count(*)
+            , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs
           FROM pg_catalog.pg_stat_activity
           GROUP BY datname, state, usename, application_name
-        ) sa ON states.state = sa.state
+        ) sa ON states.state OPERATOR(pg_catalog.=) sa.state
         WHERE sa.usename IS NOT NULL
       metrics:
         - datname:
@@ -49,10 +49,10 @@ data:
 
     backends_waiting:
       query: |
-        SELECT count(*) AS total
+        SELECT pg_catalog.count(*) AS total
         FROM pg_catalog.pg_locks blocked_locks
         JOIN pg_catalog.pg_locks blocking_locks
-          ON blocking_locks.locktype = blocked_locks.locktype
+          ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype
           AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
           AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
           AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
@@ -62,8 +62,8 @@ data:
           AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
           AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
           AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
-          AND blocking_locks.pid != blocked_locks.pid
-        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+          AND blocking_locks.pid OPERATOR(pg_catalog.<>) blocked_locks.pid
+        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid
         WHERE NOT blocked_locks.granted
       metrics:
         - total:
@@ -105,14 +105,14 @@ data:
       query: |
         SELECT CASE WHEN (
             NOT pg_catalog.pg_is_in_recovery()
-            OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
+            OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())
           THEN 0
           ELSE GREATEST (0,
-            EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
+            EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))
           END AS lag,
           pg_catalog.pg_is_in_recovery() AS in_recovery,
-          EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-          (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
+          EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,
+          (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
       metrics:
         - lag:
             usage: "GAUGE"
@@ -160,17 +160,17 @@ data:
       query: |
         SELECT archived_count
           , failed_count
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_archived_time)), -1) AS seconds_since_last_archival
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_failed_time)), -1) AS seconds_since_last_failure
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure
           , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time
           , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
           , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
         FROM pg_catalog.pg_stat_archiver
       predicate_query: |
         SELECT NOT pg_catalog.pg_is_in_recovery()
-          OR pg_catalog.current_setting('archive_mode') = 'always'
+          OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'
       metrics:
         - archived_count:
             usage: "COUNTER"
@@ -456,12 +456,12 @@ data:
     pg_extensions:
       query: |
         SELECT
-          current_database() as datname,
+          pg_catalog.current_database() as datname,
           name as extname,
           default_version,
           installed_version,
           CASE
-            WHEN default_version = installed_version THEN 0
+            WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0
             ELSE 1
         END AS update_available
         FROM pg_catalog.pg_available_extensions
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
+    app.kubernetes.io/version: 1.29.1
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.28.0
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/dev-talos/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-debug-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
+  package: ghcr.io/vshn/appcat:v4.189.0-func
   packagePullPolicy: Always
   runtimeConfigRef:
     name: enable-proxy

--- a/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/dev/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-debug-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:v4.189.0-func
+  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
   packagePullPolicy: Always
   runtimeConfigRef:
     name: enable-proxy

--- a/tests/golden/dev/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/dev/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.1.0
+  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.2.1
   packagePullPolicy: Always
   runtimeConfigRef:
     name: provider-kubernetes

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -35,7 +35,7 @@ spec:
           billingEnabled: 'false'
           bucketRegion: rma
           busybox_image: dockerhub.vshn.net/library/busybox
-          busybox_image_tag: '1.37'
+          busybox_image_tag: '1.38'
           chartRepository: https://codecentric.github.io/helm-charts
           chartVersion: 7.1.9
           cloudProvider: cloudscale

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -37,7 +37,7 @@ spec:
           busybox_image: dockerhub.vshn.net/library/busybox
           busybox_image_tag: '1.38'
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.1.9
+          chartVersion: 7.2.0
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           controlNamespace: syn-appcat-control

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -70,7 +70,7 @@ spec:
           proxyEndpoint: 172.18.0.1:9443
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:3.0.7
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.9
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -32,7 +32,7 @@ spec:
           billingEnabled: 'false'
           bucketRegion: rma
           busybox_image: dockerhub.vshn.net/library/busybox
-          busybox_image_tag: '1.37'
+          busybox_image_tag: '1.38'
           chartRepository: https://nextcloud.github.io/helm/
           chartVersion: 9.0.5
           cloudProvider: cloudscale

--- a/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/dev/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -34,7 +34,7 @@ spec:
           busybox_image: dockerhub.vshn.net/library/busybox
           busybox_image_tag: '1.38'
           chartRepository: https://nextcloud.github.io/helm/
-          chartVersion: 9.0.5
+          chartVersion: 9.1.3
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           collaboraCPULimit: '1'

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -6401,7 +6401,6 @@ spec:
                         procMount denotes the type of proc mount to use for the containers.
                         The default value is Default which uses the container runtime defaults for
                         readonly paths and masked paths.
-                        This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
@@ -11943,7 +11942,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -13517,7 +13515,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -14002,7 +13999,6 @@ spec:
                             When set to false, a new userns is created for the pod. Setting false is useful for
                             mitigating container breakout vulnerabilities even allowing users to run their
                             containers as root without actually having root privileges on the host.
-                            This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                           type: boolean
                         hostname:
                           description: |-
@@ -15173,7 +15169,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -15742,6 +15737,14 @@ spec:
 
                               It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                               Containers that need access to the ResourceClaim reference it with this name.
+
+                              When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                              belongs to a PodGroup, a PodResourceClaim is matched to a
+                              PodGroupResourceClaim if all of their fields are equal (Name,
+                              ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                              a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                              the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                              Pods.
                             properties:
                               name:
                                 description: |-
@@ -15766,6 +15769,16 @@ spec:
                                   will also be deleted. The pod name and resource name, along with a
                                   generated component, will be used to form a unique name for the
                                   ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                  belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                  Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                  ResourceClaim generated for the PodGroup. All pods in the group that
+                                  define an equivalent PodResourceClaim matching the
+                                  PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                  generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                  owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                  instead of any individual pod.
 
                                   This field is immutable and no changes will be made to the
                                   corresponding ResourceClaim by the control plane after creating the
@@ -15893,6 +15906,28 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        schedulingGroup:
+                          description: |-
+                            SchedulingGroup provides a reference to the immediate scheduling runtime
+                            grouping object that this Pod belongs to.
+                            This field is used by the scheduler to identify the group and apply the
+                            correct group scheduling policies. The association with a group also
+                            impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                            of scheduling like preemption, resource attachment, etc. If not specified,
+                            the Pod is treated as a single unit in all of these aspects.
+                            The group object referenced by this field may not exist at the time the
+                            Pod is created.
+                            This field is immutable, but a group object with the same name may be
+                            recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            podGroupName:
+                              description: |-
+                                PodGroupName specifies the name of the standalone PodGroup object
+                                that represents the runtime instance of this group.
+                                Must be a DNS subdomain.
+                              type: string
+                          type: object
                         securityContext:
                           description: |-
                             SecurityContext holds pod-level security attributes and common container settings.
@@ -17326,7 +17361,7 @@ spec:
                                   A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                   The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                   The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  The volume will be mounted read-only (ro).
                                   Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                   The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                 properties:
@@ -17499,8 +17534,7 @@ spec:
                                 description: |-
                                   portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                   Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                  are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                  is on.
+                                  are redirected to the pxd.portworx.com CSI driver.
                                 properties:
                                   fsType:
                                     description: |-
@@ -18330,42 +18364,6 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
-                        workloadRef:
-                          description: |-
-                            WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                            This field is used by the scheduler to identify the PodGroup and apply the
-                            correct group scheduling policies. The Workload object referenced
-                            by this field may not exist at the time the Pod is created.
-                            This field is immutable, but a Workload object with the same name
-                            may be recreated with different policies. Doing this during pod scheduling
-                            may result in the placement not conforming to the expected policies.
-                          properties:
-                            name:
-                              description: |-
-                                Name defines the name of the Workload object this Pod belongs to.
-                                Workload must be in the same namespace as the Pod.
-                                If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                until a Workload object is created and observed by the kube-scheduler.
-                                It must be a DNS subdomain.
-                              type: string
-                            podGroup:
-                              description: |-
-                                PodGroup is the name of the PodGroup within the Workload that this Pod
-                                belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                the Pod will remain unschedulable until the Workload object is recreated
-                                and observed by the kube-scheduler. It must be a DNS label.
-                              type: string
-                            podGroupReplicaKey:
-                              description: |-
-                                PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                Pod belongs. It is used to distinguish pods belonging to different replicas
-                                of the same pod group. The pod group policy is applied separately to each replica.
-                                When set, it must be a DNS label.
-                              type: string
-                          required:
-                            - name
-                            - podGroup
-                          type: object
                       required:
                         - containers
                       type: object

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
-        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
-        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
+        checksum/config: e8a7810ca1b5a05169150af99605e9c4d990a21fad6d5f33111074c7c329afb1
+        checksum/monitoring-config: 69d7106d91691ffded680b977394afab7b1c004594ce5a197c9d4ff094a31ed1
+        checksum/rbac: de28f52a82bc0ae7bedd16f87c0eddaa9df54204697ff0e218ac9f984a9a3bbf
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,7 +36,7 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -47,7 +47,7 @@ spec:
               value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -21,11 +21,11 @@ data:
             , state
             , usename
             , COALESCE(application_name, '') AS application_name
-            , COUNT(*)
-            , COALESCE(EXTRACT (EPOCH FROM (max(now() - xact_start))), 0) AS max_tx_secs
+            , pg_catalog.count(*)
+            , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs
           FROM pg_catalog.pg_stat_activity
           GROUP BY datname, state, usename, application_name
-        ) sa ON states.state = sa.state
+        ) sa ON states.state OPERATOR(pg_catalog.=) sa.state
         WHERE sa.usename IS NOT NULL
       metrics:
         - datname:
@@ -49,10 +49,10 @@ data:
 
     backends_waiting:
       query: |
-        SELECT count(*) AS total
+        SELECT pg_catalog.count(*) AS total
         FROM pg_catalog.pg_locks blocked_locks
         JOIN pg_catalog.pg_locks blocking_locks
-          ON blocking_locks.locktype = blocked_locks.locktype
+          ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype
           AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
           AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
           AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
@@ -62,8 +62,8 @@ data:
           AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
           AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
           AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
-          AND blocking_locks.pid != blocked_locks.pid
-        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+          AND blocking_locks.pid OPERATOR(pg_catalog.<>) blocked_locks.pid
+        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid
         WHERE NOT blocked_locks.granted
       metrics:
         - total:
@@ -105,14 +105,14 @@ data:
       query: |
         SELECT CASE WHEN (
             NOT pg_catalog.pg_is_in_recovery()
-            OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
+            OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())
           THEN 0
           ELSE GREATEST (0,
-            EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
+            EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))
           END AS lag,
           pg_catalog.pg_is_in_recovery() AS in_recovery,
-          EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-          (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
+          EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,
+          (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
       metrics:
         - lag:
             usage: "GAUGE"
@@ -160,17 +160,17 @@ data:
       query: |
         SELECT archived_count
           , failed_count
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_archived_time)), -1) AS seconds_since_last_archival
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_failed_time)), -1) AS seconds_since_last_failure
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure
           , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time
           , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
           , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
         FROM pg_catalog.pg_stat_archiver
       predicate_query: |
         SELECT NOT pg_catalog.pg_is_in_recovery()
-          OR pg_catalog.current_setting('archive_mode') = 'always'
+          OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'
       metrics:
         - archived_count:
             usage: "COUNTER"
@@ -456,12 +456,12 @@ data:
     pg_extensions:
       query: |
         SELECT
-          current_database() as datname,
+          pg_catalog.current_database() as datname,
           name as extname,
           default_version,
           installed_version,
           CASE
-            WHEN default_version = installed_version THEN 0
+            WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0
             ELSE 1
         END AS update_available
         FROM pg_catalog.pg_available_extensions
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
+    app.kubernetes.io/version: 1.29.1
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.28.0
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/dev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
+    app.kubernetes.io/version: 2.3.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.2.0
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: Always
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: Always
           name: crossplane-init
           resources:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.0
-        helm.sh/chart: crossplane-2.2.0
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: Always
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.0
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: Always
           name: crossplane-init
           resources:

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/dev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.0
-    helm.sh/chart: crossplane-2.2.0
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/clusterrole.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/clusterrole.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-manager-role
 rules:
   - apiGroups:
@@ -30,15 +30,10 @@ rules:
     resources:
       - pods
     verbs:
+      - delete
       - get
       - list
       - watch
-  - apiGroups:
-      - ''
-    resources:
-      - pods/exec
-    verbs:
-      - create
   - apiGroups:
       - ''
     resources:

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/clusterrolebinding.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/clusterrolebinding.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/crds.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/crds.yaml
@@ -2,15 +2,15 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: garageadmintokens.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info
@@ -23,255 +23,13 @@ spec:
     singular: garageadmintoken
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.clusterRef.name
-          name: Cluster
-          type: string
-        - jsonPath: .status.tokenId
-          name: TokenID
-          type: string
-        - jsonPath: .status.expired
-          name: Expired
-          type: boolean
-        - jsonPath: .status.phase
-          name: Phase
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
+    - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: |-
-            GarageAdminToken is the Schema for the garageadmintokens API
-            It manages admin API tokens for Garage clusters
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: |-
-                GarageAdminTokenSpec defines the desired state of GarageAdminToken
-                Admin tokens are used to authenticate with the Garage Admin API.
-                They are separate from S3 access keys (GarageKey).
-
-                Note: This operator uses file-based admin tokens (loaded via admin_token_file in TOML config).
-                File-based tokens always have full admin access. For scoped/restricted tokens, use Garage's
-                Admin API token management (CreateAdminToken, UpdateAdminToken) directly.
-              properties:
-                clusterRef:
-                  description: ClusterRef references the GarageCluster this token
-                    belongs to
-                  properties:
-                    kubeConfigSecretRef:
-                      description: |-
-                        KubeConfigSecretRef references a secret containing kubeconfig for a remote cluster.
-                        Only used for cross-cluster references in multi-cluster federation scenarios.
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          default: ''
-                          description: |-
-                            Name of the referent.
-                            This field is effectively required, but due to backwards compatibility is
-                            allowed to be empty. Instances of this type with an empty value here are
-                            almost certainly wrong.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or its key must
-                            be defined
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    name:
-                      description: Name of the GarageCluster
-                      type: string
-                    namespace:
-                      description: Namespace of the GarageCluster (defaults to the
-                        same namespace as the referencing resource)
-                      type: string
-                  required:
-                    - name
-                  type: object
-                expiration:
-                  description: |-
-                    Expiration sets when this token expires (RFC 3339 format)
-                    Note: Expiration is tracked by the operator but not enforced by Garage
-                    for file-based tokens. Token rotation must be done manually.
-                  type: string
-                name:
-                  description: |-
-                    Name is a friendly name for this admin token
-                    If not set, metadata.name is used
-                  type: string
-                neverExpires:
-                  description: |-
-                    NeverExpires sets the token to never expire
-                    Mutually exclusive with Expiration
-                  type: boolean
-                secretTemplate:
-                  description: SecretTemplate configures how the secret containing
-                    the token is generated
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations to add to the secret
-                      type: object
-                    endpointKey:
-                      default: admin-endpoint
-                      description: EndpointKey is the key name for the admin endpoint
-                      type: string
-                    includeEndpoint:
-                      description: |-
-                        IncludeEndpoint includes the admin API endpoint in the secret
-                        Defaults to true if not specified
-                      type: boolean
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels to add to the secret
-                      type: object
-                    name:
-                      description: |-
-                        Name is the name of the secret to create
-                        Defaults to the GarageAdminToken name
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace is the namespace for the secret
-                        Defaults to the GarageAdminToken namespace
-                      type: string
-                    tokenKey:
-                      default: admin-token
-                      description: TokenKey is the key name for the admin token in
-                        the secret
-                      type: string
-                  type: object
-              required:
-                - clusterRef
-              type: object
-            status:
-              description: GarageAdminTokenStatus defines the observed state of GarageAdminToken
-              properties:
-                conditions:
-                  description: Conditions represent the current state
-                  items:
-                    description: Condition contains details for one aspect of the
-                      current state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False,
-                          Unknown.
-                        enum:
-                          - 'True'
-                          - 'False'
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                expiration:
-                  description: Expiration is when this token expires (if set)
-                  type: string
-                expired:
-                  description: Expired indicates if this token has expired
-                  type: boolean
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation
-                  format: int64
-                  type: integer
-                phase:
-                  description: Phase represents the current phase
-                  type: string
-                secretRef:
-                  description: SecretRef references the created secret
-                  properties:
-                    name:
-                      description: name is unique within a namespace to reference
-                        a secret resource.
-                      type: string
-                    namespace:
-                      description: namespace defines the space within which the secret
-                        name must be unique.
-                      type: string
-                  type: object
-                  x-kubernetes-map-type: atomic
-                tokenId:
-                  description: TokenID is the Garage-assigned token ID (first 8 chars)
-                  type: string
-              type: object
-          required:
-            - spec
           type: object
-      served: true
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
       storage: false
-      subresources:
-        status: {}
     - additionalPrinterColumns:
         - jsonPath: .spec.clusterRef.name
           name: Cluster
@@ -532,15 +290,15 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: garagebuckets.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info
@@ -1073,12 +831,15 @@ spec:
                           - name
                         type: object
                       owner:
+                        default: false
                         description: Owner allows bucket owner operations
                         type: boolean
                       read:
+                        default: false
                         description: Read allows reading objects
                         type: boolean
                       write:
+                        default: false
                         description: Write allows writing objects
                         type: boolean
                     required:
@@ -1390,6 +1151,15 @@ spec:
                         type: string
                     type: object
                   type: array
+                managedKeyGrants:
+                  description: |-
+                    ManagedKeyGrants lists the access key IDs this bucket's spec.keyPermissions
+                    last granted access to. Used to revoke grants when a keyRef is dropped
+                    from the spec, without disturbing grants made via a GarageKey's
+                    bucketPermissions/allBuckets or by hand.
+                  items:
+                    type: string
+                  type: array
                 observedGeneration:
                   description: ObservedGeneration is the last observed generation
                   format: int64
@@ -1470,17 +1240,28 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    cert-manager.io/inject-ca-from: syn-garage-operator/appcat-garage-operator-webhook-cert
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: garageclusters.garage.rajsingh.info
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: appcat-garage-operator-webhook
+          namespace: syn-garage-operator
+          path: /convert
+      conversionReviewVersions:
+        - v1
   group: garage.rajsingh.info
   names:
     kind: GarageCluster
@@ -1491,4063 +1272,13 @@ spec:
     singular: garagecluster
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.replicas
-          name: Replicas
-          type: integer
-        - jsonPath: .status.readyReplicas
-          name: Ready
-          type: integer
-        - jsonPath: .spec.zone
-          name: Zone
-          type: string
-        - jsonPath: .status.phase
-          name: Phase
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
+    - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: GarageCluster is the Schema for the garageclusters API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: GarageClusterSpec defines the desired state of GarageCluster
-              properties:
-                admin:
-                  description: Admin configures the admin API endpoint and metrics
-                  properties:
-                    adminTokenSecretRef:
-                      description: AdminTokenSecretRef references a secret containing
-                        the admin API token
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          default: ''
-                          description: |-
-                            Name of the referent.
-                            This field is effectively required, but due to backwards compatibility is
-                            allowed to be empty. Instances of this type with an empty value here are
-                            almost certainly wrong.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or its key must
-                            be defined
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    bindAddress:
-                      description: |-
-                        BindAddress is a custom bind address for the Admin API.
-                        Can be a TCP address or Unix socket path (e.g., "unix:///run/garage/admin.sock").
-                        If set, this overrides BindPort.
-                      type: string
-                    bindPort:
-                      default: 3903
-                      description: BindPort is the port to bind for admin API
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
-                    enabled:
-                      default: true
-                      description: Enabled enables the admin API
-                      type: boolean
-                    metricsRequireToken:
-                      description: MetricsRequireToken requires authentication for
-                        /metrics endpoint
-                      type: boolean
-                    metricsTokenSecretRef:
-                      description: MetricsTokenSecretRef references a secret containing
-                        the metrics token
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          default: ''
-                          description: |-
-                            Name of the referent.
-                            This field is effectively required, but due to backwards compatibility is
-                            allowed to be empty. Instances of this type with an empty value here are
-                            almost certainly wrong.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or its key must
-                            be defined
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    traceSink:
-                      description: |-
-                        TraceSink is the OpenTelemetry collector address for tracing
-                        Example: "http://localhost:4317"
-                      type: string
-                  type: object
-                affinity:
-                  description: Affinity for pod scheduling
-                  properties:
-                    nodeAffinity:
-                      description: Describes node affinity scheduling rules for the
-                        pod.
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            The scheduler will prefer to schedule pods to nodes that satisfy
-                            the affinity expressions specified by this field, but it may choose
-                            a node that violates one or more of the expressions. The node that is
-                            most preferred is the one with the greatest sum of weights, i.e.
-                            for each node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions, etc.),
-                            compute a sum by iterating through the elements of this field and adding
-                            "weight" to the sum if the node matches the corresponding matchExpressions; the
-                            node(s) with the highest sum are the most preferred.
-                          items:
-                            description: |-
-                              An empty preferred scheduling term matches all objects with implicit weight 0
-                              (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                            properties:
-                              preference:
-                                description: A node selector term, associated with
-                                  the corresponding weight.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              weight:
-                                description: Weight associated with matching the corresponding
-                                  nodeSelectorTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            If the affinity requirements specified by this field are not met at
-                            scheduling time, the pod will not be scheduled onto the node.
-                            If the affinity requirements specified by this field cease to be met
-                            at some point during pod execution (e.g. due to an update), the system
-                            may or may not try to eventually evict the pod from its node.
-                          properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms.
-                                The terms are ORed.
-                              items:
-                                description: |-
-                                  A null or empty node selector term matches no objects. The requirements of
-                                  them are ANDed.
-                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                            - nodeSelectorTerms
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      type: object
-                    podAffinity:
-                      description: Describes pod affinity scheduling rules (e.g. co-locate
-                        this pod in the same node, zone, etc. as some other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            The scheduler will prefer to schedule pods to nodes that satisfy
-                            the affinity expressions specified by this field, but it may choose
-                            a node that violates one or more of the expressions. The node that is
-                            most preferred is the one with the greatest sum of weights, i.e.
-                            for each node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions, etc.),
-                            compute a sum by iterating through the elements of this field and adding
-                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                            node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: |-
-                                      A label query over a set of resources, in this case pods.
-                                      If it's null, this PodAffinityTerm matches with no Pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  matchLabelKeys:
-                                    description: |-
-                                      MatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  mismatchLabelKeys:
-                                    description: |-
-                                      MismatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  namespaceSelector:
-                                    description: |-
-                                      A label query over the set of namespaces that the term applies to.
-                                      The term is applied to the union of the namespaces selected by this field
-                                      and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list means "this pod's namespace".
-                                      An empty selector ({}) matches all namespaces.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  namespaces:
-                                    description: |-
-                                      namespaces specifies a static list of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces listed in this field
-                                      and the ones selected by namespaceSelector.
-                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  topologyKey:
-                                    description: |-
-                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey matches that of any node on which any of the
-                                      selected pods is running.
-                                      Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: |-
-                                  weight associated with matching the corresponding podAffinityTerm,
-                                  in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            If the affinity requirements specified by this field are not met at
-                            scheduling time, the pod will not be scheduled onto the node.
-                            If the affinity requirements specified by this field cease to be met
-                            at some point during pod execution (e.g. due to a pod label update), the
-                            system may or may not try to eventually evict the pod from its node.
-                            When there are multiple elements, the lists of nodes corresponding to each
-                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: |-
-                              Defines a set of pods (namely those matching the labelSelector
-                              relative to the given namespace(s)) that this pod should be
-                              co-located (affinity) or not co-located (anti-affinity) with,
-                              where co-located is defined as running on a node whose value of
-                              the label with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: |-
-                                  A label query over a set of resources, in this case pods.
-                                  If it's null, this PodAffinityTerm matches with no Pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: |-
-                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                        relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            operator represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            values is an array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: |-
-                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              matchLabelKeys:
-                                description: |-
-                                  MatchLabelKeys is a set of pod label keys to select which pods will
-                                  be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                  to select the group of existing pods which pods will be taken into consideration
-                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                  pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              mismatchLabelKeys:
-                                description: |-
-                                  MismatchLabelKeys is a set of pod label keys to select which pods will
-                                  be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                  to select the group of existing pods which pods will be taken into consideration
-                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                  pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              namespaceSelector:
-                                description: |-
-                                  A label query over the set of namespaces that the term applies to.
-                                  The term is applied to the union of the namespaces selected by this field
-                                  and the ones listed in the namespaces field.
-                                  null selector and null or empty namespaces list means "this pod's namespace".
-                                  An empty selector ({}) matches all namespaces.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: |-
-                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                        relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            operator represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            values is an array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: |-
-                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              namespaces:
-                                description: |-
-                                  namespaces specifies a static list of namespace names that the term applies to.
-                                  The term is applied to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector.
-                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              topologyKey:
-                                description: |-
-                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches that of any node on which any of the
-                                  selected pods is running.
-                                  Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      type: object
-                    podAntiAffinity:
-                      description: Describes pod anti-affinity scheduling rules (e.g.
-                        avoid putting this pod in the same node, zone, etc. as some
-                        other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            The scheduler will prefer to schedule pods to nodes that satisfy
-                            the anti-affinity expressions specified by this field, but it may choose
-                            a node that violates one or more of the expressions. The node that is
-                            most preferred is the one with the greatest sum of weights, i.e.
-                            for each node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling anti-affinity expressions, etc.),
-                            compute a sum by iterating through the elements of this field and subtracting
-                            "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                            node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: |-
-                                      A label query over a set of resources, in this case pods.
-                                      If it's null, this PodAffinityTerm matches with no Pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  matchLabelKeys:
-                                    description: |-
-                                      MatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  mismatchLabelKeys:
-                                    description: |-
-                                      MismatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  namespaceSelector:
-                                    description: |-
-                                      A label query over the set of namespaces that the term applies to.
-                                      The term is applied to the union of the namespaces selected by this field
-                                      and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list means "this pod's namespace".
-                                      An empty selector ({}) matches all namespaces.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  namespaces:
-                                    description: |-
-                                      namespaces specifies a static list of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces listed in this field
-                                      and the ones selected by namespaceSelector.
-                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  topologyKey:
-                                    description: |-
-                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey matches that of any node on which any of the
-                                      selected pods is running.
-                                      Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: |-
-                                  weight associated with matching the corresponding podAffinityTerm,
-                                  in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            If the anti-affinity requirements specified by this field are not met at
-                            scheduling time, the pod will not be scheduled onto the node.
-                            If the anti-affinity requirements specified by this field cease to be met
-                            at some point during pod execution (e.g. due to a pod label update), the
-                            system may or may not try to eventually evict the pod from its node.
-                            When there are multiple elements, the lists of nodes corresponding to each
-                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: |-
-                              Defines a set of pods (namely those matching the labelSelector
-                              relative to the given namespace(s)) that this pod should be
-                              co-located (affinity) or not co-located (anti-affinity) with,
-                              where co-located is defined as running on a node whose value of
-                              the label with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: |-
-                                  A label query over a set of resources, in this case pods.
-                                  If it's null, this PodAffinityTerm matches with no Pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: |-
-                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                        relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            operator represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            values is an array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: |-
-                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              matchLabelKeys:
-                                description: |-
-                                  MatchLabelKeys is a set of pod label keys to select which pods will
-                                  be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                  to select the group of existing pods which pods will be taken into consideration
-                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                  pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              mismatchLabelKeys:
-                                description: |-
-                                  MismatchLabelKeys is a set of pod label keys to select which pods will
-                                  be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                  to select the group of existing pods which pods will be taken into consideration
-                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                  pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              namespaceSelector:
-                                description: |-
-                                  A label query over the set of namespaces that the term applies to.
-                                  The term is applied to the union of the namespaces selected by this field
-                                  and the ones listed in the namespaces field.
-                                  null selector and null or empty namespaces list means "this pod's namespace".
-                                  An empty selector ({}) matches all namespaces.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: |-
-                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                        relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            operator represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            values is an array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: |-
-                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              namespaces:
-                                description: |-
-                                  namespaces specifies a static list of namespace names that the term applies to.
-                                  The term is applied to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector.
-                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              topologyKey:
-                                description: |-
-                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches that of any node on which any of the
-                                  selected pods is running.
-                                  Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      type: object
-                  type: object
-                blocks:
-                  description: Blocks configures block storage settings
-                  properties:
-                    compressionLevel:
-                      description: |-
-                        CompressionLevel is the zstd compression level
-                        1-19: standard, 20-22: ultra, -1 to -99: fast, "none": disabled
-                      type: string
-                    disableScrub:
-                      description: DisableScrub disables automatic monthly data directory
-                        scrub
-                      type: boolean
-                    maxConcurrentReads:
-                      description: MaxConcurrentReads is the maximum simultaneous
-                        block file reads
-                      minimum: 1
-                      type: integer
-                    maxConcurrentWritesPerRequest:
-                      description: |-
-                        MaxConcurrentWritesPerRequest is the maximum parallel block writes per PUT request.
-                        Higher values improve throughput but increase memory usage.
-                        Default: 3. Recommended: 10-30 for NVMe, 3-10 for HDD.
-                        Added in Garage v2.2.0.
-                      minimum: 1
-                      type: integer
-                    ramBufferMax:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: RAMBufferMax is the maximum RAM for buffering blocks
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    size:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: 'Size is the size of data blocks (default: 1M)'
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    useLocalTZ:
-                      description: UseLocalTZ runs lifecycle worker at midnight in
-                        local timezone
-                      type: boolean
-                  type: object
-                capacityReservePercent:
-                  description: |-
-                    CapacityReservePercent reserves a percentage of PVC capacity for overhead.
-                    Only used when LayoutPolicy is "Auto".
-                    For example, setting this to 10 will report 90% of PVC size as node capacity.
-                    This is useful to reserve headroom for filesystem overhead, snapshots, or growth.
-                    Default: 0 (use full PVC size as capacity)
-                  maximum: 50
-                  minimum: 0
-                  type: integer
-                connectTo:
-                  description: |-
-                    ConnectTo specifies the storage cluster this gateway cluster connects to.
-                    Required when gateway=true. The gateway cluster will:
-                    - Use the same RPC secret as the storage cluster
-                    - Connect to the storage cluster's nodes
-                    - Register its pods as gateway nodes in the storage cluster's layout
-                  properties:
-                    adminApiEndpoint:
-                      description: |-
-                        AdminAPIEndpoint is the admin API endpoint for discovering nodes and registering gateways
-                        Required if clusterRef is not in the same namespace
-                        Example: "http://garage-storage.other-namespace:3903"
-                      type: string
-                    adminTokenSecretRef:
-                      description: |-
-                        AdminTokenSecretRef references the admin token for the storage cluster
-                        If clusterRef is specified and in same namespace, uses that cluster's token
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          default: ''
-                          description: |-
-                            Name of the referent.
-                            This field is effectively required, but due to backwards compatibility is
-                            allowed to be empty. Instances of this type with an empty value here are
-                            almost certainly wrong.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or its key must
-                            be defined
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    bootstrapPeers:
-                      description: |-
-                        BootstrapPeers are the initial peers to connect to (for external storage clusters)
-                        Format: "<node_public_key>@<ip_or_hostname>:<port>"
-                      items:
-                        type: string
-                      type: array
-                    clusterRef:
-                      description: |-
-                        ClusterRef references a GarageCluster in the same namespace
-                        The gateway will use this cluster's RPC secret and connect to its nodes
-                      properties:
-                        kubeConfigSecretRef:
-                          description: |-
-                            KubeConfigSecretRef references a secret containing kubeconfig for a remote cluster.
-                            Only used for cross-cluster references in multi-cluster federation scenarios.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              default: ''
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        name:
-                          description: Name of the GarageCluster
-                          type: string
-                        namespace:
-                          description: Namespace of the GarageCluster (defaults to
-                            the same namespace as the referencing resource)
-                          type: string
-                      required:
-                        - name
-                      type: object
-                    rpcSecretRef:
-                      description: |-
-                        RPCSecretRef references a shared RPC secret (for cross-namespace or external clusters)
-                        If clusterRef is specified, this is ignored (uses the referenced cluster's secret)
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          default: ''
-                          description: |-
-                            Name of the referent.
-                            This field is effectively required, but due to backwards compatibility is
-                            allowed to be empty. Instances of this type with an empty value here are
-                            almost certainly wrong.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or its key must
-                            be defined
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                      x-kubernetes-map-type: atomic
-                  type: object
-                containerSecurityContext:
-                  description: ContainerSecurityContext for Garage containers
-                  properties:
-                    allowPrivilegeEscalation:
-                      description: |-
-                        AllowPrivilegeEscalation controls whether a process can gain more
-                        privileges than its parent process. This bool directly controls if
-                        the no_new_privs flag will be set on the container process.
-                        AllowPrivilegeEscalation is true always when the container is:
-                        1) run as Privileged
-                        2) has CAP_SYS_ADMIN
-                        Note that this field cannot be set when spec.os.name is windows.
-                      type: boolean
-                    appArmorProfile:
-                      description: |-
-                        appArmorProfile is the AppArmor options to use by this container. If set, this profile
-                        overrides the pod's appArmorProfile.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      properties:
-                        localhostProfile:
-                          description: |-
-                            localhostProfile indicates a profile loaded on the node that should be used.
-                            The profile must be preconfigured on the node to work.
-                            Must match the loaded name of the profile.
-                            Must be set if and only if type is "Localhost".
-                          type: string
-                        type:
-                          description: |-
-                            type indicates which kind of AppArmor profile will be applied.
-                            Valid options are:
-                              Localhost - a profile pre-loaded on the node.
-                              RuntimeDefault - the container runtime's default profile.
-                              Unconfined - no AppArmor enforcement.
-                          type: string
-                      required:
-                        - type
-                      type: object
-                    capabilities:
-                      description: |-
-                        The capabilities to add/drop when running containers.
-                        Defaults to the default set of capabilities granted by the container runtime.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      properties:
-                        add:
-                          description: Added capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        drop:
-                          description: Removed capabilities
-                          items:
-                            description: Capability represent POSIX capabilities type
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      type: object
-                    privileged:
-                      description: |-
-                        Run container in privileged mode.
-                        Processes in privileged containers are essentially equivalent to root on the host.
-                        Defaults to false.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      type: boolean
-                    procMount:
-                      description: |-
-                        procMount denotes the type of proc mount to use for the containers.
-                        The default value is Default which uses the container runtime defaults for
-                        readonly paths and masked paths.
-                        This requires the ProcMountType feature flag to be enabled.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      type: string
-                    readOnlyRootFilesystem:
-                      description: |-
-                        Whether this container has a read-only root filesystem.
-                        Default is false.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      type: boolean
-                    runAsGroup:
-                      description: |-
-                        The GID to run the entrypoint of the container process.
-                        Uses runtime default if unset.
-                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: |-
-                        Indicates that the container must run as a non-root user.
-                        If true, the Kubelet will validate the image at runtime to ensure that it
-                        does not run as UID 0 (root) and fail to start the container if it does.
-                        If unset or false, no such validation will be performed.
-                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: |-
-                        The UID to run the entrypoint of the container process.
-                        Defaults to user specified in image metadata if unspecified.
-                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: |-
-                        The SELinux context to be applied to the container.
-                        If unspecified, the container runtime will allocate a random SELinux context for each
-                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    seccompProfile:
-                      description: |-
-                        The seccomp options to use by this container. If seccomp options are
-                        provided at both the pod & container level, the container options
-                        override the pod options.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      properties:
-                        localhostProfile:
-                          description: |-
-                            localhostProfile indicates a profile defined in a file on the node should be used.
-                            The profile must be preconfigured on the node to work.
-                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                            Must be set if type is "Localhost". Must NOT be set for any other type.
-                          type: string
-                        type:
-                          description: |-
-                            type indicates which kind of seccomp profile will be applied.
-                            Valid options are:
-
-                            Localhost - a profile defined in a file on the node should be used.
-                            RuntimeDefault - the container runtime default profile should be used.
-                            Unconfined - no profile should be applied.
-                          type: string
-                      required:
-                        - type
-                      type: object
-                    windowsOptions:
-                      description: |-
-                        The Windows specific settings applied to all containers.
-                        If unspecified, the options from the PodSecurityContext will be used.
-                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                        Note that this field cannot be set when spec.os.name is linux.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: |-
-                            GMSACredentialSpec is where the GMSA admission webhook
-                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                            GMSA credential spec named by the GMSACredentialSpecName field.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use.
-                          type: string
-                        hostProcess:
-                          description: |-
-                            HostProcess determines if a container should be run as a 'Host Process' container.
-                            All of a Pod's containers must have the same effective HostProcess value
-                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                            In addition, if HostProcess is true then HostNetwork must also be set to true.
-                          type: boolean
-                        runAsUserName:
-                          description: |-
-                            The UserName in Windows to run the entrypoint of the container process.
-                            Defaults to the user specified in image metadata if unspecified.
-                            May also be set in PodSecurityContext. If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext takes precedence.
-                          type: string
-                      type: object
-                  type: object
-                database:
-                  description: Database configures the metadata database engine
-                  properties:
-                    engine:
-                      default: lmdb
-                      description: Engine specifies the database engine to use
-                      enum:
-                        - lmdb
-                        - sqlite
-                        - fjall
-                      type: string
-                    fjallBlockCacheSize:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: FjallBlockCacheSize is the block cache size for
-                        Fjall
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    lmdbMapSize:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: LMDBMapSize is the virtual memory region size for
-                        LMDB
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                  type: object
-                defaultNodeTags:
-                  description: |-
-                    DefaultNodeTags are tags applied to all auto-managed nodes.
-                    Only used when LayoutPolicy is "Auto".
-                    For per-node tags, use LayoutPolicy "Manual" with GarageNode resources.
-                  items:
-                    type: string
-                  type: array
-                discovery:
-                  description: Discovery configures peer discovery mechanisms
-                  properties:
-                    consul:
-                      description: Consul configures Consul-based peer discovery
-                      properties:
-                        api:
-                          default: catalog
-                          description: API specifies the service registration API
-                            ("catalog" or "agent")
-                          enum:
-                            - catalog
-                            - agent
-                          type: string
-                        caCert:
-                          description: CACert is the CA certificate for TLS connection
-                          type: string
-                        caCertSecretRef:
-                          description: CACertSecretRef references a secret containing
-                            the CA certificate
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              default: ''
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        clientCertSecretRef:
-                          description: ClientCertSecretRef references a secret containing
-                            client TLS cert
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              default: ''
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        clientKeySecretRef:
-                          description: ClientKeySecretRef references a secret containing
-                            client TLS key
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              default: ''
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        datacenters:
-                          description: Datacenters for WAN federation
-                          items:
-                            type: string
-                          type: array
-                        enabled:
-                          description: Enabled enables Consul-based discovery
-                          type: boolean
-                        httpAddr:
-                          description: HTTPAddr is the full HTTP(S) address of Consul
-                            server
-                          type: string
-                        meta:
-                          additionalProperties:
-                            type: string
-                          description: Meta is service metadata key-value pairs
-                          type: object
-                        serviceName:
-                          description: ServiceName for Garage RPC port registration
-                          type: string
-                        tags:
-                          description: Tags are additional service tags
-                          items:
-                            type: string
-                          type: array
-                        tlsSkipVerify:
-                          description: TLSSkipVerify skips TLS hostname verification
-                          type: boolean
-                        tokenSecretRef:
-                          description: TokenSecretRef references a secret containing
-                            the bearer token
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              default: ''
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      type: object
-                    kubernetes:
-                      description: Kubernetes configures Kubernetes-based peer discovery
-                      properties:
-                        enabled:
-                          description: Enabled enables Kubernetes-based discovery
-                          type: boolean
-                        namespace:
-                          description: Namespace for Garage custom resources
-                          type: string
-                        serviceName:
-                          description: ServiceName label to filter custom resources
-                          type: string
-                        skipCRD:
-                          description: SkipCRD skips automatic CRD creation/patching
-                          type: boolean
-                      type: object
-                  type: object
-                gateway:
-                  description: |-
-                    Gateway marks this cluster as a gateway-only cluster.
-                    Gateway clusters don't store data - they only handle API requests.
-                    When true:
-                    - Creates a StatefulSet with metadata PVC only (for node identity persistence)
-                    - Data storage uses EmptyDir (gateways don't store blocks)
-                    - Pods are registered as gateway nodes in the layout (capacity=null)
-                    - Must specify connectTo to reference a storage cluster
-                  type: boolean
-                image:
-                  default: dxflrs/garage:v2.3.0
-                  description: |-
-                    Image specifies the Garage container image to use.
-                    Takes precedence over imageRepository if both are set.
-                  type: string
-                imagePullPolicy:
-                  default: IfNotPresent
-                  description: ImagePullPolicy specifies the image pull policy
-                  type: string
-                imagePullSecrets:
-                  description: ImagePullSecrets specifies secrets for pulling images
-                    from private registries
-                  items:
-                    description: |-
-                      LocalObjectReference contains enough information to let you locate the
-                      referenced object inside the same namespace.
-                    properties:
-                      name:
-                        default: ''
-                        description: |-
-                          Name of the referent.
-                          This field is effectively required, but due to backwards compatibility is
-                          allowed to be empty. Instances of this type with an empty value here are
-                          almost certainly wrong.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        type: string
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  type: array
-                imageRepository:
-                  description: |-
-                    ImageRepository overrides just the repository portion of the default Garage image,
-                    preserving the default tag for automatic version upgrades.
-                    For example, setting this to "my-mirror/garage" with the default tag v2.3.0
-                    produces "my-mirror/garage:v2.3.0".
-                    Ignored if image is set.
-                  type: string
-                k2vApi:
-                  description: |-
-                    K2VAPI configures the K2V (key-value) API endpoint.
-                    Omit to disable K2V.
-                  properties:
-                    bindAddress:
-                      description: |-
-                        BindAddress is a custom bind address for the K2V API.
-                        Can be a TCP address or Unix socket path (e.g., "unix:///run/garage/k2v.sock").
-                        If set, this overrides BindPort.
-                      type: string
-                    bindPort:
-                      default: 3904
-                      description: BindPort is the port to bind for K2V API
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
-                  type: object
-                layoutManagement:
-                  description: LayoutManagement controls how the cluster layout is
-                    managed
-                  properties:
-                    autoApply:
-                      description: AutoApply automatically applies staged layout changes
-                      type: boolean
-                    minNodesHealthy:
-                      description: MinNodesHealthy is the minimum healthy nodes required
-                        before applying layout changes
-                      type: integer
-                  type: object
-                layoutPolicy:
-                  default: Auto
-                  description: |-
-                    LayoutPolicy controls whether node layouts are automatically managed or manually configured.
-                    - "Auto": The controller automatically assigns all local pods to the layout using the
-                      cluster's zone and derives capacity from data PVC size. No GarageNode resources needed.
-                    - "Manual": You must create GarageNode resources for each node you want in the layout.
-                      Use this for fine-grained control over zones, capacities, or external nodes.
-                  enum:
-                    - Auto
-                    - Manual
-                  type: string
-                logging:
-                  description: Logging configures logging behavior for Garage nodes
-                  properties:
-                    journald:
-                      description: Journald enables logging to systemd journald (requires
-                        Garage built with journald feature)
-                      type: boolean
-                    level:
-                      description: |-
-                        Level sets the log level using RUST_LOG format.
-
-                        Examples:
-                        - "info": Default info level for all components
-                        - "debug": Debug level for all components
-                        - "garage=debug": Debug only for garage module
-                        - "garage=debug,netapp=info": Fine-grained per-component levels
-                        - "garage=trace,netapp=debug,rusoto=warn": Multiple components
-
-                        See https://docs.rs/env_logger for full syntax.
-                      type: string
-                    syslog:
-                      description: Syslog enables logging to syslog (requires Garage
-                        built with syslog feature)
-                      type: boolean
-                  type: object
-                monitoring:
-                  description: Monitoring configures Prometheus integration for this
-                    cluster.
-                  properties:
-                    additionalLabels:
-                      additionalProperties:
-                        type: string
-                      description: AdditionalLabels are added to the ServiceMonitor
-                        metadata.
-                      type: object
-                    enabled:
-                      description: |-
-                        Enabled creates a ServiceMonitor targeting the admin API /metrics endpoint.
-                        Requires prometheus-operator to be installed in the cluster.
-                      type: boolean
-                    interval:
-                      description: |-
-                        Interval is the Prometheus scrape interval (e.g. "30s", "1m").
-                        Defaults to the Prometheus global scrape interval when unset.
-                      type: string
-                  type: object
-                network:
-                  description: Network configures RPC and API networking
-                  properties:
-                    bootstrapPeers:
-                      description: |-
-                        BootstrapPeers lists initial peers for cluster formation.
-
-                        Format: "<node_public_key>@<ip_or_hostname>:<port>"
-
-                        Example:
-                        - "563e1ac825ee3323aa441e72c26d1030d6d4414aeb3dd25287c531e7fc2bc95d@10.0.0.1:3901"
-                        - "ec79480e0ce52ae26fd00c9da684e4fa56f77571b9b8560382f859930e63571d@garage-2.example.com:3901"
-                      items:
-                        type: string
-                      type: array
-                    rpcBindAddress:
-                      description: |-
-                        RPCBindAddress is a custom bind address for the RPC server.
-                        Can be a TCP address (e.g., "0.0.0.0:3901", "[::]:3901").
-                        If set, this overrides RPCBindPort.
-                      type: string
-                    rpcBindOutgoing:
-                      description: RPCBindOutgoing pre-binds outgoing sockets to same
-                        IP
-                      type: boolean
-                    rpcBindPort:
-                      default: 3901
-                      description: RPCBindPort is the port for inter-cluster RPC
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
-                    rpcPingTimeoutMs:
-                      description: RPCPingTimeoutMs sets the RPC ping timeout in milliseconds
-                      format: int64
-                      type: integer
-                    rpcPublicAddr:
-                      description: RPCPublicAddr is the external address for other
-                        nodes to contact this node
-                      type: string
-                    rpcPublicAddrSubnet:
-                      description: RPCPublicAddrSubnet filters autodiscovered IPs
-                        to specific subnet
-                      type: string
-                    rpcSecretRef:
-                      description: |-
-                        RPCSecret is a reference to a secret containing the RPC secret
-                        The secret must have a key 'rpc-secret' with a 32-byte hex-encoded value
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          default: ''
-                          description: |-
-                            Name of the referent.
-                            This field is effectively required, but due to backwards compatibility is
-                            allowed to be empty. Instances of this type with an empty value here are
-                            almost certainly wrong.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or its key must
-                            be defined
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    rpcTimeoutMs:
-                      description: RPCTimeoutMs sets the RPC call timeout in milliseconds
-                      format: int64
-                      type: integer
-                    service:
-                      description: Service configures the Kubernetes Service for the
-                        cluster
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations for the service
-                          type: object
-                        externalTrafficPolicy:
-                          description: ExternalTrafficPolicy for LoadBalancer/NodePort
-                          type: string
-                        loadBalancerIP:
-                          description: LoadBalancerIP for LoadBalancer type
-                          type: string
-                        loadBalancerSourceRanges:
-                          description: LoadBalancerSourceRanges for LoadBalancer type
-                          items:
-                            type: string
-                          type: array
-                        type:
-                          default: ClusterIP
-                          description: Type of service
-                          enum:
-                            - ClusterIP
-                            - NodePort
-                            - LoadBalancer
-                          type: string
-                      type: object
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: NodeSelector for pod scheduling
-                  type: object
-                podAnnotations:
-                  additionalProperties:
-                    type: string
-                  description: PodAnnotations to add to Garage pods
-                  type: object
-                podDisruptionBudget:
-                  description: PodDisruptionBudget configures the PodDisruptionBudget
-                    for the cluster
-                  properties:
-                    enabled:
-                      default: true
-                      description: Enabled enables PodDisruptionBudget creation
-                      type: boolean
-                    maxUnavailable:
-                      description: |-
-                        MaxUnavailable specifies the maximum number of pods that can be unavailable
-                        Can be an absolute number (e.g., 1) or a percentage (e.g., "25%")
-                        Mutually exclusive with MinAvailable
-                      type: string
-                    minAvailable:
-                      description: |-
-                        MinAvailable specifies the minimum number of pods that must be available
-                        Can be an absolute number (e.g., 2) or a percentage (e.g., "50%")
-                        Mutually exclusive with MaxUnavailable
-                      type: string
-                  type: object
-                podLabels:
-                  additionalProperties:
-                    type: string
-                  description: PodLabels to add to Garage pods
-                  type: object
-                priorityClassName:
-                  description: PriorityClassName for Garage pods
-                  type: string
-                publicEndpoint:
-                  description: |-
-                    PublicEndpoint configures how remote clusters reach this cluster's nodes
-                    Required for multi-cluster federation
-                  properties:
-                    externalIP:
-                      description: ExternalIP configuration
-                      properties:
-                        addressTemplate:
-                          description: |-
-                            AddressTemplate uses go template to generate addresses from pod info
-                            Example: "garage-{{.Index}}.example.com"
-                          type: string
-                        addresses:
-                          additionalProperties:
-                            type: string
-                          description: Addresses maps pod names to external IPs
-                          type: object
-                      type: object
-                    loadBalancer:
-                      description: LoadBalancer configuration
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations for the LoadBalancer service
-                          type: object
-                        perNode:
-                          description: PerNode creates a separate LoadBalancer per
-                            node (more expensive but ensures direct routing)
-                          type: boolean
-                      type: object
-                    nodePort:
-                      description: NodePort configuration
-                      properties:
-                        basePort:
-                          description: BasePort is the starting NodePort (each node
-                            gets BasePort + index)
-                          format: int32
-                          maximum: 32767
-                          minimum: 30000
-                          type: integer
-                        externalAddresses:
-                          description: ExternalAddresses are the external IPs/hostnames
-                            of the Kubernetes nodes
-                          items:
-                            type: string
-                          type: array
-                      required:
-                        - externalAddresses
-                      type: object
-                    type:
-                      description: Type specifies how nodes are exposed
-                      enum:
-                        - LoadBalancer
-                        - NodePort
-                        - ExternalIP
-                        - Headless
-                      type: string
-                  required:
-                    - type
-                  type: object
-                remoteClusters:
-                  description: |-
-                    RemoteClusters are Garage clusters in other Kubernetes clusters
-                    The operator will auto-discover nodes and coordinate layout
-                  items:
-                    description: RemoteClusterConfig defines a Garage cluster in another
-                      Kubernetes cluster
-                    properties:
-                      connection:
-                        description: Connection defines how to connect to this remote
-                          cluster
-                        properties:
-                          adminApiEndpoint:
-                            description: |-
-                              AdminAPIEndpoint is the admin API endpoint of the remote cluster
-                              This should be a reachable HTTP/HTTPS URL (e.g., via Tailscale, LoadBalancer, or port-forward)
-                              Example: "http://garage-remote.tailscale:3903"
-                            type: string
-                          adminTokenSecretRef:
-                            description: |-
-                              AdminTokenSecretRef references the admin token for the remote cluster's API
-                              If not specified, uses the local cluster's admin token (for shared-token setups)
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
-                                type: string
-                              name:
-                                default: ''
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                        required:
-                          - adminApiEndpoint
-                        type: object
-                      defaultCapacity:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: |-
-                          DefaultCapacity is the default storage capacity to assign to remote nodes
-                          that don't yet have a role in the layout. If not specified, defaults to 100Gi.
-                          Set to "0" to add nodes as gateway-only (no storage).
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      name:
-                        description: Name is a friendly name for this remote cluster
-                        type: string
-                      zone:
-                        description: Zone is the zone name for nodes in this remote
-                          cluster
-                        type: string
-                    required:
-                      - connection
-                      - name
-                      - zone
-                    type: object
-                  type: array
-                replicas:
-                  default: 3
-                  description: Replicas is the number of Garage nodes to deploy in
-                    this cluster
-                  format: int32
-                  minimum: 1
-                  type: integer
-                replication:
-                  description: Replication configures data replication settings
-                  properties:
-                    consistencyMode:
-                      default: consistent
-                      description: |-
-                        ConsistencyMode controls quorum behavior for read/write operations.
-
-                        Values:
-                        - "consistent" (default): Require quorum for both reads and writes.
-                          Safest option, ensures strong consistency.
-                        - "degraded": Allow reads from single node when quorum unavailable.
-                          May return stale data during network partitions.
-                        - "dangerous": Allow reads AND writes without quorum.
-                          WARNING: May lose data during failures!
-                      enum:
-                        - consistent
-                        - degraded
-                        - dangerous
-                      type: string
-                    factor:
-                      default: 3
-                      description: |-
-                        Factor is the replication factor (1, 2, 3, 5, 7, etc.)
-                        Must be the same on all nodes in the cluster
-                      maximum: 7
-                      minimum: 1
-                      type: integer
-                    zoneRedundancy:
-                      description: |-
-                        ZoneRedundancy controls how data is distributed across zones.
-
-                        Values:
-                        - "Maximum": Maximize redundancy by placing replicas in as many zones as possible
-                        - "AtLeast(n)": Require replicas to be in at least n different zones
-
-                        The value n must not exceed the replication factor.
-
-                        Examples:
-                        - "Maximum" (default): Best effort zone distribution
-                        - "AtLeast(1)": No zone constraint (all replicas can be in one zone)
-                        - "AtLeast(2)": Survives 1 zone failure (requires 2+ zones)
-                        - "AtLeast(3)": Survives 2 zone failures (requires 3+ zones)
-                      pattern: ^(Maximum|AtLeast\([1-7]\))$
-                      type: string
-                  required:
-                    - factor
-                  type: object
-                resources:
-                  description: Resources specifies compute resources for Garage pods
-                  properties:
-                    claims:
-                      description: |-
-                        Claims lists the names of resources, defined in spec.resourceClaims,
-                        that are used by this container.
-
-                        This field depends on the
-                        DynamicResourceAllocation feature gate.
-
-                        This field is immutable. It can only be set for containers.
-                      items:
-                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                        properties:
-                          name:
-                            description: |-
-                              Name must match the name of one entry in pod.spec.resourceClaims of
-                              the Pod where this field is used. It makes that resource available
-                              inside a container.
-                            type: string
-                          request:
-                            description: |-
-                              Request is the name chosen for a request in the referenced claim.
-                              If empty, everything from the claim is made available, otherwise
-                              only the result of this request.
-                            type: string
-                        required:
-                          - name
-                        type: object
-                      type: array
-                      x-kubernetes-list-map-keys:
-                        - name
-                      x-kubernetes-list-type: map
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: |-
-                        Limits describes the maximum amount of compute resources allowed.
-                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: |-
-                        Requests describes the minimum amount of compute resources required.
-                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                      type: object
-                  type: object
-                s3Api:
-                  description: S3API configures the S3-compatible API endpoint
-                  properties:
-                    bindAddress:
-                      description: |-
-                        BindAddress is a custom bind address for the S3 API.
-                        Can be a TCP address (e.g., "0.0.0.0:3900", "[::]:3900") or
-                        a Unix socket path (e.g., "unix:///run/garage/s3.sock").
-                        If set, this overrides BindPort.
-                      type: string
-                    bindPort:
-                      default: 3900
-                      description: BindPort is the port to bind for S3 API
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
-                    region:
-                      default: garage
-                      description: Region is the AWS S3 region name to use
-                      type: string
-                    rootDomain:
-                      description: |-
-                        RootDomain is the root domain suffix for vhost-style S3 access.
-                        When set, buckets can be accessed via <bucket-name>.<root-domain>.
-
-                        Examples:
-                        - ".s3.garage.tld" -> Access bucket "mybucket" at "mybucket.s3.garage.tld"
-                        - ".s3.example.com" -> Access bucket "data" at "data.s3.example.com"
-
-                        Note: Include the leading dot.
-                      type: string
-                  required:
-                    - region
-                  type: object
-                security:
-                  description: Security configures security-related settings
-                  properties:
-                    allowPunycode:
-                      description: AllowPunycode allows punycode in bucket names
-                      type: boolean
-                    allowWorldReadableSecrets:
-                      description: AllowWorldReadableSecrets bypasses permission check
-                        for secret files
-                      type: boolean
-                    tls:
-                      description: TLS configures TLS settings
-                      properties:
-                        caSecretRef:
-                          description: CASecretRef references a secret containing
-                            the CA certificate for verifying peer nodes
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              default: ''
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        certSecretRef:
-                          description: CertSecretRef references a secret containing
-                            the TLS certificate for RPC
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              default: ''
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        enabled:
-                          description: |-
-                            Enabled enables TLS for inter-node RPC communication.
-                            NOTE: This does NOT enable TLS for S3/Admin APIs - use a service mesh or load balancer for that.
-                          type: boolean
-                        keySecretRef:
-                          description: KeySecretRef references a secret containing
-                            the TLS private key for RPC
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              default: ''
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      type: object
-                  type: object
-                securityContext:
-                  description: SecurityContext for Garage pods
-                  properties:
-                    appArmorProfile:
-                      description: |-
-                        appArmorProfile is the AppArmor options to use by the containers in this pod.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      properties:
-                        localhostProfile:
-                          description: |-
-                            localhostProfile indicates a profile loaded on the node that should be used.
-                            The profile must be preconfigured on the node to work.
-                            Must match the loaded name of the profile.
-                            Must be set if and only if type is "Localhost".
-                          type: string
-                        type:
-                          description: |-
-                            type indicates which kind of AppArmor profile will be applied.
-                            Valid options are:
-                              Localhost - a profile pre-loaded on the node.
-                              RuntimeDefault - the container runtime's default profile.
-                              Unconfined - no AppArmor enforcement.
-                          type: string
-                      required:
-                        - type
-                      type: object
-                    fsGroup:
-                      description: |-
-                        A special supplemental group that applies to all containers in a pod.
-                        Some volume types allow the Kubelet to change the ownership of that volume
-                        to be owned by the pod:
-
-                        1. The owning GID will be the FSGroup
-                        2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
-                        3. The permission bits are OR'd with rw-rw----
-
-                        If unset, the Kubelet will not modify the ownership and permissions of any volume.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      format: int64
-                      type: integer
-                    fsGroupChangePolicy:
-                      description: |-
-                        fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
-                        before being exposed inside Pod. This field will only apply to
-                        volume types which support fsGroup based ownership(and permissions).
-                        It will have no effect on ephemeral volume types such as: secret, configmaps
-                        and emptydir.
-                        Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      type: string
-                    runAsGroup:
-                      description: |-
-                        The GID to run the entrypoint of the container process.
-                        Uses runtime default if unset.
-                        May also be set in SecurityContext.  If set in both SecurityContext and
-                        PodSecurityContext, the value specified in SecurityContext takes precedence
-                        for that container.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: |-
-                        Indicates that the container must run as a non-root user.
-                        If true, the Kubelet will validate the image at runtime to ensure that it
-                        does not run as UID 0 (root) and fail to start the container if it does.
-                        If unset or false, no such validation will be performed.
-                        May also be set in SecurityContext.  If set in both SecurityContext and
-                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: |-
-                        The UID to run the entrypoint of the container process.
-                        Defaults to user specified in image metadata if unspecified.
-                        May also be set in SecurityContext.  If set in both SecurityContext and
-                        PodSecurityContext, the value specified in SecurityContext takes precedence
-                        for that container.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      format: int64
-                      type: integer
-                    seLinuxChangePolicy:
-                      description: |-
-                        seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
-                        It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
-                        Valid values are "MountOption" and "Recursive".
-
-                        "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
-                        This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
-
-                        "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
-                        This requires all Pods that share the same volume to use the same SELinux label.
-                        It is not possible to share the same volume among privileged and unprivileged Pods.
-                        Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
-                        whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
-                        CSIDriver instance. Other volumes are always re-labelled recursively.
-                        "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
-
-                        If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
-                        If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
-                        and "Recursive" for all other volumes.
-
-                        This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
-
-                        All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      type: string
-                    seLinuxOptions:
-                      description: |-
-                        The SELinux context to be applied to all containers.
-                        If unspecified, the container runtime will allocate a random SELinux context for each
-                        container.  May also be set in SecurityContext.  If set in
-                        both SecurityContext and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence for that container.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    seccompProfile:
-                      description: |-
-                        The seccomp options to use by the containers in this pod.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      properties:
-                        localhostProfile:
-                          description: |-
-                            localhostProfile indicates a profile defined in a file on the node should be used.
-                            The profile must be preconfigured on the node to work.
-                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                            Must be set if type is "Localhost". Must NOT be set for any other type.
-                          type: string
-                        type:
-                          description: |-
-                            type indicates which kind of seccomp profile will be applied.
-                            Valid options are:
-
-                            Localhost - a profile defined in a file on the node should be used.
-                            RuntimeDefault - the container runtime default profile should be used.
-                            Unconfined - no profile should be applied.
-                          type: string
-                      required:
-                        - type
-                      type: object
-                    supplementalGroups:
-                      description: |-
-                        A list of groups applied to the first process run in each container, in
-                        addition to the container's primary GID and fsGroup (if specified).  If
-                        the SupplementalGroupsPolicy feature is enabled, the
-                        supplementalGroupsPolicy field determines whether these are in addition
-                        to or instead of any group memberships defined in the container image.
-                        If unspecified, no additional groups are added, though group memberships
-                        defined in the container image may still be used, depending on the
-                        supplementalGroupsPolicy field.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      items:
-                        format: int64
-                        type: integer
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    supplementalGroupsPolicy:
-                      description: |-
-                        Defines how supplemental groups of the first container processes are calculated.
-                        Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
-                        (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
-                        and the container runtime must implement support for this feature.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      type: string
-                    sysctls:
-                      description: |-
-                        Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
-                        sysctls (by the container runtime) might fail to launch.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      items:
-                        description: Sysctl defines a kernel parameter to be set
-                        properties:
-                          name:
-                            description: Name of a property to set
-                            type: string
-                          value:
-                            description: Value of a property to set
-                            type: string
-                        required:
-                          - name
-                          - value
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    windowsOptions:
-                      description: |-
-                        The Windows specific settings applied to all containers.
-                        If unspecified, the options within a container's SecurityContext will be used.
-                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                        Note that this field cannot be set when spec.os.name is linux.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: |-
-                            GMSACredentialSpec is where the GMSA admission webhook
-                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                            GMSA credential spec named by the GMSACredentialSpecName field.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use.
-                          type: string
-                        hostProcess:
-                          description: |-
-                            HostProcess determines if a container should be run as a 'Host Process' container.
-                            All of a Pod's containers must have the same effective HostProcess value
-                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                            In addition, if HostProcess is true then HostNetwork must also be set to true.
-                          type: boolean
-                        runAsUserName:
-                          description: |-
-                            The UserName in Windows to run the entrypoint of the container process.
-                            Defaults to the user specified in image metadata if unspecified.
-                            May also be set in PodSecurityContext. If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext takes precedence.
-                          type: string
-                      type: object
-                  type: object
-                serviceAccountName:
-                  description: ServiceAccountName for Garage pods
-                  type: string
-                serviceAnnotations:
-                  additionalProperties:
-                    type: string
-                  description: ServiceAnnotations to add to Garage services
-                  type: object
-                storage:
-                  description: |-
-                    Storage configures storage settings for metadata and data.
-                    Optional - sensible defaults are provided:
-                    - Storage clusters: 10Gi metadata, 100Gi data
-                    - Gateway clusters: 1Gi metadata only (data uses EmptyDir)
-                  properties:
-                    data:
-                      description: Data configures data block storage
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations to set on the data PVC. Only valid
-                            when Type=PersistentVolumeClaim.
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: Labels to set on the data PVC. Only valid when
-                            Type=PersistentVolumeClaim.
-                          type: object
-                        paths:
-                          description: |-
-                            Paths specifies multiple data directories with capacities
-                            For advanced multi-disk configurations. Only valid when Type=PersistentVolumeClaim.
-                          items:
-                            description: DataPath specifies a data directory with
-                              capacity
-                            properties:
-                              capacity:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Capacity of the drive (required unless
-                                  readOnly)
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              path:
-                                description: Path to the data directory
-                                type: string
-                              readOnly:
-                                description: ReadOnly marks directory as legacy read-only
-                                  for migrations
-                                type: boolean
-                              volume:
-                                description: Volume configuration if using PVC
-                                properties:
-                                  accessModes:
-                                    description: AccessModes for the PVC. Only valid
-                                      when Type=PersistentVolumeClaim.
-                                    items:
-                                      type: string
-                                    type: array
-                                  annotations:
-                                    additionalProperties:
-                                      type: string
-                                    description: Annotations to set on the PVC. Only
-                                      valid when Type=PersistentVolumeClaim.
-                                    type: object
-                                  labels:
-                                    additionalProperties:
-                                      type: string
-                                    description: Labels to set on the PVC. Only valid
-                                      when Type=PersistentVolumeClaim.
-                                    type: object
-                                  selector:
-                                    description: Selector to select PVs. Only valid
-                                      when Type=PersistentVolumeClaim.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  size:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: |-
-                                      Size of the volume.
-                                      - For PVC: storage request (defaults to 10Gi for metadata if not specified)
-                                      - For EmptyDir: optional sizeLimit (if omitted, uses available node resources)
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  storageClassName:
-                                    description: StorageClassName for the PVC. Only
-                                      valid when Type=PersistentVolumeClaim.
-                                    type: string
-                                  type:
-                                    default: PersistentVolumeClaim
-                                    description: |-
-                                      Type specifies the volume type: PersistentVolumeClaim (default) or EmptyDir.
-                                      When EmptyDir, data is lost on pod restart - only use for testing.
-                                    enum:
-                                      - PersistentVolumeClaim
-                                      - EmptyDir
-                                    type: string
-                                  volumeClaimTemplateSpec:
-                                    description: |-
-                                      VolumeClaimTemplateSpec allows full customization of the PVC.
-                                      Only valid when Type=PersistentVolumeClaim.
-                                    properties:
-                                      accessModes:
-                                        description: |-
-                                          accessModes contains the desired access modes the volume should have.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      dataSource:
-                                        description: |-
-                                          dataSource field can be used to specify either:
-                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                          * An existing PVC (PersistentVolumeClaim)
-                                          If the provisioner or an external controller can support the specified data source,
-                                          it will create a new volume based on the contents of the specified data source.
-                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
-                                        properties:
-                                          apiGroup:
-                                            description: |-
-                                              APIGroup is the group for the resource being referenced.
-                                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                                              For any other third-party types, APIGroup is required.
-                                            type: string
-                                          kind:
-                                            description: Kind is the type of resource
-                                              being referenced
-                                            type: string
-                                          name:
-                                            description: Name is the name of resource
-                                              being referenced
-                                            type: string
-                                        required:
-                                          - kind
-                                          - name
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      dataSourceRef:
-                                        description: |-
-                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                          volume is desired. This may be any object from a non-empty API group (non
-                                          core object) or a PersistentVolumeClaim object.
-                                          When this field is specified, volume binding will only succeed if the type of
-                                          the specified object matches some installed volume populator or dynamic
-                                          provisioner.
-                                          This field will replace the functionality of the dataSource field and as such
-                                          if both fields are non-empty, they must have the same value. For backwards
-                                          compatibility, when namespace isn't specified in dataSourceRef,
-                                          both fields (dataSource and dataSourceRef) will be set to the same
-                                          value automatically if one of them is empty and the other is non-empty.
-                                          When namespace is specified in dataSourceRef,
-                                          dataSource isn't set to the same value and must be empty.
-                                          There are three important differences between dataSource and dataSourceRef:
-                                          * While dataSource only allows two specific types of objects, dataSourceRef
-                                            allows any non-core object, as well as PersistentVolumeClaim objects.
-                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                            preserves all values, and generates an error if a disallowed value is
-                                            specified.
-                                          * While dataSource only allows local objects, dataSourceRef allows objects
-                                            in any namespaces.
-                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
-                                        properties:
-                                          apiGroup:
-                                            description: |-
-                                              APIGroup is the group for the resource being referenced.
-                                              If APIGroup is not specified, the specified Kind must be in the core API group.
-                                              For any other third-party types, APIGroup is required.
-                                            type: string
-                                          kind:
-                                            description: Kind is the type of resource
-                                              being referenced
-                                            type: string
-                                          name:
-                                            description: Name is the name of resource
-                                              being referenced
-                                            type: string
-                                          namespace:
-                                            description: |-
-                                              Namespace is the namespace of resource being referenced
-                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
-                                            type: string
-                                        required:
-                                          - kind
-                                          - name
-                                        type: object
-                                      resources:
-                                        description: |-
-                                          resources represents the minimum resources the volume should have.
-                                          Users are allowed to specify resource requirements
-                                          that are lower than previous value but must still be higher than capacity recorded in the
-                                          status field of the claim.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
-                                        properties:
-                                          limits:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Limits describes the maximum amount of compute resources allowed.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                            type: object
-                                          requests:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Requests describes the minimum amount of compute resources required.
-                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                            type: object
-                                        type: object
-                                      selector:
-                                        description: selector is a label query over
-                                          volumes to consider for binding.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      storageClassName:
-                                        description: |-
-                                          storageClassName is the name of the StorageClass required by the claim.
-                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
-                                        type: string
-                                      volumeAttributesClassName:
-                                        description: |-
-                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                          If specified, the CSI driver will create or update the volume with the attributes defined
-                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                          it can be changed after the claim is created. An empty string or nil value indicates that no
-                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                          this field can be reset to its previous value (including nil) to cancel the modification.
-                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                          exists.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        type: string
-                                      volumeMode:
-                                        description: |-
-                                          volumeMode defines what type of volume is required by the claim.
-                                          Value of Filesystem is implied when not included in claim spec.
-                                        type: string
-                                      volumeName:
-                                        description: volumeName is the binding reference
-                                          to the PersistentVolume backing this claim.
-                                        type: string
-                                    type: object
-                                type: object
-                            required:
-                              - path
-                            type: object
-                          type: array
-                        size:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          description: 'Size of the data volume. For PVC: storage
-                            request. For EmptyDir: sizeLimit (optional).'
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        storageClassName:
-                          description: StorageClassName for the data PVC. Only valid
-                            when Type=PersistentVolumeClaim.
-                          type: string
-                        type:
-                          default: PersistentVolumeClaim
-                          description: |-
-                            Type specifies the volume type: PersistentVolumeClaim (default) or EmptyDir.
-                            When EmptyDir, data is lost on pod restart - only use for testing.
-                          enum:
-                            - PersistentVolumeClaim
-                            - EmptyDir
-                          type: string
-                      type: object
-                    dataFsync:
-                      description: DataFsync enables fsync for data block writes
-                      type: boolean
-                    metadata:
-                      description: Metadata configures metadata storage
-                      properties:
-                        accessModes:
-                          description: AccessModes for the PVC. Only valid when Type=PersistentVolumeClaim.
-                          items:
-                            type: string
-                          type: array
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations to set on the PVC. Only valid when
-                            Type=PersistentVolumeClaim.
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: Labels to set on the PVC. Only valid when Type=PersistentVolumeClaim.
-                          type: object
-                        selector:
-                          description: Selector to select PVs. Only valid when Type=PersistentVolumeClaim.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                required:
-                                  - key
-                                  - operator
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        size:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          description: |-
-                            Size of the volume.
-                            - For PVC: storage request (defaults to 10Gi for metadata if not specified)
-                            - For EmptyDir: optional sizeLimit (if omitted, uses available node resources)
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        storageClassName:
-                          description: StorageClassName for the PVC. Only valid when
-                            Type=PersistentVolumeClaim.
-                          type: string
-                        type:
-                          default: PersistentVolumeClaim
-                          description: |-
-                            Type specifies the volume type: PersistentVolumeClaim (default) or EmptyDir.
-                            When EmptyDir, data is lost on pod restart - only use for testing.
-                          enum:
-                            - PersistentVolumeClaim
-                            - EmptyDir
-                          type: string
-                        volumeClaimTemplateSpec:
-                          description: |-
-                            VolumeClaimTemplateSpec allows full customization of the PVC.
-                            Only valid when Type=PersistentVolumeClaim.
-                          properties:
-                            accessModes:
-                              description: |-
-                                accessModes contains the desired access modes the volume should have.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            dataSource:
-                              description: |-
-                                dataSource field can be used to specify either:
-                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                * An existing PVC (PersistentVolumeClaim)
-                                If the provisioner or an external controller can support the specified data source,
-                                it will create a new volume based on the contents of the specified data source.
-                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
-                              properties:
-                                apiGroup:
-                                  description: |-
-                                    APIGroup is the group for the resource being referenced.
-                                    If APIGroup is not specified, the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
-                                  type: string
-                                kind:
-                                  description: Kind is the type of resource being
-                                    referenced
-                                  type: string
-                                name:
-                                  description: Name is the name of resource being
-                                    referenced
-                                  type: string
-                              required:
-                                - kind
-                                - name
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            dataSourceRef:
-                              description: |-
-                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                volume is desired. This may be any object from a non-empty API group (non
-                                core object) or a PersistentVolumeClaim object.
-                                When this field is specified, volume binding will only succeed if the type of
-                                the specified object matches some installed volume populator or dynamic
-                                provisioner.
-                                This field will replace the functionality of the dataSource field and as such
-                                if both fields are non-empty, they must have the same value. For backwards
-                                compatibility, when namespace isn't specified in dataSourceRef,
-                                both fields (dataSource and dataSourceRef) will be set to the same
-                                value automatically if one of them is empty and the other is non-empty.
-                                When namespace is specified in dataSourceRef,
-                                dataSource isn't set to the same value and must be empty.
-                                There are three important differences between dataSource and dataSourceRef:
-                                * While dataSource only allows two specific types of objects, dataSourceRef
-                                  allows any non-core object, as well as PersistentVolumeClaim objects.
-                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                  preserves all values, and generates an error if a disallowed value is
-                                  specified.
-                                * While dataSource only allows local objects, dataSourceRef allows objects
-                                  in any namespaces.
-                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
-                              properties:
-                                apiGroup:
-                                  description: |-
-                                    APIGroup is the group for the resource being referenced.
-                                    If APIGroup is not specified, the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
-                                  type: string
-                                kind:
-                                  description: Kind is the type of resource being
-                                    referenced
-                                  type: string
-                                name:
-                                  description: Name is the name of resource being
-                                    referenced
-                                  type: string
-                                namespace:
-                                  description: |-
-                                    Namespace is the namespace of resource being referenced
-                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
-                                  type: string
-                              required:
-                                - kind
-                                - name
-                              type: object
-                            resources:
-                              description: |-
-                                resources represents the minimum resources the volume should have.
-                                Users are allowed to specify resource requirements
-                                that are lower than previous value but must still be higher than capacity recorded in the
-                                status field of the claim.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: |-
-                                    Limits describes the maximum amount of compute resources allowed.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: |-
-                                    Requests describes the minimum amount of compute resources required.
-                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                  type: object
-                              type: object
-                            selector:
-                              description: selector is a label query over volumes
-                                to consider for binding.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
-                                  items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the
-                                          selector applies to.
-                                        type: string
-                                      operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                      - key
-                                      - operator
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                  type: object
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            storageClassName:
-                              description: |-
-                                storageClassName is the name of the StorageClass required by the claim.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
-                              type: string
-                            volumeAttributesClassName:
-                              description: |-
-                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                If specified, the CSI driver will create or update the volume with the attributes defined
-                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                it can be changed after the claim is created. An empty string or nil value indicates that no
-                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                this field can be reset to its previous value (including nil) to cancel the modification.
-                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                exists.
-                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                              type: string
-                            volumeMode:
-                              description: |-
-                                volumeMode defines what type of volume is required by the claim.
-                                Value of Filesystem is implied when not included in claim spec.
-                              type: string
-                            volumeName:
-                              description: volumeName is the binding reference to
-                                the PersistentVolume backing this claim.
-                              type: string
-                          type: object
-                      type: object
-                    metadataAutoSnapshotInterval:
-                      description: |-
-                        MetadataAutoSnapshotInterval enables automatic metadata snapshots
-                        Format: "6h", "1d", etc.
-                      type: string
-                    metadataFsync:
-                      description: MetadataFsync enables fsync for metadata transactions
-                      type: boolean
-                    metadataSnapshotsDir:
-                      description: MetadataSnapshotsDir specifies directory for metadata
-                        snapshots
-                      type: string
-                    pvcRetentionPolicy:
-                      description: |-
-                        PVCRetentionPolicy controls whether PVCs are deleted when the StatefulSet is deleted or scaled down.
-                        Requires Kubernetes 1.23+. If not specified, defaults to Retain for both policies.
-                      properties:
-                        whenDeleted:
-                          default: Retain
-                          description: |-
-                            WhenDeleted specifies what happens to PVCs when the StatefulSet is deleted.
-                            - "Retain" (default): PVCs are kept for manual cleanup or data recovery
-                            - "Delete": PVCs are automatically deleted with the StatefulSet
-                          enum:
-                            - Retain
-                            - Delete
-                          type: string
-                        whenScaled:
-                          default: Retain
-                          description: |-
-                            WhenScaled specifies what happens to PVCs when the StatefulSet is scaled down.
-                            - "Retain" (default): PVCs are kept when scaling down (allows scale back up)
-                            - "Delete": PVCs for removed replicas are deleted
-                          enum:
-                            - Retain
-                            - Delete
-                          type: string
-                      type: object
-                  type: object
-                tolerations:
-                  description: Tolerations for pod scheduling
-                  items:
-                    description: |-
-                      The pod this Toleration is attached to tolerates any taint that matches
-                      the triple <key,value,effect> using the matching operator <operator>.
-                    properties:
-                      effect:
-                        description: |-
-                          Effect indicates the taint effect to match. Empty means match all taint effects.
-                          When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: |-
-                          Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                          If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                        type: string
-                      operator:
-                        description: |-
-                          Operator represents a key's relationship to the value.
-                          Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                          Exists is equivalent to wildcard for value, so that a pod can
-                          tolerate all taints of a particular category.
-                          Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
-                        type: string
-                      tolerationSeconds:
-                        description: |-
-                          TolerationSeconds represents the period of time the toleration (which must be
-                          of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do not evict). Zero and
-                          negative values will be treated as 0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: |-
-                          Value is the taint value the toleration matches to.
-                          If the operator is Exists, the value should be empty, otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-                topologySpreadConstraints:
-                  description: TopologySpreadConstraints for pod scheduling
-                  items:
-                    description: TopologySpreadConstraint specifies how to spread
-                      matching pods among the given topology.
-                    properties:
-                      labelSelector:
-                        description: |-
-                          LabelSelector is used to find matching pods.
-                          Pods that match this label selector are counted to determine the number of pods
-                          in their corresponding topology domain.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: |-
-                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: |-
-                                    operator represents a key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: |-
-                                    values is an array of string values. If the operator is In or NotIn,
-                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                    the values array must be empty. This array is replaced during a strategic
-                                    merge patch.
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      matchLabelKeys:
-                        description: |-
-                          MatchLabelKeys is a set of pod label keys to select the pods over which
-                          spreading will be calculated. The keys are used to lookup values from the
-                          incoming pod labels, those key-value labels are ANDed with labelSelector
-                          to select the group of existing pods over which spreading will be calculated
-                          for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                          MatchLabelKeys cannot be set when LabelSelector isn't set.
-                          Keys that don't exist in the incoming pod labels will
-                          be ignored. A null or empty list means only match against labelSelector.
-
-                          This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
-                        items:
-                          type: string
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      maxSkew:
-                        description: |-
-                          MaxSkew describes the degree to which pods may be unevenly distributed.
-                          When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                          between the number of matching pods in the target topology and the global minimum.
-                          The global minimum is the minimum number of matching pods in an eligible domain
-                          or zero if the number of eligible domains is less than MinDomains.
-                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                          labelSelector spread as 2/2/1:
-                          In this case, the global minimum is 1.
-                          | zone1 | zone2 | zone3 |
-                          |  P P  |  P P  |   P   |
-                          - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
-                          scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
-                          violate MaxSkew(1).
-                          - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                          When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
-                          to topologies that satisfy it.
-                          It's a required field. Default value is 1 and 0 is not allowed.
-                        format: int32
-                        type: integer
-                      minDomains:
-                        description: |-
-                          MinDomains indicates a minimum number of eligible domains.
-                          When the number of eligible domains with matching topology keys is less than minDomains,
-                          Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
-                          And when the number of eligible domains with matching topology keys equals or greater than minDomains,
-                          this value has no effect on scheduling.
-                          As a result, when the number of eligible domains is less than minDomains,
-                          scheduler won't schedule more than maxSkew Pods to those domains.
-                          If value is nil, the constraint behaves as if MinDomains is equal to 1.
-                          Valid values are integers greater than 0.
-                          When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
-
-                          For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
-                          labelSelector spread as 2/2/2:
-                          | zone1 | zone2 | zone3 |
-                          |  P P  |  P P  |  P P  |
-                          The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
-                          In this situation, new pod with the same labelSelector cannot be scheduled,
-                          because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
-                          it will violate MaxSkew.
-                        format: int32
-                        type: integer
-                      nodeAffinityPolicy:
-                        description: |-
-                          NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                          when calculating pod topology spread skew. Options are:
-                          - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                          - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
-
-                          If this value is nil, the behavior is equivalent to the Honor policy.
-                        type: string
-                      nodeTaintsPolicy:
-                        description: |-
-                          NodeTaintsPolicy indicates how we will treat node taints when calculating
-                          pod topology spread skew. Options are:
-                          - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                          has a toleration, are included.
-                          - Ignore: node taints are ignored. All nodes are included.
-
-                          If this value is nil, the behavior is equivalent to the Ignore policy.
-                        type: string
-                      topologyKey:
-                        description: |-
-                          TopologyKey is the key of node labels. Nodes that have a label with this key
-                          and identical values are considered to be in the same topology.
-                          We consider each <key, value> as a "bucket", and try to put balanced number
-                          of pods into each bucket.
-                          We define a domain as a particular instance of a topology.
-                          Also, we define an eligible domain as a domain whose nodes meet the requirements of
-                          nodeAffinityPolicy and nodeTaintsPolicy.
-                          e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
-                          And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
-                          It's a required field.
-                        type: string
-                      whenUnsatisfiable:
-                        description: |-
-                          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                          the spread constraint.
-                          - DoNotSchedule (default) tells the scheduler not to schedule it.
-                          - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                            but giving higher precedence to topologies that would help reduce the
-                            skew.
-                          A constraint is considered "Unsatisfiable" for an incoming pod
-                          if and only if every possible node assignment for that pod would violate
-                          "MaxSkew" on some topology.
-                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                          labelSelector spread as 3/1/1:
-                          | zone1 | zone2 | zone3 |
-                          | P P P |   P   |   P   |
-                          If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
-                          to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
-                          MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
-                          won't make it *more* imbalanced.
-                          It's a required field.
-                        type: string
-                    required:
-                      - maxSkew
-                      - topologyKey
-                      - whenUnsatisfiable
-                    type: object
-                  type: array
-                webApi:
-                  description: |-
-                    WebAPI configures the static website hosting endpoint.
-                    Enabled by default with rootDomain ".<name>.<namespace>.svc".
-                    Set webApi.disabled: true to turn off.
-                  properties:
-                    addHostToMetrics:
-                      description: AddHostToMetrics adds the domain name to metrics
-                        labels for per-domain tracking.
-                      type: boolean
-                    bindAddress:
-                      description: |-
-                        BindAddress is a custom bind address for the Web API.
-                        Can be a TCP address or Unix socket path (e.g., "unix:///run/garage/web.sock").
-                        If set, this overrides BindPort.
-                      type: string
-                    bindPort:
-                      default: 3902
-                      description: BindPort is the port to bind for web serving
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
-                    disabled:
-                      description: Disabled disables the web endpoint entirely.
-                      type: boolean
-                    rootDomain:
-                      description: |-
-                        RootDomain is the root domain suffix for bucket website access.
-                        Bucket websites are accessible via <bucket-name>.<root-domain>.
-                        Defaults to ".<cluster-name>.<namespace>.svc" if not specified.
-
-                        Examples:
-                        - ".web.garage.tld" -> Access bucket "site" website at "site.web.garage.tld"
-                        - ".sites.example.com" -> Access bucket "blog" at "blog.sites.example.com"
-
-                        Note: Include the leading dot.
-                      type: string
-                  type: object
-                zone:
-                  description: |-
-                    Zone is the zone name for all nodes in this cluster.
-                    Used for fault tolerance - Garage distributes replicas across zones.
-                    Required for multi-cluster federation.
-
-                    Examples: "us-east-1", "rack-a", "dc1", "zone-a"
-                  type: string
-              required:
-                - replicas
-                - replication
-              type: object
-            status:
-              description: GarageClusterStatus defines the observed state of GarageCluster
-              properties:
-                activeRepairs:
-                  description: ActiveRepairs contains currently running repair operations
-                  items:
-                    description: RepairStatus contains status of a repair operation
-                    properties:
-                      nodeId:
-                        description: NodeID is the node running this repair
-                        type: string
-                      progress:
-                        description: Progress is a human-readable progress description
-                        type: string
-                      startedAt:
-                        description: StartedAt is when the repair started
-                        format: date-time
-                        type: string
-                      type:
-                        description: Type is the repair operation type (Tables, Blocks,
-                          Scrub, Rebalance, etc.)
-                        type: string
-                    type: object
-                  type: array
-                blockErrorDetails:
-                  description: BlockErrorDetails provides detailed information about
-                    block errors
-                  properties:
-                    count:
-                      description: Count is the total number of blocks with errors
-                      format: int32
-                      type: integer
-                    lastErrorAt:
-                      description: LastErrorAt is when the most recent block error
-                        occurred
-                      format: date-time
-                      type: string
-                    topErrors:
-                      description: |-
-                        TopErrors contains details about the most problematic blocks
-                        Limited to top 10 blocks by error count
-                      items:
-                        description: BlockErrorDetail contains information about a
-                          specific block error
-                        properties:
-                          blockHash:
-                            description: BlockHash is the hash of the affected block
-                            type: string
-                          errorCount:
-                            description: ErrorCount is the number of times this block
-                              failed to sync
-                            format: int32
-                            type: integer
-                          lastAttempt:
-                            description: LastAttempt is when the last sync attempt
-                              occurred
-                            format: date-time
-                            type: string
-                          lastError:
-                            description: LastError is the most recent error message
-                              for this block
-                            type: string
-                          nextRetry:
-                            description: NextRetry is when the next sync retry is
-                              scheduled
-                            format: date-time
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                blockErrors:
-                  description: BlockErrors is the count of blocks with sync errors
-                    across all nodes
-                  format: int32
-                  type: integer
-                buildInfo:
-                  description: BuildInfo contains Garage build information
-                  properties:
-                    features:
-                      description: Features lists enabled Cargo features
-                      items:
-                        type: string
-                      type: array
-                    rustVersion:
-                      description: RustVersion is the Rust compiler version used to
-                        build Garage
-                      type: string
-                    version:
-                      description: Version is the Garage version string (e.g., "v1.0.1")
-                      type: string
-                  type: object
-                clusterId:
-                  description: ClusterID is the unique identifier of the Garage cluster
-                  type: string
-                conditions:
-                  description: Conditions represent the current state of the cluster
-                  items:
-                    description: Condition contains details for one aspect of the
-                      current state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False,
-                          Unknown.
-                        enum:
-                          - 'True'
-                          - 'False'
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                drainingNodes:
-                  description: |-
-                    DrainingNodes is the count of nodes that are draining data from an older layout version.
-                    These nodes had a storage role in a previous layout and are migrating data to other nodes.
-                    A non-zero value indicates a layout transition is in progress.
-                  type: integer
-                endpoints:
-                  description: Endpoints contains service endpoints
-                  properties:
-                    admin:
-                      description: Admin is the admin API endpoint
-                      type: string
-                    k2v:
-                      description: K2V is the K2V API endpoint
-                      type: string
-                    metrics:
-                      description: Metrics is the Prometheus metrics endpoint (typically
-                        Admin + /metrics)
-                      type: string
-                    rpc:
-                      description: RPC is the internal RPC endpoint
-                      type: string
-                    s3:
-                      description: S3 is the S3 API endpoint
-                      type: string
-                    web:
-                      description: Web is the web hosting endpoint
-                      type: string
-                  type: object
-                health:
-                  description: Health contains cluster health information
-                  properties:
-                    available:
-                      description: Available indicates if quorum is available
-                      type: boolean
-                    connectedNodes:
-                      description: ConnectedNodes is the number of currently connected
-                        nodes
-                      type: integer
-                    healthy:
-                      description: Healthy indicates if all nodes are connected
-                      type: boolean
-                    knownNodes:
-                      description: KnownNodes is the number of nodes seen in cluster
-                      type: integer
-                    partitions:
-                      description: Partitions is the total partitions in layout
-                      type: integer
-                    partitionsAllOk:
-                      description: PartitionsAllOK is partitions with all nodes connected
-                      type: integer
-                    partitionsQuorum:
-                      description: PartitionsQuorum is partitions with quorum connectivity
-                      type: integer
-                    status:
-                      description: Status is the overall cluster status
-                      type: string
-                    storageNodes:
-                      description: StorageNodes is the number of storage nodes in
-                        layout
-                      type: integer
-                    storageNodesOk:
-                      description: StorageNodesOK is the number of connected storage
-                        nodes
-                      type: integer
-                  type: object
-                layoutHistory:
-                  description: LayoutHistory contains layout version history
-                  properties:
-                    currentVersion:
-                      description: CurrentVersion is the current layout version
-                      format: int64
-                      type: integer
-                    minAck:
-                      description: MinAck is the minimum acknowledged layout version
-                        by all nodes
-                      format: int64
-                      type: integer
-                    versions:
-                      description: Versions contains the history of layout versions
-                      items:
-                        description: LayoutVersionInfo contains information about
-                          a layout version
-                        properties:
-                          gatewayNodes:
-                            description: GatewayNodes is the number of gateway nodes
-                              in this version
-                            type: integer
-                          status:
-                            description: Status is the version status (Current, Draining,
-                              Historical)
-                            type: string
-                          storageNodes:
-                            description: StorageNodes is the number of storage nodes
-                              in this version
-                            type: integer
-                          version:
-                            description: Version is the layout version number
-                            format: int64
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                layoutPreview:
-                  description: LayoutPreview shows what would change if staged layout
-                    is applied
-                  properties:
-                    dataTransferEstimate:
-                      description: DataTransferEstimate is a human-readable estimate
-                        of data movement (e.g., "~50 GB")
-                      type: string
-                    nodesAdded:
-                      description: NodesAdded shows node IDs that would be added to
-                        the layout
-                      items:
-                        type: string
-                      type: array
-                    nodesModified:
-                      description: NodesModified shows node IDs with changed configuration
-                        (zone, capacity, tags)
-                      items:
-                        type: string
-                      type: array
-                    nodesRemoved:
-                      description: NodesRemoved shows node IDs that would be removed
-                        from the layout
-                      items:
-                        type: string
-                      type: array
-                    partitionTransfers:
-                      description: PartitionTransfers is the estimated number of partition
-                        transfers
-                      format: int32
-                      type: integer
-                    zonesAffected:
-                      description: ZonesAffected shows which zones would be affected
-                        by the changes
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                layoutVersion:
-                  description: LayoutVersion is the current layout version
-                  format: int64
-                  type: integer
-                lifecycleStatus:
-                  description: LifecycleStatus contains the status of bucket lifecycle
-                    operations
-                  properties:
-                    lastCompleted:
-                      description: |-
-                        LastCompleted is when the last lifecycle worker run completed
-                        (from lifecycle-last-completed worker variable)
-                      format: date-time
-                      type: string
-                  type: object
-                nodes:
-                  description: Nodes contains status information for each node
-                  items:
-                    description: NodeStatus contains status information for a Garage
-                      node
-                    properties:
-                      capacity:
-                        description: Capacity is the storage capacity of the node
-                        type: string
-                      connected:
-                        description: Connected indicates if the node is connected
-                          to the cluster
-                        type: boolean
-                      dataDiskAvailable:
-                        description: DataDiskAvailable is the available space on data
-                          disk
-                        type: string
-                      dataDiskTotal:
-                        description: DataDiskTotal is the total space on data disk
-                        type: string
-                      gateway:
-                        description: Gateway indicates if the node is gateway-only
-                        type: boolean
-                      metadataDiskAvailable:
-                        description: MetadataDiskAvailable is the available space
-                          on metadata disk
-                        type: string
-                      metadataDiskTotal:
-                        description: MetadataDiskTotal is the total space on metadata
-                          disk
-                        type: string
-                      nodeId:
-                        description: NodeID is the public key of the node
-                        type: string
-                      podName:
-                        description: PodName is the name of the pod running this node
-                        type: string
-                      version:
-                        description: Version is the Garage version running on this
-                          node
-                        type: string
-                      zone:
-                        description: Zone is the zone assignment of the node
-                        type: string
-                    type: object
-                  type: array
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation
-                  format: int64
-                  type: integer
-                phase:
-                  description: Phase represents the current phase of the cluster
-                  type: string
-                readyReplicas:
-                  description: ReadyReplicas is the number of ready Garage pods
-                  format: int32
-                  type: integer
-                remoteClusters:
-                  description: RemoteClusters contains status of remote clusters in
-                    the federation
-                  items:
-                    description: RemoteClusterStatus is the status of a remote cluster
-                    properties:
-                      connected:
-                        description: Connected indicates if we can reach this cluster
-                        type: boolean
-                      healthyNodes:
-                        description: HealthyNodes is the number of healthy nodes
-                        type: integer
-                      lastSeen:
-                        description: LastSeen is when we last successfully connected
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the cluster name
-                        type: string
-                      nodes:
-                        description: Nodes is the number of nodes in this cluster
-                        type: integer
-                      zone:
-                        description: Zone is the cluster's zone
-                        type: string
-                    type: object
-                  type: array
-                replicas:
-                  description: Replicas is the total number of Garage pods targeted
-                    by this cluster
-                  format: int32
-                  type: integer
-                resyncQueueLength:
-                  description: ResyncQueueLength is the total block resync queue depth
-                    across all nodes
-                  format: int64
-                  type: integer
-                scrubStatus:
-                  description: ScrubStatus contains the status of data scrub operations
-                  properties:
-                    corruptedBlocks:
-                      description: |-
-                        CorruptedBlocks is the number of corrupted blocks found in the last scrub
-                        (from scrub-corruptions_detected worker variable)
-                      format: int32
-                      type: integer
-                    lastCompleted:
-                      description: LastCompleted is when the last scrub completed
-                        (from scrub-last-completed worker variable)
-                      format: date-time
-                      type: string
-                    nextRun:
-                      description: NextRun is when the next scrub is scheduled to
-                        run (from scrub-next-run worker variable)
-                      format: date-time
-                      type: string
-                    nodeStatuses:
-                      description: NodeStatuses contains per-node scrub status
-                      items:
-                        description: NodeScrubStatus contains scrub status for a single
-                          node
-                        properties:
-                          errorsFound:
-                            description: ErrorsFound is the number of errors found
-                              on this node
-                            format: int32
-                            type: integer
-                          itemsChecked:
-                            description: ItemsChecked is the number of items checked
-                            format: int64
-                            type: integer
-                          nodeId:
-                            description: NodeID is the node identifier
-                            type: string
-                          progress:
-                            description: Progress percentage (0-100)
-                            type: integer
-                          running:
-                            description: Running indicates if scrub is running on
-                              this node
-                            type: boolean
-                        type: object
-                      type: array
-                    paused:
-                      description: Paused indicates if the scrub is paused
-                      type: boolean
-                    progress:
-                      description: Progress is a human-readable progress description
-                        (e.g., "45% complete")
-                      type: string
-                    running:
-                      description: Running indicates if a scrub is currently running
-                        on any node
-                      type: boolean
-                    tranquilityLevel:
-                      description: TranquilityLevel is the current tranquility setting
-                        (higher = less aggressive)
-                      type: integer
-                  type: object
-                selector:
-                  description: |-
-                    Selector is the serialized label selector for pods managed by this cluster.
-                    Required for the scale subresource to work with HPA/VPA.
-                  type: string
-                stagedLayoutVersion:
-                  description: StagedLayoutVersion is the staged layout version pending
-                    application
-                  format: int64
-                  type: integer
-                stagedRoles:
-                  description: StagedRoles is the number of roles in the staged layout
-                  format: int32
-                  type: integer
-                storageStats:
-                  description: StorageStats contains cluster-wide storage statistics
-                  properties:
-                    availableCapacity:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: AvailableCapacity is the available storage across
-                        all nodes
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    healthyPartitions:
-                      description: HealthyPartitions is the number of partitions with
-                        full redundancy
-                      format: int32
-                      type: integer
-                    totalCapacity:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: TotalCapacity is the total storage capacity across
-                        all nodes
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    totalPartitions:
-                      description: TotalPartitions is the total number of partitions
-                        in the layout
-                      format: int32
-                      type: integer
-                    usedCapacity:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: UsedCapacity is the used storage across all nodes
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                  type: object
-                totalNodes:
-                  description: TotalNodes is the total nodes across all clusters (local
-                    + remote)
-                  type: integer
-                workerCount:
-                  description: WorkerCount is the total number of background workers
-                  format: int32
-                  type: integer
-                workers:
-                  description: Workers contains detailed information about background
-                    workers
-                  properties:
-                    busy:
-                      description: Busy is the number of busy/active workers
-                      format: int32
-                      type: integer
-                    errored:
-                      description: Errored is the number of workers with errors
-                      format: int32
-                      type: integer
-                    errors:
-                      description: Errors contains details about worker errors
-                      items:
-                        description: WorkerError contains information about a worker
-                          error
-                        properties:
-                          consecutiveErrors:
-                            description: ConsecutiveErrors is the count of consecutive
-                              errors
-                            format: int32
-                            type: integer
-                          lastError:
-                            description: LastError is the last error message
-                            type: string
-                          lastErrorSecsAgo:
-                            description: LastErrorSecsAgo is seconds since the last
-                              error
-                            format: int64
-                            type: integer
-                          name:
-                            description: Name is the worker name
-                            type: string
-                          workerId:
-                            description: WorkerID is the worker identifier
-                            format: int64
-                            type: integer
-                        type: object
-                      type: array
-                    idle:
-                      description: Idle is the number of idle workers
-                      format: int32
-                      type: integer
-                    total:
-                      description: Total is the total number of background workers
-                      format: int32
-                      type: integer
-                    variables:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        Variables contains runtime worker configuration variables
-                        These can be adjusted through the Admin API to tune background worker behavior
-                      type: object
-                  type: object
-                workersFailed:
-                  description: WorkersFailed is the number of failed workers
-                  format: int32
-                  type: integer
-              required:
-                - replicas
-                - selector
-              type: object
-          required:
-            - spec
           type: object
-      served: true
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
       storage: false
-      subresources:
-        scale:
-          labelSelectorPath: .status.selector
-          specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.replicas
-        status: {}
     - additionalPrinterColumns:
         - jsonPath: .spec.replicas
           name: Replicas
@@ -5564,10 +1295,18 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+      deprecated: true
+      deprecationWarning: garage.rajsingh.info/v1beta1 GarageCluster is deprecated;
+        migrate to garage.rajsingh.info/v1beta2
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description: GarageCluster is the Schema for the garageclusters API
+          description: |-
+            GarageCluster is the Schema for the garageclusters API.
+
+            Deprecated: v1beta1 is retained for read-only access via the conversion
+            webhook. New CRs should use garage.rajsingh.info/v1beta2 which supports
+            the storage + gateway tier-based schema.
           properties:
             apiVersion:
               description: |-
@@ -6841,7 +2580,6 @@ spec:
                         procMount denotes the type of proc mount to use for the containers.
                         The default value is Default which uses the container runtime defaults for
                         readonly paths and masked paths.
-                        This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
@@ -7287,7 +3025,6 @@ spec:
                       description: |-
                         Suspended pauses all reconciliation for this cluster.
                         The operator will not make any changes while suspended.
-                        Prefer this over the garage.rajsingh.info/pause-reconcile annotation, which is deprecated.
                       type: boolean
                   type: object
                 monitoring:
@@ -7310,6 +3047,98 @@ spec:
                         Interval is the Prometheus scrape interval (e.g. "30s", "1m").
                         Defaults to the Prometheus global scrape interval when unset.
                       type: string
+                    metricRelabelings:
+                      description: "MetricRelabelings are applied to samples scraped\
+                        \ from the admin /metrics\nendpoint before ingestion (set\
+                        \ as the ServiceMonitor endpoint's\nmetricRelabelings). Use\
+                        \ them to drop high-cardinality series that nothing\nqueries\
+                        \ \u2014 e.g. the per-method rpc_duration_* histograms, which\
+                        \ dominate a\nGarage node's metric series count."
+                      items:
+                        description: |-
+                          RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                          scraped samples and remote write samples.
+
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                        properties:
+                          action:
+                            default: replace
+                            description: |-
+                              action to perform based on the regex matching.
+
+                              `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                              `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                              Default: "Replace"
+                            enum:
+                              - replace
+                              - Replace
+                              - keep
+                              - Keep
+                              - drop
+                              - Drop
+                              - hashmod
+                              - HashMod
+                              - labelmap
+                              - LabelMap
+                              - labeldrop
+                              - LabelDrop
+                              - labelkeep
+                              - LabelKeep
+                              - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
+                              - keepequal
+                              - KeepEqual
+                              - dropequal
+                              - DropEqual
+                            type: string
+                          modulus:
+                            description: |-
+                              modulus to take of the hash of the source label values.
+
+                              Only applicable when the action is `HashMod`.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: regex defines the regular expression against
+                              which the extracted value is matched.
+                            type: string
+                          replacement:
+                            description: |-
+                              replacement value against which a Replace action is performed if the
+                              regular expression matches.
+
+                              Regex capture groups are available.
+                            type: string
+                          separator:
+                            description: separator defines the string between concatenated
+                              SourceLabels.
+                            type: string
+                          sourceLabels:
+                            description: |-
+                              sourceLabels defines the source labels select values from existing labels. Their content is
+                              concatenated using the configured Separator and matched against the
+                              configured regular expression.
+                            items:
+                              description: |-
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: |-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
+
+                              It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                              `KeepEqual` and `DropEqual` actions.
+
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
                   type: object
                 network:
                   description: Network configures RPC and API networking
@@ -7603,6 +3432,13 @@ spec:
                               - key
                             type: object
                             x-kubernetes-map-type: atomic
+                          gatewayRpcEndpointTemplate:
+                            description: |-
+                              GatewayRPCEndpointTemplate is a hostname:port template used by federation
+                              to connect to remote gateway pods individually. The literal `{ordinal}`
+                              is replaced with each remote gateway pod's ordinal (0, 1, ...).
+                              Example: "ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901"
+                            type: string
                         required:
                           - adminApiEndpoint
                         type: object
@@ -7633,10 +3469,11 @@ spec:
                   type: array
                 replicas:
                   default: 3
-                  description: Replicas is the number of Garage nodes to deploy in
-                    this cluster
+                  description: |-
+                    Replicas is the number of Garage nodes to deploy in this cluster.
+                    Set to 0 to keep the cluster declared but stop all pods.
                   format: int32
-                  minimum: 1
+                  minimum: 0
                   type: integer
                 replication:
                   description: |-
@@ -8727,6 +4564,11 @@ spec:
                     dataFsync:
                       description: DataFsync enables fsync for data block writes
                       type: boolean
+                    layoutPolicy:
+                      description: |-
+                        LayoutPolicy overrides the cluster layoutPolicy for the storage tier only
+                        (Auto/Manual). Round-trips losslessly with v1beta2 spec.storage.layoutPolicy.
+                      type: string
                     metadata:
                       description: Metadata configures metadata storage
                       properties:
@@ -9369,6 +5211,12 @@ spec:
                             - Delete
                           type: string
                       type: object
+                    rpcPublicAddr:
+                      description: |-
+                        RPCPublicAddr is the externally-routable rpc_public_addr advertised by
+                        storage pods. Supports an `{ordinal}` placeholder for per-pod addresses.
+                        Round-trips losslessly with v1beta2 spec.storage.rpcPublicAddr.
+                      type: string
                   type: object
                 tolerations:
                   description: Tolerations for pod scheduling
@@ -10320,62 +6168,40 @@ spec:
             - spec
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         scale:
           labelSelectorPath: .status.selector
           specReplicasPath: .spec.replicas
           statusReplicasPath: .status.replicas
         status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-    helm.sh/resource-policy: keep
-  labels:
-    app.kubernetes.io/instance: appcat
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
-    control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
-  name: garagekeys.garage.rajsingh.info
-spec:
-  group: garage.rajsingh.info
-  names:
-    kind: GarageKey
-    listKind: GarageKeyList
-    plural: garagekeys
-    shortNames:
-      - gk
-    singular: garagekey
-  scope: Namespaced
-  versions:
     - additionalPrinterColumns:
-        - jsonPath: .spec.clusterRef.name
-          name: Cluster
-          type: string
-        - jsonPath: .status.keyId
-          name: KeyID
-          type: string
-        - jsonPath: .status.accessKeyId
-          name: AccessKeyID
+        - jsonPath: .status.storageReplicas
+          name: Storage
+          type: integer
+        - jsonPath: .status.gatewayReplicas
+          name: Gateway
+          type: integer
+        - jsonPath: .status.readyReplicas
+          name: Ready
+          type: integer
+        - jsonPath: .spec.zone
+          name: Zone
           type: string
         - jsonPath: .status.phase
           name: Phase
           type: string
-        - jsonPath: .status.clusterWide
-          name: ClusterWide
-          type: boolean
+        - jsonPath: .status.layoutDiagnosis
+          name: Diagnosis
+          priority: 1
+          type: string
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      name: v1alpha1
+      name: v1beta2
       schema:
         openAPIV3Schema:
-          description: GarageKey is the Schema for the garagekeys API
+          description: GarageCluster is the Schema for the garageclusters API.
           properties:
             apiVersion:
               description: |-
@@ -10395,80 +6221,26 @@ spec:
             metadata:
               type: object
             spec:
-              description: GarageKeySpec defines the desired state of GarageKey
+              description: "GarageClusterSpec defines the desired state of a GarageCluster.\n\
+                \nA cluster has two optional tiers:\n\n  - `storage` \u2014 long-lived\
+                \ StatefulSet with PVCs for metadata and data blocks.\n  - `gateway`\
+                \ \u2014 StatefulSet with a small metadata PVC and EmptyDir for the\n\
+                \    data dir. Routes S3/Admin traffic and stores no object blocks.\
+                \ The\n    metadata PVC preserves the Ed25519 node identity across\
+                \ pod restarts,\n    so rolling updates don't churn the cluster layout.\n\
+                \nExactly one of these must hold true:\n\n 1. `storage` set (storage-only\
+                \ or unified with `gateway`).\n 2. `gateway` set together with `storage`\
+                \ (unified cluster \u2014 most common).\n 3. `gateway` set together\
+                \ with `connectTo` (edge gateway pattern \u2014 gateway pods\n   \
+                \ live in a different K8s cluster from the storage backend)."
               properties:
-                allBuckets:
-                  description: |-
-                    AllBuckets grants this key access to ALL buckets in the cluster.
-                    Useful for admin tools, monitoring, or systems that need cluster-wide access.
-                    Uses deny-then-allow to enforce exact permissions: flags set false are actively
-                    revoked, not just ignored. Per-bucket permissions (bucketPermissions) run after
-                    and override additively on top.
-
-                    The key must be in the same namespace as the GarageBucket resources for
-                    bidirectional reconciliation (bucket controller also applies these permissions
-                    when new buckets are created).
-
-                    Note: ListBuckets returns ALL Garage buckets, including those not managed by
-                    the operator. Cluster-wide permissions will be applied to those buckets as well.
+                admin:
+                  description: Admin configures the admin API endpoint and metrics
                   properties:
-                    owner:
-                      description: Owner allows bucket owner operations on all buckets
-                      type: boolean
-                    read:
-                      description: Read allows reading objects from all buckets
-                      type: boolean
-                    write:
-                      description: Write allows writing objects to all buckets
-                      type: boolean
-                  type: object
-                bucketPermissions:
-                  description: |-
-                    BucketPermissions grants this key access to buckets.
-
-                    Note: Permissions can be granted from either direction:
-                    - Here (GarageKey.bucketPermissions): Grant this key access to buckets
-                    - On GarageBucket (GarageBucket.keyPermissions): Grant keys access to the bucket
-
-                    Both approaches are equivalent and result in the same Garage API calls.
-                    Use whichever is more convenient for your workflow:
-                    - Key-centric: Define all bucket access on the key
-                    - Bucket-centric: Define all key access on the bucket
-
-                    If the same permission is defined in both places, they are merged (not conflicting).
-                  items:
-                    description: BucketPermission grants access to a bucket
-                    properties:
-                      bucketId:
-                        description: BucketID references the bucket by its Garage
-                          ID
-                        type: string
-                      bucketRef:
-                        description: BucketRef references the GarageBucket by name
-                        type: string
-                      globalAlias:
-                        description: GlobalAlias references the bucket by global alias
-                        type: string
-                      owner:
-                        description: Owner allows bucket owner operations (delete
-                          bucket, configure website, etc.)
-                        type: boolean
-                      read:
-                        description: Read allows reading objects from the bucket
-                        type: boolean
-                      write:
-                        description: Write allows writing objects to the bucket
-                        type: boolean
-                    type: object
-                  type: array
-                clusterRef:
-                  description: ClusterRef references the GarageCluster this key belongs
-                    to
-                  properties:
-                    kubeConfigSecretRef:
+                    adminTokenSecretRef:
                       description: |-
-                        KubeConfigSecretRef references a secret containing kubeconfig for a remote cluster.
-                        Only used for cross-cluster references in multi-cluster federation scenarios.
+                        AdminTokenSecretRef references the secret used by the operator to authenticate
+                        with Garage's Admin API.
                       properties:
                         key:
                           description: The key of the secret to select from.  Must
@@ -10491,193 +6263,7019 @@ spec:
                         - key
                       type: object
                       x-kubernetes-map-type: atomic
-                    name:
-                      description: Name of the GarageCluster
+                    bindAddress:
+                      description: BindAddress is a custom bind address for the Admin
+                        API.
                       type: string
-                    namespace:
-                      description: Namespace of the GarageCluster (defaults to the
-                        same namespace as the referencing resource)
-                      type: string
-                  required:
-                    - name
-                  type: object
-                expiration:
-                  description: |-
-                    Expiration sets when this key expires (RFC 3339 format)
-                    Example: "2025-12-31T23:59:59Z"
-                    Mutually exclusive with NeverExpires
-                  type: string
-                importKey:
-                  description: ImportKey imports an existing key instead of generating
-                    new credentials
-                  properties:
-                    accessKeyId:
-                      description: AccessKeyID is the existing access key ID
-                      type: string
-                    accessKeyIdKey:
-                      description: |-
-                        AccessKeyIDKey is the key in the secret that contains the access key ID
-                        Only used with SecretRef. Defaults to "access-key-id"
-                      type: string
-                    secretAccessKey:
-                      description: SecretAccessKey is the existing secret access key
-                      type: string
-                    secretAccessKeyKey:
-                      description: |-
-                        SecretAccessKeyKey is the key in the secret that contains the secret access key
-                        Only used with SecretRef. Defaults to "secret-access-key"
-                      type: string
-                    secretRef:
-                      description: |-
-                        SecretRef references a secret containing the credentials
-                        By default the secret should have keys: access-key-id, secret-access-key
-                        Use AccessKeyIDKey and SecretAccessKeyKey to override the key names
+                    bindPort:
+                      default: 3903
+                      description: BindPort is the port to bind for admin API.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    metricsRequireToken:
+                      description: MetricsRequireToken requires Bearer token authentication
+                        for the /metrics endpoint.
+                      type: boolean
+                    metricsTokenSecretRef:
+                      description: MetricsTokenSecretRef references a secret containing
+                        a token that protects /metrics.
                       properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
                         name:
-                          description: name is unique within a namespace to reference
-                            a secret resource.
+                          default: ''
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    traceSink:
+                      description: TraceSink is the OpenTelemetry collector address
+                        for tracing.
+                      type: string
+                  type: object
+                blocks:
+                  description: Blocks configures block storage settings
+                  properties:
+                    compressionLevel:
+                      description: CompressionLevel is the zstd compression level.
+                      pattern: ^(none|-?[1-9][0-9]*)$
+                      type: string
+                    disableScrub:
+                      description: DisableScrub disables automatic monthly data directory
+                        scrub.
+                      type: boolean
+                    maxConcurrentReads:
+                      description: MaxConcurrentReads is the maximum simultaneous
+                        block file reads.
+                      minimum: 1
+                      type: integer
+                    maxConcurrentWritesPerRequest:
+                      description: MaxConcurrentWritesPerRequest is the maximum parallel
+                        block writes per PUT request.
+                      minimum: 1
+                      type: integer
+                    ramBufferMax:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: RAMBufferMax is the maximum RAM for buffering blocks.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    size:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: 'Size is the size of data blocks (default: 1M).'
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    useLocalTZ:
+                      description: UseLocalTZ runs lifecycle worker at midnight in
+                        local timezone.
+                      type: boolean
+                  type: object
+                connectTo:
+                  description: |-
+                    ConnectTo specifies a remote storage cluster this cluster connects to.
+                    Required when `gateway` is set without `storage` (edge gateway pattern).
+                  properties:
+                    adminApiEndpoint:
+                      description: AdminAPIEndpoint is the storage cluster's Admin
+                        API URL.
+                      type: string
+                    adminTokenSecretRef:
+                      description: AdminTokenSecretRef references the storage cluster's
+                        admin token.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ''
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    bootstrapPeers:
+                      description: BootstrapPeers are initial peers for cluster formation.
+                      items:
+                        type: string
+                      type: array
+                    clusterRef:
+                      description: ClusterRef references a GarageCluster in the same
+                        namespace.
+                      properties:
+                        kubeConfigSecretRef:
+                          description: |-
+                            KubeConfigSecretRef references a secret containing a kubeconfig for a remote Kubernetes cluster.
+                            Only needed for multi-cluster federation where the GarageCluster lives in a different
+                            Kubernetes cluster entirely (not just a different namespace).
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ''
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        name:
+                          description: Name of the GarageCluster resource.
                           type: string
                         namespace:
-                          description: namespace defines the space within which the
-                            secret name must be unique.
+                          description: |-
+                            Namespace of the GarageCluster. Defaults to the referencing resource's namespace.
+                            Cross-namespace references require a GarageReferenceGrant in the target namespace.
                           type: string
+                      required:
+                        - name
+                      type: object
+                    rpcSecretRef:
+                      description: RPCSecretRef references a secret containing the
+                        shared RPC secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ''
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                        - key
                       type: object
                       x-kubernetes-map-type: atomic
                   type: object
-                name:
-                  description: |-
-                    Name is a friendly name for this access key
-                    If not set, metadata.name is used
-                  type: string
-                neverExpires:
-                  description: |-
-                    NeverExpires sets the key to never expire
-                    Mutually exclusive with Expiration
-                  type: boolean
-                permissions:
-                  description: |-
-                    Permissions configures key-level permissions
-                    Note: For admin API access, use admin tokens configured in GarageCluster
+                database:
+                  description: Database configures the metadata database engine
                   properties:
-                    createBucket:
-                      description: CreateBucket allows this key to create new buckets
-                        via the S3 CreateBucket API
-                      type: boolean
+                    engine:
+                      default: lmdb
+                      description: Engine specifies the database engine to use.
+                      enum:
+                        - lmdb
+                        - sqlite
+                        - fjall
+                      type: string
+                    fjallBlockCacheSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: FjallBlockCacheSize is the block cache size for
+                        Fjall.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    lmdbMapSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: LMDBMapSize is the virtual memory region size for
+                        LMDB.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                   type: object
-                secretTemplate:
-                  description: SecretTemplate configures how the secret is generated
-                  properties:
-                    accessKeyIdKey:
-                      default: access-key-id
-                      description: AccessKeyIDKey is the key name for the access key
-                        ID
-                      type: string
-                    additionalData:
-                      additionalProperties:
-                        type: string
-                      description: AdditionalData includes additional key-value pairs
-                        in the secret
-                      type: object
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations to add to the secret
-                      type: object
-                    endpointKey:
-                      default: endpoint
-                      description: EndpointKey is the key name for the S3 endpoint
-                        (includes http:// scheme)
-                      type: string
-                    hostKey:
-                      default: host
-                      description: HostKey is the key name for the S3 host (without
-                        scheme, e.g., "host:port")
-                      type: string
-                    includeEndpoint:
-                      description: |-
-                        IncludeEndpoint includes the S3 endpoint in the secret
-                        Defaults to true if not specified
-                      type: boolean
-                    includeRegion:
-                      description: |-
-                        IncludeRegion includes the S3 region in the secret
-                        Defaults to true if not specified
-                      type: boolean
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels to add to the secret
-                      type: object
-                    name:
-                      description: |-
-                        Name is the name of the secret to create
-                        Defaults to the GarageKey name
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace is the namespace for the secret
-                        Defaults to the GarageKey namespace
-                      type: string
-                    regionKey:
-                      default: region
-                      description: RegionKey is the key name for the S3 region
-                      type: string
-                    schemeKey:
-                      default: scheme
-                      description: SchemeKey is the key name for the endpoint scheme
-                        (http or https)
-                      type: string
-                    secretAccessKeyKey:
-                      default: secret-access-key
-                      description: SecretAccessKeyKey is the key name for the secret
-                        access key
-                      type: string
-                    type:
-                      default: Opaque
-                      description: Type is the secret type
-                      type: string
-                  type: object
-              required:
-                - clusterRef
-              type: object
-            status:
-              description: GarageKeyStatus defines the observed state of GarageKey
-              properties:
-                accessKeyId:
-                  description: AccessKeyID is the S3 access key ID
-                  type: string
-                buckets:
-                  description: Buckets lists buckets this key has access to
+                defaultNodeTags:
+                  description: |-
+                    DefaultNodeTags are tags applied to all auto-managed nodes.
+                    Only used when LayoutPolicy is "Auto".
                   items:
-                    description: KeyBucketAccess shows bucket access for this key
+                    type: string
+                  type: array
+                discovery:
+                  description: Discovery configures peer discovery mechanisms
+                  properties:
+                    consul:
+                      description: Consul configures Consul-based peer discovery.
+                      properties:
+                        api:
+                          default: catalog
+                          description: API specifies the service registration API.
+                          enum:
+                            - catalog
+                            - agent
+                          type: string
+                        caCert:
+                          description: CACert is the CA certificate for TLS connection.
+                          type: string
+                        caCertSecretRef:
+                          description: CACertSecretRef references a secret containing
+                            the CA certificate.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ''
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        clientCertSecretRef:
+                          description: ClientCertSecretRef references a secret containing
+                            client TLS cert.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ''
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        clientKeySecretRef:
+                          description: ClientKeySecretRef references a secret containing
+                            client TLS key.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ''
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        datacenters:
+                          description: Datacenters for WAN federation.
+                          items:
+                            type: string
+                          type: array
+                        enabled:
+                          description: Enabled enables Consul-based discovery.
+                          type: boolean
+                        httpAddr:
+                          description: HTTPAddr is the full HTTP(S) address of Consul
+                            server.
+                          type: string
+                        meta:
+                          additionalProperties:
+                            type: string
+                          description: Meta is service metadata key-value pairs.
+                          type: object
+                        serviceName:
+                          description: ServiceName for Garage RPC port registration.
+                          type: string
+                        tags:
+                          description: Tags are additional service tags.
+                          items:
+                            type: string
+                          type: array
+                        tlsSkipVerify:
+                          description: TLSSkipVerify skips TLS hostname verification.
+                          type: boolean
+                        tokenSecretRef:
+                          description: TokenSecretRef references a secret containing
+                            the bearer token.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ''
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    kubernetes:
+                      description: Kubernetes configures Kubernetes-based peer discovery.
+                      properties:
+                        enabled:
+                          description: Enabled enables Kubernetes-based discovery.
+                          type: boolean
+                        namespace:
+                          description: Namespace for Garage custom resources.
+                          type: string
+                        serviceName:
+                          description: ServiceName label to filter custom resources.
+                          type: string
+                        skipCRD:
+                          description: SkipCRD skips automatic CRD creation/patching.
+                          type: boolean
+                      type: object
+                  type: object
+                gateway:
+                  description: |-
+                    Gateway configures the gateway tier (StatefulSet + small metadata PVC).
+                    Gateway pods route S3/Admin traffic and store no object blocks; the
+                    metadata PVC persists their node identity across restarts.
+                    May be combined with `storage` (unified cluster) or `connectTo` (edge cluster).
+                  properties:
+                    affinity:
+                      description: Affinity for pod scheduling.
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: |-
+                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: |-
+                                      A null or empty node selector term matches no objects. The requirements of
+                                      them are ANDed.
+                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the anti-affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and subtracting
+                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the anti-affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the anti-affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                      type: object
+                    containerSecurityContext:
+                      description: ContainerSecurityContext for the Garage container.
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process. This bool directly controls if
+                            the no_new_privs flag will be set on the container process.
+                            AllowPrivilegeEscalation is true always when the container is:
+                            1) run as Privileged
+                            2) has CAP_SYS_ADMIN
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        capabilities:
+                          description: |-
+                            The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by the container runtime.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
+                            Defaults to false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        procMount:
+                          description: |-
+                            procMount denotes the type of proc mount to use for the containers.
+                            The default value is Default which uses the container runtime defaults for
+                            readonly paths and masked paths.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by this container. If seccomp options are
+                            provided at both the pod & container level, the container options
+                            override the pod options.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    env:
+                      description: |-
+                        Env is a list of additional environment variables to set on the Garage
+                        container. These are appended AFTER the operator's built-in vars
+                        (GARAGE_NODE_HOST, RUST_LOG, etc.), so a user-supplied entry with the same
+                        name as a built-in will override it. Typical use: setting
+                        GARAGE_ALLOW_WORLD_READABLE_SECRETS, or any other GARAGE_* env Garage
+                        honors at startup.
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any service environment variables. If a variable cannot be resolved,
+                              the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                              Escaped references will never be expanded, regardless of whether the variable
+                              exists or not.
+                              Defaults to "".
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ''
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: |-
+                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ''
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    envFrom:
+                      description: |-
+                        EnvFrom is a list of sources to populate environment variables in the
+                        Garage container, allowing injection from Secrets or ConfigMaps. These
+                        sources are evaluated before the per-variable Env list, matching standard
+                        Kubernetes container semantics.
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps or Secrets
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                default: ''
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                default: ''
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                    metadata:
+                      description: "Metadata configures the metadata PVC for gateway\
+                        \ pods. Only metadata_dir\nis persisted \u2014 data_dir stays\
+                        \ EmptyDir because gateways do not store\nobject blocks. Default\
+                        \ size is 1Gi."
+                      properties:
+                        accessModes:
+                          description: AccessModes for the PVC.
+                          items:
+                            type: string
+                          type: array
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to set on the PVC.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to set on the PVC.
+                          type: object
+                        paths:
+                          description: "Paths configures multiple data directories\
+                            \ for multi-disk setups.\nOnly valid for data volumes\
+                            \ \u2014 webhook rejects this on metadata volumes."
+                          items:
+                            description: DataPath specifies a data directory with
+                              capacity.
+                            properties:
+                              capacity:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Capacity of the drive (required unless
+                                  readOnly).
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              path:
+                                description: Path to the data directory.
+                                type: string
+                              readOnly:
+                                description: ReadOnly marks directory as legacy read-only
+                                  for migrations.
+                                type: boolean
+                              volume:
+                                description: Volume configuration if using PVC.
+                                properties:
+                                  accessModes:
+                                    description: AccessModes for the PVC.
+                                    items:
+                                      type: string
+                                    type: array
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to set on the PVC.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels to set on the PVC.
+                                    type: object
+                                  selector:
+                                    description: Selector to select PVs.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  size:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Size of the volume (storage request).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  storageClassName:
+                                    description: StorageClassName for the PVC.
+                                    type: string
+                                  type:
+                                    default: PersistentVolumeClaim
+                                    description: Type specifies the volume type.
+                                    enum:
+                                      - PersistentVolumeClaim
+                                      - EmptyDir
+                                    type: string
+                                  volumeClaimTemplateSpec:
+                                    description: VolumeClaimTemplateSpec allows full
+                                      customization of the PVC.
+                                    properties:
+                                      accessModes:
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          Users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: |-
+                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
+                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                          exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        type: string
+                                      volumeMode:
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                type: object
+                            required:
+                              - path
+                            type: object
+                          type: array
+                        selector:
+                          description: Selector to select PVs.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        size:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Size of the volume.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: StorageClassName for the PVC.
+                          type: string
+                        type:
+                          default: PersistentVolumeClaim
+                          description: 'Type specifies the volume type: PersistentVolumeClaim
+                            (default) or EmptyDir.'
+                          enum:
+                            - PersistentVolumeClaim
+                            - EmptyDir
+                          type: string
+                        volumeClaimTemplateSpec:
+                          description: VolumeClaimTemplateSpec allows full customization
+                            of the PVC.
+                          properties:
+                            accessModes:
+                              description: |-
+                                accessModes contains the desired access modes the volume should have.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            dataSource:
+                              description: |-
+                                dataSource field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim)
+                                If the provisioner or an external controller can support the specified data source,
+                                it will create a new volume based on the contents of the specified data source.
+                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty API group (non
+                                core object) or a PersistentVolumeClaim object.
+                                When this field is specified, volume binding will only succeed if the type of
+                                the specified object matches some installed volume populator or dynamic
+                                provisioner.
+                                This field will replace the functionality of the dataSource field and as such
+                                if both fields are non-empty, they must have the same value. For backwards
+                                compatibility, when namespace isn't specified in dataSourceRef,
+                                both fields (dataSource and dataSourceRef) will be set to the same
+                                value automatically if one of them is empty and the other is non-empty.
+                                When namespace is specified in dataSourceRef,
+                                dataSource isn't set to the same value and must be empty.
+                                There are three important differences between dataSource and dataSourceRef:
+                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                  in any namespaces.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of resource being referenced
+                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              description: |-
+                                resources represents the minimum resources the volume should have.
+                                Users are allowed to specify resource requirements
+                                that are lower than previous value but must still be higher than capacity recorded in the
+                                status field of the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes
+                                to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: |-
+                                storageClassName is the name of the StorageClass required by the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                              type: string
+                            volumeAttributesClassName:
+                              description: |-
+                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                it can be changed after the claim is created. An empty string or nil value indicates that no
+                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                this field can be reset to its previous value (including nil) to cancel the modification.
+                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                exists.
+                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              type: string
+                            volumeMode:
+                              description: |-
+                                volumeMode defines what type of volume is required by the claim.
+                                Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      type: object
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector for pod scheduling.
+                      type: object
+                    podAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: PodAnnotations to add to pods.
+                      type: object
+                    podDisruptionBudget:
+                      description: "PodDisruptionBudget configures a PDB for the gateway\
+                        \ Deployment. Gateway\npods serve S3/Admin traffic but hold\
+                        \ no object data, so a PDB only\nprotects request availability\
+                        \ during node drains \u2014 not data durability."
+                      properties:
+                        enabled:
+                          default: true
+                          description: Enabled enables PodDisruptionBudget creation
+                          type: boolean
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: MaxUnavailable specifies the maximum number
+                            of pods that can be unavailable.
+                          x-kubernetes-int-or-string: true
+                        minAvailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: MinAvailable specifies the minimum number of
+                            pods that must be available.
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    podLabels:
+                      additionalProperties:
+                        type: string
+                      description: PodLabels to add to pods.
+                      type: object
+                    priorityClassName:
+                      description: PriorityClassName for pods.
+                      type: string
+                    readinessProbe:
+                      description: "ReadinessProbe overrides the gateway tier's readiness\
+                        \ probe. When unset,\nthe operator uses a bind-only TCP check\
+                        \ on the S3 port. The default is\ndeliberately NOT a serving-aware\
+                        \ admin /health probe: /health is a\ncluster-wide consistent\
+                        \ write-quorum signal, so at replication.factor=2 a\nsingle\
+                        \ storage-node loss (or, for a federated cluster, the window\
+                        \ before\nremote peers join) makes /health return 503 on every\
+                        \ node, which would mark\nall gateways NotReady and \u2014\
+                        \ behind a publishNotReadyAddresses=false Service\nsuch as\
+                        \ the Tailscale anycast \u2014 withdraw the whole anycast\
+                        \ and take down\nreads too, even though read_quorum=1 means\
+                        \ reads still work. Serving-health\nbelongs in monitoring\
+                        \ (alert on /health), not readiness. Set this only if\nyou\
+                        \ have a custom read-capability gate (e.g. an exec probe)\
+                        \ that won't\nwithdraw a gateway that can still serve reads."
+                      properties:
+                        exec:
+                          description: Exec specifies a command to execute in the
+                            container.
+                          properties:
+                            command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              default: ''
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                If this is not specified, the default behavior is defined by gRPC.
+                              type: string
+                          required:
+                            - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
+                          properties:
+                            host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                            - port
+                          type: object
+                        initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                            - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                            value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                      type: object
+                    replicas:
+                      default: 2
+                      description: |-
+                        Replicas is the number of gateway pods to deploy. Set to 0 to keep the
+                        gateway tier declared but stop all pods; the operator scales the
+                        statefulset down and removes vacated entries from the layout.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resources:
+                      description: Resources specifies compute resources for the pod.
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This field depends on the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                    rpcPublicAddr:
+                      description: "RPCPublicAddr, when set, is written into the gateway\
+                        \ pods' garage.toml as\nrpc_public_addr so that peers in other\
+                        \ regions can dial gateways by hostname.\nPurely cosmetic\
+                        \ for federated layouts \u2014 leave unset when gateways only\n\
+                        communicate with the local storage tier."
+                      type: string
+                    securityContext:
+                      description: SecurityContext for the pod.
+                      properties:
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod.
+                            Some volume types allow the Kubelet to change the ownership of that volume
+                            to be owned by the pod:
+
+                            1. The owning GID will be the FSGroup
+                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                            3. The permission bits are OR'd with rw-rw----
+
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: |-
+                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                            before being exposed inside Pod. This field will only apply to
+                            volume types which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                            and emptydir.
+                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxChangePolicy:
+                          description: |-
+                            seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                            It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                            Valid values are "MountOption" and "Recursive".
+
+                            "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                            This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                            "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                            This requires all Pods that share the same volume to use the same SELinux label.
+                            It is not possible to share the same volume among privileged and unprivileged Pods.
+                            Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                            whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                            CSIDriver instance. Other volumes are always re-labelled recursively.
+                            "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                            If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                            If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                            and "Recursive" for all other volumes.
+
+                            This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                            All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in SecurityContext.  If set in
+                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        supplementalGroups:
+                          description: |-
+                            A list of groups applied to the first process run in each container, in
+                            addition to the container's primary GID and fsGroup (if specified).  If
+                            the SupplementalGroupsPolicy feature is enabled, the
+                            supplementalGroupsPolicy field determines whether these are in addition
+                            to or instead of any group memberships defined in the container image.
+                            If unspecified, no additional groups are added, though group memberships
+                            defined in the container image may still be used, depending on the
+                            supplementalGroupsPolicy field.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        supplementalGroupsPolicy:
+                          description: |-
+                            Defines how supplemental groups of the first container processes are calculated.
+                            Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                            (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                            and the container runtime must implement support for this feature.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        sysctls:
+                          description: |-
+                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                            sysctls (by the container runtime) might fail to launch.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options within a container's SecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    tolerations:
+                      description: Tolerations for pod scheduling.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: TopologySpreadConstraints for pod scheduling.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread
+                          matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: |-
+                              LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine the number of pods
+                              in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: |-
+                              MatchLabelKeys is a set of pod label keys to select the pods over which
+                              spreading will be calculated. The keys are used to lookup values from the
+                              incoming pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading will be calculated
+                              for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                              MatchLabelKeys cannot be set when LabelSelector isn't set.
+                              Keys that don't exist in the incoming pod labels will
+                              be ignored. A null or empty list means only match against labelSelector.
+
+                              This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: |-
+                              MaxSkew describes the degree to which pods may be unevenly distributed.
+                              When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                              between the number of matching pods in the target topology and the global minimum.
+                              The global minimum is the minimum number of matching pods in an eligible domain
+                              or zero if the number of eligible domains is less than MinDomains.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 2/2/1:
+                              In this case, the global minimum is 1.
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |   P   |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                              scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                              violate MaxSkew(1).
+                              - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                              to topologies that satisfy it.
+                              It's a required field. Default value is 1 and 0 is not allowed.
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains.
+                              When the number of eligible domains with matching topology keys is less than minDomains,
+                              Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                              And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                              this value has no effect on scheduling.
+                              As a result, when the number of eligible domains is less than minDomains,
+                              scheduler won't schedule more than maxSkew Pods to those domains.
+                              If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                              Valid values are integers greater than 0.
+                              When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                              labelSelector spread as 2/2/2:
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |  P P  |
+                              The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                              In this situation, new pod with the same labelSelector cannot be scheduled,
+                              because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                              it will violate MaxSkew.
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                              when calculating pod topology spread skew. Options are:
+                              - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                              - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                              If this value is nil, the behavior is equivalent to the Honor policy.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating
+                              pod topology spread skew. Options are:
+                              - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                              has a toleration, are included.
+                              - Ignore: node taints are ignored. All nodes are included.
+
+                              If this value is nil, the behavior is equivalent to the Ignore policy.
+                            type: string
+                          topologyKey:
+                            description: |-
+                              TopologyKey is the key of node labels. Nodes that have a label with this key
+                              and identical values are considered to be in the same topology.
+                              We consider each <key, value> as a "bucket", and try to put balanced number
+                              of pods into each bucket.
+                              We define a domain as a particular instance of a topology.
+                              Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                              nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                              And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                              It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                              the spread constraint.
+                              - DoNotSchedule (default) tells the scheduler not to schedule it.
+                              - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod
+                              if and only if every possible node assignment for that pod would violate
+                              "MaxSkew" on some topology.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 3/1/1:
+                              | zone1 | zone2 | zone3 |
+                              | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                              to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                              MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                              won't make it *more* imbalanced.
+                              It's a required field.
+                            type: string
+                        required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                        type: object
+                      type: array
+                  required:
+                    - replicas
+                  type: object
+                image:
+                  default: dxflrs/garage:v2.3.0
+                  description: |-
+                    Image specifies the Garage container image to use.
+                    Takes precedence over imageRepository if both are set.
+                  type: string
+                imagePullPolicy:
+                  default: IfNotPresent
+                  description: ImagePullPolicy specifies the image pull policy
+                  type: string
+                imagePullSecrets:
+                  description: ImagePullSecrets specifies secrets for pulling images
+                    from private registries
+                  items:
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
                     properties:
-                      bucketId:
-                        description: BucketID is the bucket ID
+                      name:
+                        default: ''
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                         type: string
-                      globalAlias:
-                        description: GlobalAlias is the bucket's global alias
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                imageRepository:
+                  description: |-
+                    ImageRepository overrides just the repository portion of the default Garage image,
+                    preserving the default tag for automatic version upgrades.
+                    Ignored if image is set.
+                  type: string
+                k2vApi:
+                  description: |-
+                    K2VAPI configures the K2V (key-value) API endpoint.
+                    Omit to disable K2V.
+                  properties:
+                    bindAddress:
+                      description: BindAddress is a custom bind address for the K2V
+                        API.
+                      type: string
+                    bindPort:
+                      default: 3904
+                      description: BindPort is the port to bind for K2V API.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  type: object
+                layoutManagement:
+                  description: LayoutManagement controls automatic layout application
+                    behavior.
+                  properties:
+                    autoApply:
+                      description: AutoApply automatically applies staged layout changes.
+                      type: boolean
+                    minNodesHealthy:
+                      description: MinNodesHealthy is the minimum healthy nodes required
+                        before applying layout changes.
+                      type: integer
+                  type: object
+                layoutPolicy:
+                  default: Auto
+                  description: LayoutPolicy controls whether node layouts are automatically
+                    managed or manually configured.
+                  enum:
+                    - Auto
+                    - Manual
+                  type: string
+                logging:
+                  description: Logging configures logging behavior for Garage nodes
+                  properties:
+                    journald:
+                      description: Journald enables logging to systemd journald.
+                      type: boolean
+                    level:
+                      description: Level sets the log level using RUST_LOG format.
+                      type: string
+                    syslog:
+                      description: Syslog enables logging to syslog.
+                      type: boolean
+                  type: object
+                maintenance:
+                  description: Maintenance configures maintenance mode for this cluster.
+                  properties:
+                    suspended:
+                      description: Suspended pauses all reconciliation for this cluster.
+                      type: boolean
+                  type: object
+                monitoring:
+                  description: Monitoring configures Prometheus integration for this
+                    cluster.
+                  properties:
+                    additionalLabels:
+                      additionalProperties:
                         type: string
-                      localAlias:
-                        description: LocalAlias is this key's local alias for the
-                          bucket
+                      description: AdditionalLabels are added to the ServiceMonitor
+                        metadata.
+                      type: object
+                    enabled:
+                      description: Enabled creates a ServiceMonitor targeting the
+                        admin API /metrics endpoint.
+                      type: boolean
+                    interval:
+                      description: Interval is the Prometheus scrape interval (e.g.
+                        "30s", "1m").
+                      type: string
+                    metricRelabelings:
+                      description: "MetricRelabelings are applied to samples scraped\
+                        \ from the admin /metrics\nendpoint before ingestion (set\
+                        \ as the ServiceMonitor endpoint's\nmetricRelabelings). Use\
+                        \ them to drop high-cardinality series that nothing\nqueries\
+                        \ \u2014 e.g. the per-method rpc_duration_* histograms, which\
+                        \ dominate a\nGarage node's metric series count."
+                      items:
+                        description: |-
+                          RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                          scraped samples and remote write samples.
+
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                        properties:
+                          action:
+                            default: replace
+                            description: |-
+                              action to perform based on the regex matching.
+
+                              `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                              `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                              Default: "Replace"
+                            enum:
+                              - replace
+                              - Replace
+                              - keep
+                              - Keep
+                              - drop
+                              - Drop
+                              - hashmod
+                              - HashMod
+                              - labelmap
+                              - LabelMap
+                              - labeldrop
+                              - LabelDrop
+                              - labelkeep
+                              - LabelKeep
+                              - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
+                              - keepequal
+                              - KeepEqual
+                              - dropequal
+                              - DropEqual
+                            type: string
+                          modulus:
+                            description: |-
+                              modulus to take of the hash of the source label values.
+
+                              Only applicable when the action is `HashMod`.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: regex defines the regular expression against
+                              which the extracted value is matched.
+                            type: string
+                          replacement:
+                            description: |-
+                              replacement value against which a Replace action is performed if the
+                              regular expression matches.
+
+                              Regex capture groups are available.
+                            type: string
+                          separator:
+                            description: separator defines the string between concatenated
+                              SourceLabels.
+                            type: string
+                          sourceLabels:
+                            description: |-
+                              sourceLabels defines the source labels select values from existing labels. Their content is
+                              concatenated using the configured Separator and matched against the
+                              configured regular expression.
+                            items:
+                              description: |-
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: |-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
+
+                              It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                              `KeepEqual` and `DropEqual` actions.
+
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                network:
+                  description: Network configures RPC and API networking
+                  properties:
+                    bootstrapPeers:
+                      description: BootstrapPeers lists initial peers for cluster
+                        formation.
+                      items:
                         type: string
-                      owner:
-                        description: Owner permission
-                        type: boolean
-                      read:
-                        description: Read permission
-                        type: boolean
-                      write:
-                        description: Write permission
-                        type: boolean
+                      type: array
+                    rpcBindAddress:
+                      description: RPCBindAddress is a custom bind address for the
+                        RPC server.
+                      type: string
+                    rpcBindOutgoing:
+                      description: RPCBindOutgoing pre-binds outgoing sockets to same
+                        IP.
+                      type: boolean
+                    rpcBindPort:
+                      default: 3901
+                      description: RPCBindPort is the port for inter-cluster RPC.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    rpcPingTimeout:
+                      description: RPCPingTimeout sets the RPC ping timeout.
+                      type: string
+                    rpcPublicAddr:
+                      description: |-
+                        RPCPublicAddr is the external address for storage-tier nodes to advertise.
+                        Gateway tier has its own rpcPublicAddr field on `spec.gateway`.
+                      type: string
+                    rpcPublicAddrSubnet:
+                      description: RPCPublicAddrSubnet filters autodiscovered IPs
+                        to specific subnet.
+                      type: string
+                    rpcSecretRef:
+                      description: RPCSecretRef references a secret containing the
+                        shared RPC secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ''
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    rpcTimeout:
+                      description: RPCTimeout sets the RPC call timeout.
+                      type: string
+                    service:
+                      description: Service configures the Kubernetes Service for the
+                        cluster.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to add to the service.
+                          type: object
+                        externalTrafficPolicy:
+                          description: ExternalTrafficPolicy for LoadBalancer/NodePort.
+                          type: string
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to add to the service. Operator-managed
+                            labels take precedence on conflict.
+                          type: object
+                        loadBalancerIP:
+                          description: LoadBalancerIP for LoadBalancer type.
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: LoadBalancerSourceRanges for LoadBalancer type.
+                          items:
+                            type: string
+                          type: array
+                        type:
+                          default: ClusterIP
+                          description: Type of service.
+                          enum:
+                            - ClusterIP
+                            - NodePort
+                            - LoadBalancer
+                          type: string
+                      type: object
+                  type: object
+                publicEndpoint:
+                  description: |-
+                    PublicEndpoint configures how remote clusters reach this cluster's nodes.
+                    Used for multi-cluster federation of the storage tier.
+                  properties:
+                    externalIP:
+                      description: ExternalIP configuration.
+                      properties:
+                        addressTemplate:
+                          description: AddressTemplate uses go template to generate
+                            addresses from pod info.
+                          type: string
+                        addresses:
+                          additionalProperties:
+                            type: string
+                          description: Addresses maps pod names to external IPs.
+                          type: object
+                      type: object
+                    loadBalancer:
+                      description: LoadBalancer configuration.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to add to the service.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to add to the service. Operator-managed
+                            labels take precedence on conflict.
+                          type: object
+                        perNode:
+                          description: PerNode creates a separate LoadBalancer service
+                            per GarageCluster pod.
+                          type: boolean
+                      type: object
+                    nodePort:
+                      description: NodePort configuration.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to add to the service.
+                          type: object
+                        basePort:
+                          description: BasePort is the starting NodePort; Garage pod
+                            N is exposed on BasePort+N.
+                          format: int32
+                          maximum: 32767
+                          minimum: 30000
+                          type: integer
+                        externalAddresses:
+                          description: ExternalAddresses are the externally-reachable
+                            IPs or hostnames of the Kubernetes nodes.
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to add to the service. Operator-managed
+                            labels take precedence on conflict.
+                          type: object
+                      required:
+                        - externalAddresses
+                      type: object
+                    type:
+                      description: Type specifies how nodes are exposed to remote
+                        clusters for RPC.
+                      enum:
+                        - LoadBalancer
+                        - NodePort
+                        - ExternalIP
+                        - Headless
+                      type: string
+                  required:
+                    - type
+                  type: object
+                remoteClusters:
+                  description: |-
+                    RemoteClusters lists Garage clusters in other Kubernetes clusters to federate with.
+                    Applies to the storage tier. Gateways inherit reachability via the local storage peer.
+                  items:
+                    description: RemoteClusterConfig defines a Garage cluster in another
+                      Kubernetes cluster.
+                    properties:
+                      connection:
+                        description: Connection defines how to connect to this remote
+                          cluster.
+                        properties:
+                          adminApiEndpoint:
+                            description: AdminAPIEndpoint is the admin API endpoint
+                              of the remote cluster.
+                            minLength: 1
+                            type: string
+                          adminTokenSecretRef:
+                            description: AdminTokenSecretRef references the admin
+                              token for the remote cluster's API.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ''
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          gatewayRpcEndpointTemplate:
+                            description: "GatewayRPCEndpointTemplate is a hostname:port\
+                              \ template used by federation\nto connect to remote\
+                              \ gateway pods individually. The literal `{ordinal}`\n\
+                              is replaced with each remote gateway pod's ordinal (0,\
+                              \ 1, ...) parsed\nfrom the layout role's pod-name tag\
+                              \ (e.g. `garage-gateway-0`).\n\nRequired when the remote\
+                              \ cluster runs gateway pods that participate in\nthe\
+                              \ cluster layout (default since v0.5.8). FullReplication\
+                              \ tables\n(key_table, bucket_table, ...) need quorum\
+                              \ across all_nodes, which\nincludes remote gateways.\
+                              \ Without this field the operator only peers\nstorage\u2194\
+                              storage cross-region; remote gateways appear in layout\
+                              \ but\nremain unreachable, blocking GetKeyInfo / DeleteKey\
+                              \ / FullReplication\nwrites that need full quorum.\n\
+                              \nExample: \"ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901\""
+                            type: string
+                          storageRpcEndpointTemplate:
+                            description: "StorageRPCEndpointTemplate is a hostname:port\
+                              \ template used by federation\nto connect to remote\
+                              \ STORAGE pods individually, mirroring\nGatewayRPCEndpointTemplate.\
+                              \ The literal `{ordinal}` is replaced with each\nremote\
+                              \ storage pod's ordinal (0, 1, ...) parsed from the\
+                              \ layout role's\npod-name tag (e.g. `garage-storage-0`).\n\
+                              \nNeeded when a remote region runs more than one storage\
+                              \ pod behind a single\nadmin hostname (e.g. a Tailscale\
+                              \ VIP): the default storage\u2194storage connect\nloop\
+                              \ dials every remote node at that one shared hostname,\
+                              \ which only ever\nlands one pod, leaving the rest unreachable\
+                              \ cross-region. Set this together\nwith the remote region's\
+                              \ spec.storage.rpcPublicAddr `{ordinal}` template so\n\
+                              each storage pod is both advertised and dialed per-pod.\n\
+                              \nExample: \"ottawa-storage-{ordinal}.keiretsu.ts.net:3901\""
+                            type: string
+                        required:
+                          - adminApiEndpoint
+                        type: object
+                      defaultCapacity:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: DefaultCapacity is the default storage capacity
+                          to assign to remote nodes.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      name:
+                        description: Name is a friendly name for this remote cluster.
+                        minLength: 1
+                        type: string
+                      zone:
+                        description: Zone is the zone name for nodes in this remote
+                          cluster.
+                        minLength: 1
+                        type: string
+                    required:
+                      - connection
+                      - name
+                      - zone
                     type: object
                   type: array
-                clusterWide:
-                  description: ClusterWide indicates this key has cluster-wide bucket
-                    access via allBuckets
-                  type: boolean
+                replication:
+                  description: |-
+                    Replication configures data replication settings.
+                    If omitted, defaults to factor: 3 and consistencyMode: consistent.
+                  properties:
+                    consistencyMode:
+                      default: consistent
+                      description: ConsistencyMode controls quorum behavior for read/write
+                        operations.
+                      enum:
+                        - consistent
+                        - degraded
+                        - dangerous
+                      type: string
+                    factor:
+                      default: 3
+                      description: Factor is the replication factor (1, 2, 3, 5, 7,
+                        etc.)
+                      maximum: 7
+                      minimum: 1
+                      type: integer
+                    zoneRedundancyMinZones:
+                      description: ZoneRedundancyMinZones is the minimum number of
+                        zones required.
+                      maximum: 7
+                      minimum: 1
+                      type: integer
+                    zoneRedundancyMode:
+                      description: ZoneRedundancyMode controls how data is distributed
+                        across zones.
+                      enum:
+                        - Maximum
+                        - AtLeast
+                      type: string
+                  required:
+                    - factor
+                  type: object
+                s3Api:
+                  description: S3API configures the S3-compatible API endpoint
+                  properties:
+                    bindAddress:
+                      description: BindAddress is a custom bind address for the S3
+                        API.
+                      type: string
+                    bindPort:
+                      default: 3900
+                      description: BindPort is the port to bind for S3 API.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    region:
+                      default: garage
+                      description: Region is the AWS S3 region name to use.
+                      type: string
+                    rootDomain:
+                      description: RootDomain is the root domain suffix for vhost-style
+                        S3 access.
+                      type: string
+                  required:
+                    - region
+                  type: object
+                security:
+                  description: Security configures security-related settings
+                  properties:
+                    allowInsecureSecretPermissions:
+                      description: |-
+                        AllowInsecureSecretPermissions bypasses Garage's check that secret files
+                        are not world-readable on disk.
+                      type: boolean
+                    allowPunycode:
+                      description: AllowPunycode allows punycode in bucket names.
+                      type: boolean
+                    tls:
+                      description: TLS configures TLS settings.
+                      properties:
+                        caSecretRef:
+                          description: CASecretRef references a secret containing
+                            the CA certificate.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ''
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        certSecretRef:
+                          description: CertSecretRef references a secret containing
+                            the TLS certificate for RPC.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ''
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        enabled:
+                          description: Enabled enables TLS for inter-node RPC communication.
+                          type: boolean
+                        keySecretRef:
+                          description: KeySecretRef references a secret containing
+                            the TLS private key for RPC.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ''
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  type: object
+                serviceAccountName:
+                  description: ServiceAccountName for Garage pods (shared by both
+                    tiers).
+                  type: string
+                storage:
+                  description: |-
+                    Storage configures the long-lived storage tier (StatefulSet + PVCs).
+                    Omit for gateway-only edge clusters.
+                  properties:
+                    affinity:
+                      description: Affinity for pod scheduling.
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: |-
+                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: |-
+                                      A null or empty node selector term matches no objects. The requirements of
+                                      them are ANDed.
+                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the anti-affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and subtracting
+                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the anti-affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the anti-affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                      type: object
+                    capacityReservePercent:
+                      description: |-
+                        CapacityReservePercent reserves a percentage of PVC capacity for overhead.
+                        Only meaningful when LayoutPolicy is "Auto".
+                      maximum: 50
+                      minimum: 0
+                      type: integer
+                    containerSecurityContext:
+                      description: ContainerSecurityContext for the Garage container.
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process. This bool directly controls if
+                            the no_new_privs flag will be set on the container process.
+                            AllowPrivilegeEscalation is true always when the container is:
+                            1) run as Privileged
+                            2) has CAP_SYS_ADMIN
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        capabilities:
+                          description: |-
+                            The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by the container runtime.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
+                            Defaults to false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        procMount:
+                          description: |-
+                            procMount denotes the type of proc mount to use for the containers.
+                            The default value is Default which uses the container runtime defaults for
+                            readonly paths and masked paths.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by this container. If seccomp options are
+                            provided at both the pod & container level, the container options
+                            override the pod options.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    data:
+                      description: Data configures the data PVC (object blocks).
+                      properties:
+                        accessModes:
+                          description: AccessModes for the PVC.
+                          items:
+                            type: string
+                          type: array
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to set on the PVC.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to set on the PVC.
+                          type: object
+                        paths:
+                          description: "Paths configures multiple data directories\
+                            \ for multi-disk setups.\nOnly valid for data volumes\
+                            \ \u2014 webhook rejects this on metadata volumes."
+                          items:
+                            description: DataPath specifies a data directory with
+                              capacity.
+                            properties:
+                              capacity:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Capacity of the drive (required unless
+                                  readOnly).
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              path:
+                                description: Path to the data directory.
+                                type: string
+                              readOnly:
+                                description: ReadOnly marks directory as legacy read-only
+                                  for migrations.
+                                type: boolean
+                              volume:
+                                description: Volume configuration if using PVC.
+                                properties:
+                                  accessModes:
+                                    description: AccessModes for the PVC.
+                                    items:
+                                      type: string
+                                    type: array
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to set on the PVC.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels to set on the PVC.
+                                    type: object
+                                  selector:
+                                    description: Selector to select PVs.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  size:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Size of the volume (storage request).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  storageClassName:
+                                    description: StorageClassName for the PVC.
+                                    type: string
+                                  type:
+                                    default: PersistentVolumeClaim
+                                    description: Type specifies the volume type.
+                                    enum:
+                                      - PersistentVolumeClaim
+                                      - EmptyDir
+                                    type: string
+                                  volumeClaimTemplateSpec:
+                                    description: VolumeClaimTemplateSpec allows full
+                                      customization of the PVC.
+                                    properties:
+                                      accessModes:
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          Users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: |-
+                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
+                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                          exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        type: string
+                                      volumeMode:
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                type: object
+                            required:
+                              - path
+                            type: object
+                          type: array
+                        selector:
+                          description: Selector to select PVs.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        size:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Size of the volume.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: StorageClassName for the PVC.
+                          type: string
+                        type:
+                          default: PersistentVolumeClaim
+                          description: 'Type specifies the volume type: PersistentVolumeClaim
+                            (default) or EmptyDir.'
+                          enum:
+                            - PersistentVolumeClaim
+                            - EmptyDir
+                          type: string
+                        volumeClaimTemplateSpec:
+                          description: VolumeClaimTemplateSpec allows full customization
+                            of the PVC.
+                          properties:
+                            accessModes:
+                              description: |-
+                                accessModes contains the desired access modes the volume should have.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            dataSource:
+                              description: |-
+                                dataSource field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim)
+                                If the provisioner or an external controller can support the specified data source,
+                                it will create a new volume based on the contents of the specified data source.
+                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty API group (non
+                                core object) or a PersistentVolumeClaim object.
+                                When this field is specified, volume binding will only succeed if the type of
+                                the specified object matches some installed volume populator or dynamic
+                                provisioner.
+                                This field will replace the functionality of the dataSource field and as such
+                                if both fields are non-empty, they must have the same value. For backwards
+                                compatibility, when namespace isn't specified in dataSourceRef,
+                                both fields (dataSource and dataSourceRef) will be set to the same
+                                value automatically if one of them is empty and the other is non-empty.
+                                When namespace is specified in dataSourceRef,
+                                dataSource isn't set to the same value and must be empty.
+                                There are three important differences between dataSource and dataSourceRef:
+                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                  in any namespaces.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of resource being referenced
+                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              description: |-
+                                resources represents the minimum resources the volume should have.
+                                Users are allowed to specify resource requirements
+                                that are lower than previous value but must still be higher than capacity recorded in the
+                                status field of the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes
+                                to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: |-
+                                storageClassName is the name of the StorageClass required by the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                              type: string
+                            volumeAttributesClassName:
+                              description: |-
+                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                it can be changed after the claim is created. An empty string or nil value indicates that no
+                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                this field can be reset to its previous value (including nil) to cancel the modification.
+                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                exists.
+                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              type: string
+                            volumeMode:
+                              description: |-
+                                volumeMode defines what type of volume is required by the claim.
+                                Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      type: object
+                    dataFsync:
+                      description: DataFsync enables fsync for data block writes.
+                      type: boolean
+                    env:
+                      description: |-
+                        Env is a list of additional environment variables to set on the Garage
+                        container. These are appended AFTER the operator's built-in vars
+                        (GARAGE_NODE_HOST, RUST_LOG, etc.), so a user-supplied entry with the same
+                        name as a built-in will override it. Typical use: setting
+                        GARAGE_ALLOW_WORLD_READABLE_SECRETS, or any other GARAGE_* env Garage
+                        honors at startup.
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any service environment variables. If a variable cannot be resolved,
+                              the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                              Escaped references will never be expanded, regardless of whether the variable
+                              exists or not.
+                              Defaults to "".
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ''
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: |-
+                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ''
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    envFrom:
+                      description: |-
+                        EnvFrom is a list of sources to populate environment variables in the
+                        Garage container, allowing injection from Secrets or ConfigMaps. These
+                        sources are evaluated before the per-variable Env list, matching standard
+                        Kubernetes container semantics.
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps or Secrets
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                default: ''
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                default: ''
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                    layoutPolicy:
+                      description: "LayoutPolicy overrides the cluster-level spec.layoutPolicy\
+                        \ for the STORAGE\ntier only. This lets a cluster hand-manage\
+                        \ storage GarageNodes (Manual)\nwhile the gateway tier stays\
+                        \ operator-managed (Auto) \u2014 e.g. a region with\nheterogeneous\
+                        \ per-node storage arrays defined in gitops, keeping the\n\
+                        operator's gateway automation (per-ordinal rpc_public_addr,\
+                        \ tombstone\nreaper, per-pod LBs). Defaults to spec.layoutPolicy\
+                        \ when empty. Auto->Manual\nis one-way (operator ejects its\
+                        \ storage nodes; Manual->Auto is rejected by\nthe webhook),\
+                        \ matching the cluster-level field."
+                      enum:
+                        - Auto
+                        - Manual
+                      type: string
+                    metadata:
+                      description: Metadata configures the metadata PVC (Garage node
+                        identity + index DB).
+                      properties:
+                        accessModes:
+                          description: AccessModes for the PVC.
+                          items:
+                            type: string
+                          type: array
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to set on the PVC.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to set on the PVC.
+                          type: object
+                        paths:
+                          description: "Paths configures multiple data directories\
+                            \ for multi-disk setups.\nOnly valid for data volumes\
+                            \ \u2014 webhook rejects this on metadata volumes."
+                          items:
+                            description: DataPath specifies a data directory with
+                              capacity.
+                            properties:
+                              capacity:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Capacity of the drive (required unless
+                                  readOnly).
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              path:
+                                description: Path to the data directory.
+                                type: string
+                              readOnly:
+                                description: ReadOnly marks directory as legacy read-only
+                                  for migrations.
+                                type: boolean
+                              volume:
+                                description: Volume configuration if using PVC.
+                                properties:
+                                  accessModes:
+                                    description: AccessModes for the PVC.
+                                    items:
+                                      type: string
+                                    type: array
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to set on the PVC.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels to set on the PVC.
+                                    type: object
+                                  selector:
+                                    description: Selector to select PVs.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  size:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Size of the volume (storage request).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  storageClassName:
+                                    description: StorageClassName for the PVC.
+                                    type: string
+                                  type:
+                                    default: PersistentVolumeClaim
+                                    description: Type specifies the volume type.
+                                    enum:
+                                      - PersistentVolumeClaim
+                                      - EmptyDir
+                                    type: string
+                                  volumeClaimTemplateSpec:
+                                    description: VolumeClaimTemplateSpec allows full
+                                      customization of the PVC.
+                                    properties:
+                                      accessModes:
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          Users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: |-
+                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
+                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                          exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        type: string
+                                      volumeMode:
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                type: object
+                            required:
+                              - path
+                            type: object
+                          type: array
+                        selector:
+                          description: Selector to select PVs.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        size:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Size of the volume.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: StorageClassName for the PVC.
+                          type: string
+                        type:
+                          default: PersistentVolumeClaim
+                          description: 'Type specifies the volume type: PersistentVolumeClaim
+                            (default) or EmptyDir.'
+                          enum:
+                            - PersistentVolumeClaim
+                            - EmptyDir
+                          type: string
+                        volumeClaimTemplateSpec:
+                          description: VolumeClaimTemplateSpec allows full customization
+                            of the PVC.
+                          properties:
+                            accessModes:
+                              description: |-
+                                accessModes contains the desired access modes the volume should have.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            dataSource:
+                              description: |-
+                                dataSource field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim)
+                                If the provisioner or an external controller can support the specified data source,
+                                it will create a new volume based on the contents of the specified data source.
+                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty API group (non
+                                core object) or a PersistentVolumeClaim object.
+                                When this field is specified, volume binding will only succeed if the type of
+                                the specified object matches some installed volume populator or dynamic
+                                provisioner.
+                                This field will replace the functionality of the dataSource field and as such
+                                if both fields are non-empty, they must have the same value. For backwards
+                                compatibility, when namespace isn't specified in dataSourceRef,
+                                both fields (dataSource and dataSourceRef) will be set to the same
+                                value automatically if one of them is empty and the other is non-empty.
+                                When namespace is specified in dataSourceRef,
+                                dataSource isn't set to the same value and must be empty.
+                                There are three important differences between dataSource and dataSourceRef:
+                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                  in any namespaces.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of resource being referenced
+                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              description: |-
+                                resources represents the minimum resources the volume should have.
+                                Users are allowed to specify resource requirements
+                                that are lower than previous value but must still be higher than capacity recorded in the
+                                status field of the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes
+                                to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: |-
+                                storageClassName is the name of the StorageClass required by the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                              type: string
+                            volumeAttributesClassName:
+                              description: |-
+                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                it can be changed after the claim is created. An empty string or nil value indicates that no
+                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                this field can be reset to its previous value (including nil) to cancel the modification.
+                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                exists.
+                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              type: string
+                            volumeMode:
+                              description: |-
+                                volumeMode defines what type of volume is required by the claim.
+                                Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      type: object
+                    metadataAutoSnapshotInterval:
+                      description: MetadataAutoSnapshotInterval enables automatic
+                        metadata snapshots.
+                      pattern: ^(\d+(\.\d+)?\s*(ns|us|ms|s|m|h|d|w|M|y)\s*)+$
+                      type: string
+                    metadataFsync:
+                      description: MetadataFsync enables fsync for metadata transactions.
+                      type: boolean
+                    metadataSnapshotsDir:
+                      description: MetadataSnapshotsDir specifies directory for metadata
+                        snapshots
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector for pod scheduling.
+                      type: object
+                    podAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: PodAnnotations to add to pods.
+                      type: object
+                    podDisruptionBudget:
+                      description: PodDisruptionBudget configures a PDB for the storage
+                        StatefulSet.
+                      properties:
+                        enabled:
+                          default: true
+                          description: Enabled enables PodDisruptionBudget creation
+                          type: boolean
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: MaxUnavailable specifies the maximum number
+                            of pods that can be unavailable.
+                          x-kubernetes-int-or-string: true
+                        minAvailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: MinAvailable specifies the minimum number of
+                            pods that must be available.
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    podLabels:
+                      additionalProperties:
+                        type: string
+                      description: PodLabels to add to pods.
+                      type: object
+                    priorityClassName:
+                      description: PriorityClassName for pods.
+                      type: string
+                    pvcRetentionPolicy:
+                      description: PVCRetentionPolicy controls PVC lifecycle when
+                        the StatefulSet is deleted or scaled down.
+                      properties:
+                        whenDeleted:
+                          default: Retain
+                          description: WhenDeleted specifies what happens to PVCs
+                            when the StatefulSet is deleted.
+                          enum:
+                            - Retain
+                            - Delete
+                          type: string
+                        whenScaled:
+                          default: Retain
+                          description: WhenScaled specifies what happens to PVCs when
+                            the StatefulSet is scaled down.
+                          enum:
+                            - Retain
+                            - Delete
+                          type: string
+                      type: object
+                    replicas:
+                      default: 3
+                      description: |-
+                        Replicas is the number of storage pods to deploy. Set to 0 to keep the
+                        storage tier declared (config, PVC templates) but stop all pods.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resources:
+                      description: Resources specifies compute resources for the pod.
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This field depends on the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                    rpcPublicAddr:
+                      description: "RPCPublicAddr is the externally-routable rpc_public_addr\
+                        \ advertised by\nstorage pods so peers in other regions can\
+                        \ dial them by hostname.\n\nWith replicas > 1 a single shared\
+                        \ address only ever routes to one pod\n(e.g. behind a Tailscale\
+                        \ VIP), leaving the others unreachable\ncross-region. Use\
+                        \ an `{ordinal}` placeholder \u2014 the operator substitutes\n\
+                        each pod's ordinal (0, 1, ...), symmetric with the gateway\
+                        \ tier's\nrpcPublicAddr and with remoteClusters[].storageRpcEndpointTemplate\
+                        \ on the\nconsuming side \u2014 so every pod advertises its\
+                        \ own address. An address\nwithout the placeholder is rendered\
+                        \ verbatim (fine for a single-replica\nstorage tier). When\
+                        \ a per-node publicEndpoint (LoadBalancer perNode) is in\n\
+                        effect, that address wins and this field is ignored.\n\nExample:\
+                        \ \"us-east-storage-{ordinal}.example.ts.net:3901\""
+                      type: string
+                    securityContext:
+                      description: SecurityContext for the pod.
+                      properties:
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod.
+                            Some volume types allow the Kubelet to change the ownership of that volume
+                            to be owned by the pod:
+
+                            1. The owning GID will be the FSGroup
+                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                            3. The permission bits are OR'd with rw-rw----
+
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: |-
+                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                            before being exposed inside Pod. This field will only apply to
+                            volume types which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                            and emptydir.
+                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxChangePolicy:
+                          description: |-
+                            seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                            It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                            Valid values are "MountOption" and "Recursive".
+
+                            "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                            This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                            "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                            This requires all Pods that share the same volume to use the same SELinux label.
+                            It is not possible to share the same volume among privileged and unprivileged Pods.
+                            Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                            whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                            CSIDriver instance. Other volumes are always re-labelled recursively.
+                            "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                            If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                            If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                            and "Recursive" for all other volumes.
+
+                            This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                            All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in SecurityContext.  If set in
+                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        supplementalGroups:
+                          description: |-
+                            A list of groups applied to the first process run in each container, in
+                            addition to the container's primary GID and fsGroup (if specified).  If
+                            the SupplementalGroupsPolicy feature is enabled, the
+                            supplementalGroupsPolicy field determines whether these are in addition
+                            to or instead of any group memberships defined in the container image.
+                            If unspecified, no additional groups are added, though group memberships
+                            defined in the container image may still be used, depending on the
+                            supplementalGroupsPolicy field.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        supplementalGroupsPolicy:
+                          description: |-
+                            Defines how supplemental groups of the first container processes are calculated.
+                            Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                            (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                            and the container runtime must implement support for this feature.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        sysctls:
+                          description: |-
+                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                            sysctls (by the container runtime) might fail to launch.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options within a container's SecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    tolerations:
+                      description: Tolerations for pod scheduling.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: TopologySpreadConstraints for pod scheduling.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread
+                          matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: |-
+                              LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine the number of pods
+                              in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: |-
+                              MatchLabelKeys is a set of pod label keys to select the pods over which
+                              spreading will be calculated. The keys are used to lookup values from the
+                              incoming pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading will be calculated
+                              for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                              MatchLabelKeys cannot be set when LabelSelector isn't set.
+                              Keys that don't exist in the incoming pod labels will
+                              be ignored. A null or empty list means only match against labelSelector.
+
+                              This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: |-
+                              MaxSkew describes the degree to which pods may be unevenly distributed.
+                              When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                              between the number of matching pods in the target topology and the global minimum.
+                              The global minimum is the minimum number of matching pods in an eligible domain
+                              or zero if the number of eligible domains is less than MinDomains.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 2/2/1:
+                              In this case, the global minimum is 1.
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |   P   |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                              scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                              violate MaxSkew(1).
+                              - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                              to topologies that satisfy it.
+                              It's a required field. Default value is 1 and 0 is not allowed.
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains.
+                              When the number of eligible domains with matching topology keys is less than minDomains,
+                              Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                              And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                              this value has no effect on scheduling.
+                              As a result, when the number of eligible domains is less than minDomains,
+                              scheduler won't schedule more than maxSkew Pods to those domains.
+                              If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                              Valid values are integers greater than 0.
+                              When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                              labelSelector spread as 2/2/2:
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |  P P  |
+                              The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                              In this situation, new pod with the same labelSelector cannot be scheduled,
+                              because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                              it will violate MaxSkew.
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                              when calculating pod topology spread skew. Options are:
+                              - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                              - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                              If this value is nil, the behavior is equivalent to the Honor policy.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating
+                              pod topology spread skew. Options are:
+                              - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                              has a toleration, are included.
+                              - Ignore: node taints are ignored. All nodes are included.
+
+                              If this value is nil, the behavior is equivalent to the Ignore policy.
+                            type: string
+                          topologyKey:
+                            description: |-
+                              TopologyKey is the key of node labels. Nodes that have a label with this key
+                              and identical values are considered to be in the same topology.
+                              We consider each <key, value> as a "bucket", and try to put balanced number
+                              of pods into each bucket.
+                              We define a domain as a particular instance of a topology.
+                              Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                              nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                              And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                              It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                              the spread constraint.
+                              - DoNotSchedule (default) tells the scheduler not to schedule it.
+                              - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod
+                              if and only if every possible node assignment for that pod would violate
+                              "MaxSkew" on some topology.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 3/1/1:
+                              | zone1 | zone2 | zone3 |
+                              | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                              to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                              MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                              won't make it *more* imbalanced.
+                              It's a required field.
+                            type: string
+                        required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                        type: object
+                      type: array
+                  required:
+                    - data
+                    - metadata
+                    - replicas
+                  type: object
+                webApi:
+                  description: |-
+                    WebAPI configures the static website hosting endpoint.
+                    Enabled by default with rootDomain ".<name>.<namespace>.svc".
+                    Set webApi.enabled: false to turn off.
+                  properties:
+                    addHostToMetrics:
+                      description: AddHostToMetrics adds the domain name to metrics
+                        labels for per-domain tracking.
+                      type: boolean
+                    bindAddress:
+                      description: BindAddress is a custom bind address for the Web
+                        API.
+                      type: string
+                    bindPort:
+                      default: 3902
+                      description: BindPort is the port to bind for web serving.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    enabled:
+                      description: Enabled controls whether the web endpoint is active.
+                        Defaults to true.
+                      type: boolean
+                    rootDomain:
+                      description: RootDomain is the root domain suffix for bucket
+                        website access.
+                      type: string
+                  type: object
+                workers:
+                  description: Workers configures Garage background worker behavior.
+                  properties:
+                    resyncTranquility:
+                      description: ResyncTranquility controls how aggressively the
+                        block resync worker runs.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resyncWorkerCount:
+                      description: ResyncWorkerCount sets the number of parallel block
+                        resync worker goroutines.
+                      format: int32
+                      maximum: 8
+                      minimum: 1
+                      type: integer
+                    scrubTranquility:
+                      description: ScrubTranquility controls how aggressively the
+                        block integrity scrub runs.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                  type: object
+                zone:
+                  description: |-
+                    Zone is the Garage layout zone assigned to all nodes in this cluster.
+                    Each cluster in a federation must have a unique zone name.
+                  type: string
+              type: object
+              x-kubernetes-validations:
+                - message: at least one of spec.storage, spec.gateway, or spec.connectTo
+                    must be set
+                  rule: has(self.storage) || has(self.gateway) || has(self.connectTo)
+                - message: spec.gateway requires either spec.storage (unified cluster)
+                    or spec.connectTo (edge gateway)
+                  rule: '!has(self.gateway) || has(self.storage) || has(self.connectTo)'
+            status:
+              description: GarageClusterStatus defines the observed state of GarageCluster.
+              properties:
+                activeRepairs:
+                  description: ActiveRepairs contains currently running repair operations.
+                  items:
+                    description: RepairStatus contains status of a repair operation.
+                    properties:
+                      nodeId:
+                        description: NodeID is the node running this repair.
+                        type: string
+                      progress:
+                        description: Progress is a human-readable progress description.
+                        type: string
+                      startedAt:
+                        description: StartedAt is when the repair started.
+                        format: date-time
+                        type: string
+                      type:
+                        description: Type is the repair operation type (Tables, Blocks,
+                          Scrub, Rebalance, etc.)
+                        type: string
+                    type: object
+                  type: array
+                blockErrorDetails:
+                  description: BlockErrorDetails provides detailed information about
+                    block errors.
+                  properties:
+                    count:
+                      description: Count is the total number of blocks with errors.
+                      format: int32
+                      type: integer
+                    lastErrorAt:
+                      description: LastErrorAt is when the most recent block error
+                        occurred.
+                      format: date-time
+                      type: string
+                    topErrors:
+                      description: TopErrors contains details about the most problematic
+                        blocks.
+                      items:
+                        description: BlockErrorDetail contains information about a
+                          specific block error.
+                        properties:
+                          blockHash:
+                            description: BlockHash is the hash of the affected block.
+                            type: string
+                          errorCount:
+                            description: ErrorCount is the number of times this block
+                              failed to sync.
+                            format: int32
+                            type: integer
+                          lastAttempt:
+                            description: LastAttempt is when the last sync attempt
+                              occurred.
+                            format: date-time
+                            type: string
+                          lastError:
+                            description: LastError is the most recent error message
+                              for this block.
+                            type: string
+                          nextRetry:
+                            description: NextRetry is when the next sync retry is
+                              scheduled.
+                            format: date-time
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                blockErrors:
+                  description: BlockErrors is the count of blocks with sync errors
+                    across all nodes.
+                  format: int32
+                  type: integer
+                buildInfo:
+                  description: BuildInfo contains Garage build information.
+                  properties:
+                    features:
+                      description: Features lists enabled Cargo features.
+                      items:
+                        type: string
+                      type: array
+                    rustVersion:
+                      description: RustVersion is the Rust compiler version used to
+                        build Garage.
+                      type: string
+                    version:
+                      description: Version is the Garage version string.
+                      type: string
+                  type: object
+                clusterId:
+                  description: ClusterID is the unique identifier of the Garage cluster.
+                  type: string
                 conditions:
-                  description: Conditions represent the current state
+                  description: Conditions represent the current state of the cluster.
                   items:
                     description: Condition contains details for one aspect of the
                       current state of this API Resource.
@@ -10737,85 +13335,642 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
-                createdAt:
-                  description: CreatedAt is when the key was created in Garage
-                  format: date-time
-                  type: string
-                effectivePermissions:
-                  description: EffectivePermissions shows merged permissions from
-                    both bucket and key definitions
+                drainingNodes:
+                  description: DrainingNodes is the count of nodes that are draining
+                    data from an older layout version.
+                  type: integer
+                endpoints:
+                  description: Endpoints contains service endpoints.
+                  properties:
+                    admin:
+                      description: Admin is the admin API endpoint.
+                      type: string
+                    k2v:
+                      description: K2V is the K2V API endpoint.
+                      type: string
+                    metrics:
+                      description: Metrics is the Prometheus metrics endpoint.
+                      type: string
+                    rpc:
+                      description: RPC is the internal RPC endpoint.
+                      type: string
+                    s3:
+                      description: S3 is the S3 API endpoint.
+                      type: string
+                    web:
+                      description: Web is the web hosting endpoint.
+                      type: string
+                  type: object
+                factorMigration:
+                  description: |-
+                    FactorMigration tracks an in-flight coordinated replication-factor migration
+                    (the garage.rajsingh.info/purge-cluster-layout operation). Nil when no
+                    migration has run.
+                  properties:
+                    completedAt:
+                      description: CompletedAt is when the migration finished (Completed
+                        or Failed).
+                      format: date-time
+                      type: string
+                    force:
+                      description: |-
+                        Force records whether the trigger carried the ,force flag (overriding the
+                        dangerous-mode / pending-tombstone guards). Captured at start because the
+                        annotation is consumed immediately.
+                      type: boolean
+                    fromFactor:
+                      description: FromFactor is the replication factor before the
+                        migration.
+                      type: integer
+                    message:
+                      description: Message is a human-readable description of the
+                        current phase or failure.
+                      type: string
+                    phase:
+                      description: Phase is the current migration phase.
+                      enum:
+                        - Validating
+                        - ScalingDown
+                        - Purging
+                        - Verifying
+                        - RebuildingLayout
+                        - Converging
+                        - Completed
+                        - Failed
+                      type: string
+                    phaseStartedAt:
+                      description: |-
+                        PhaseStartedAt is when the current Phase was entered. It is reset on every
+                        phase transition and bounds each wait phase independently of the overall
+                        migration duration, so a single phase that hangs (e.g. a node whose
+                        status.nodeId never repopulates after restart) trips the stuck guard
+                        rather than the whole migration sharing one global deadline.
+                      format: date-time
+                      type: string
+                    purgeId:
+                      description: |-
+                        PurgeID uniquely identifies this migration; it is the marker-file suffix the
+                        per-node init container uses so the on-disk cluster_layout is deleted exactly
+                        once even across extra restarts.
+                      type: string
+                    startedAt:
+                      description: StartedAt is when the migration began.
+                      format: date-time
+                      type: string
+                    toFactor:
+                      description: ToFactor is the target replication factor.
+                      type: integer
+                  type: object
+                gatewayNodesNotInLayout:
+                  description: "GatewayNodesNotInLayout lists operator-owned gateway\
+                    \ GarageNodes that report\nstatus.inLayout == false \u2014 they\
+                    \ have lost the capacity:nil layout role that\nkeeps S3 sig-auth\
+                    \ local (#209) and have silently degraded to quorum auth.\nDrives\
+                    \ the GatewayLayoutDegraded condition. Empty when every gateway\
+                    \ node\nholds its role."
                   items:
-                    description: EffectivePermission shows the resolved permission
-                      for a bucket
-                    properties:
-                      bucketAlias:
-                        description: BucketAlias is the bucket's global alias (if
-                          set)
-                        type: string
-                      bucketId:
-                        description: BucketID is the bucket ID
-                        type: string
-                      owner:
-                        description: Owner permission
-                        type: boolean
-                      read:
-                        description: Read permission
-                        type: boolean
-                      source:
-                        description: Source indicates where this permission was defined
-                          ("bucket", "key", or "both")
-                        type: string
-                      write:
-                        description: Write permission
-                        type: boolean
-                    type: object
+                    type: string
                   type: array
-                expiration:
-                  description: Expiration is when this key expires (if set)
+                gatewayReadyReplicas:
+                  description: GatewayReadyReplicas is the number of ready gateway-tier
+                    pods.
+                  format: int32
+                  type: integer
+                gatewayReplicas:
+                  description: GatewayReplicas is the desired gateway-tier replica
+                    count.
+                  format: int32
+                  type: integer
+                health:
+                  description: Health contains cluster health information.
+                  properties:
+                    available:
+                      description: Available indicates if quorum is available.
+                      type: boolean
+                    connectedNodes:
+                      description: ConnectedNodes is the number of currently connected
+                        nodes.
+                      type: integer
+                    healthy:
+                      description: Healthy indicates if all nodes are connected.
+                      type: boolean
+                    knownNodes:
+                      description: KnownNodes is the number of nodes seen in cluster.
+                      type: integer
+                    partitions:
+                      description: Partitions is the total partitions in layout.
+                      type: integer
+                    partitionsAllOk:
+                      description: PartitionsAllOK is partitions with all nodes connected.
+                      type: integer
+                    partitionsQuorum:
+                      description: PartitionsQuorum is partitions with quorum connectivity.
+                      type: integer
+                    status:
+                      description: Status is the overall cluster status.
+                      type: string
+                    storageNodes:
+                      description: StorageNodes is the number of storage nodes in
+                        layout.
+                      type: integer
+                    storageNodesOk:
+                      description: StorageNodesOK is the number of connected storage
+                        nodes.
+                      type: integer
+                  type: object
+                lastOperation:
+                  description: LastOperation records the result of the most recently
+                    triggered operational annotation.
+                  properties:
+                    error:
+                      description: Error contains the error message when Succeeded
+                        is false.
+                      type: string
+                    succeeded:
+                      description: Succeeded indicates the operation completed without
+                        error.
+                      type: boolean
+                    triggeredAt:
+                      description: TriggeredAt is when the operation was triggered.
+                      format: date-time
+                      type: string
+                    type:
+                      description: Type is the operation type.
+                      type: string
+                  type: object
+                layoutDiagnosis:
+                  description: |-
+                    LayoutDiagnosis is a one-line, human-readable summary of the most severe
+                    active health condition (quorum at risk, remote clusters stale, federation
+                    misconfigured). Empty when the cluster is healthy. Surfaced as a printcolumn
+                    so `kubectl get gc` shows the actionable problem at a glance.
                   type: string
-                expired:
-                  description: Expired indicates if this key has expired
-                  type: boolean
-                keyId:
-                  description: KeyID is the Garage-assigned key ID
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation
+                layoutHistory:
+                  description: LayoutHistory contains layout version history.
+                  properties:
+                    currentVersion:
+                      description: CurrentVersion is the current layout version.
+                      format: int64
+                      type: integer
+                    minAck:
+                      description: MinAck is the minimum acknowledged layout version
+                        by all nodes.
+                      format: int64
+                      type: integer
+                    versions:
+                      description: Versions contains the history of layout versions.
+                      items:
+                        description: LayoutVersionInfo contains information about
+                          a layout version.
+                        properties:
+                          gatewayNodes:
+                            description: GatewayNodes is the number of gateway nodes
+                              in this version.
+                            type: integer
+                          status:
+                            description: Status is the version status (Current, Draining,
+                              Historical).
+                            type: string
+                          storageNodes:
+                            description: StorageNodes is the number of storage nodes
+                              in this version.
+                            type: integer
+                          version:
+                            description: Version is the layout version number.
+                            format: int64
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                layoutPreview:
+                  description: LayoutPreview shows what would change if staged layout
+                    is applied.
+                  properties:
+                    dataTransferEstimate:
+                      description: DataTransferEstimate is a human-readable estimate
+                        of data movement.
+                      type: string
+                    nodesAdded:
+                      description: NodesAdded shows node IDs that would be added to
+                        the layout.
+                      items:
+                        type: string
+                      type: array
+                    nodesModified:
+                      description: NodesModified shows node IDs with changed configuration.
+                      items:
+                        type: string
+                      type: array
+                    nodesRemoved:
+                      description: NodesRemoved shows node IDs that would be removed
+                        from the layout.
+                      items:
+                        type: string
+                      type: array
+                    partitionTransfers:
+                      description: PartitionTransfers is the estimated number of partition
+                        transfers.
+                      format: int32
+                      type: integer
+                    zonesAffected:
+                      description: ZonesAffected shows which zones would be affected
+                        by the changes.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                layoutVersion:
+                  description: LayoutVersion is the current layout version.
                   format: int64
                   type: integer
-                permissions:
-                  description: Permissions shows the current permissions for this
-                    key
+                lifecycleStatus:
+                  description: LifecycleStatus contains the status of bucket lifecycle
+                    operations.
                   properties:
-                    createBucket:
-                      description: CreateBucket allows this key to create new buckets
-                        via the S3 CreateBucket API
-                      type: boolean
+                    lastCompleted:
+                      description: LastCompleted is when the last lifecycle worker
+                        run completed.
+                      format: date-time
+                      type: string
                   type: object
+                nodes:
+                  description: Nodes contains status information for each node.
+                  items:
+                    description: NodeStatus contains status information for a Garage
+                      node.
+                    properties:
+                      capacity:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Capacity is the storage capacity of the node.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      connected:
+                        description: Connected indicates if the node is connected
+                          to the cluster.
+                        type: boolean
+                      dataDiskAvailable:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: DataDiskAvailable is the available space on data
+                          disk.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      dataDiskTotal:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: DataDiskTotal is the total space on data disk.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      gateway:
+                        description: Gateway indicates if the node is gateway-only.
+                        type: boolean
+                      metadataDiskAvailable:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: MetadataDiskAvailable is the available space
+                          on metadata disk.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      metadataDiskTotal:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: MetadataDiskTotal is the total space on metadata
+                          disk.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      nodeId:
+                        description: NodeID is the public key of the node.
+                        type: string
+                      podName:
+                        description: PodName is the name of the pod running this node.
+                        type: string
+                      tier:
+                        description: Tier is "storage" or "gateway" depending on which
+                          tier this node belongs to.
+                        type: string
+                      version:
+                        description: Version is the Garage version running on this
+                          node.
+                        type: string
+                      zone:
+                        description: Zone is the zone assignment of the node.
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                pendingGatewayTombstones:
+                  description: |-
+                    PendingGatewayTombstones lists stale gateway layout entries pending removal.
+                    Populated when gateway tombstone cleanup detects orphaned entries but cannot
+                    remove them automatically (e.g. layoutManagement.autoApply is false).
+                  items:
+                    type: string
+                  type: array
                 phase:
-                  description: Phase represents the current phase
+                  description: Phase represents the current phase of the cluster.
+                  enum:
+                    - Pending
+                    - Creating
+                    - Running
+                    - Ready
+                    - Degraded
+                    - Updating
+                    - Deleting
+                    - Failed
+                    - Unknown
                   type: string
-                secretRef:
-                  description: SecretRef references the created secret
+                readyReplicas:
+                  description: ReadyReplicas is the number of ready Garage pods.
+                  format: int32
+                  type: integer
+                remoteClusters:
+                  description: RemoteClusters contains status of remote clusters in
+                    the federation.
+                  items:
+                    description: RemoteClusterStatus is the status of a remote cluster.
+                    properties:
+                      connected:
+                        description: Connected indicates if we can reach this cluster.
+                        type: boolean
+                      healthyNodes:
+                        description: HealthyNodes is the number of healthy nodes.
+                        type: integer
+                      lastSeen:
+                        description: LastSeen is when we last successfully connected.
+                        format: date-time
+                        type: string
+                      name:
+                        description: Name is the cluster name.
+                        type: string
+                      nodes:
+                        description: Nodes is the number of nodes in this cluster.
+                        type: integer
+                      zone:
+                        description: Zone is the cluster's zone.
+                        type: string
+                    type: object
+                  type: array
+                replicas:
+                  description: |-
+                    Replicas is the total number of Garage pods targeted by this cluster
+                    (storage + gateway tiers combined).
+                  format: int32
+                  type: integer
+                resyncQueueLength:
+                  description: ResyncQueueLength is the total block resync queue depth
+                    across all nodes.
+                  format: int64
+                  type: integer
+                scrubStatus:
+                  description: ScrubStatus contains the status of data scrub operations.
                   properties:
-                    name:
-                      description: name is unique within a namespace to reference
-                        a secret resource.
+                    corruptedBlocks:
+                      description: CorruptedBlocks is the number of corrupted blocks
+                        found in the last scrub.
+                      format: int32
+                      type: integer
+                    lastCompleted:
+                      description: LastCompleted is when the last scrub completed.
+                      format: date-time
                       type: string
-                    namespace:
-                      description: namespace defines the space within which the secret
-                        name must be unique.
+                    nextRun:
+                      description: NextRun is when the next scrub is scheduled to
+                        run.
+                      format: date-time
                       type: string
+                    nodeStatuses:
+                      description: NodeStatuses contains per-node scrub status.
+                      items:
+                        description: NodeScrubStatus contains scrub status for a single
+                          node.
+                        properties:
+                          errorsFound:
+                            description: ErrorsFound is the number of errors found
+                              on this node.
+                            format: int32
+                            type: integer
+                          itemsChecked:
+                            description: ItemsChecked is the number of items checked.
+                            format: int64
+                            type: integer
+                          nodeId:
+                            description: NodeID is the node identifier.
+                            type: string
+                          progress:
+                            description: Progress percentage (0-100).
+                            type: integer
+                          running:
+                            description: Running indicates if scrub is running on
+                              this node.
+                            type: boolean
+                        type: object
+                      type: array
+                    paused:
+                      description: Paused indicates if the scrub is paused.
+                      type: boolean
+                    progress:
+                      description: Progress is a human-readable progress description.
+                      type: string
+                    running:
+                      description: Running indicates if a scrub is currently running
+                        on any node.
+                      type: boolean
+                    tranquilityLevel:
+                      description: TranquilityLevel is the current tranquility setting.
+                      type: integer
                   type: object
-                  x-kubernetes-map-type: atomic
+                selector:
+                  description: Selector is the serialized label selector for pods
+                    managed by this cluster.
+                  type: string
+                stagedLayoutVersion:
+                  description: StagedLayoutVersion is the staged layout version pending
+                    application.
+                  format: int64
+                  type: integer
+                stagedRoles:
+                  description: StagedRoles is the number of roles in the staged layout.
+                  format: int32
+                  type: integer
+                storageReadyReplicas:
+                  description: StorageReadyReplicas is the number of ready storage-tier
+                    pods.
+                  format: int32
+                  type: integer
+                storageReplicas:
+                  description: StorageReplicas is the desired storage-tier replica
+                    count.
+                  format: int32
+                  type: integer
+                storageStats:
+                  description: StorageStats contains cluster-wide storage statistics.
+                  properties:
+                    availableCapacity:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: AvailableCapacity is the available storage across
+                        all nodes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    healthyPartitions:
+                      description: HealthyPartitions is the number of partitions with
+                        full redundancy.
+                      format: int32
+                      type: integer
+                    totalCapacity:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: TotalCapacity is the total storage capacity across
+                        all nodes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    totalPartitions:
+                      description: TotalPartitions is the total number of partitions
+                        in the layout.
+                      format: int32
+                      type: integer
+                    usedCapacity:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: UsedCapacity is the used storage across all nodes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                totalNodes:
+                  description: TotalNodes is the total nodes across all clusters (local
+                    + remote).
+                  type: integer
+                unreachablePeers:
+                  description: |-
+                    UnreachablePeers lists peers that have been continuously down beyond the
+                    sustained-unreachable threshold, each as "<shortNodeId> (down <duration>)".
+                    Drives the PeerUnreachable condition. Empty when all peers are reachable.
+                  items:
+                    type: string
+                  type: array
+                workerCount:
+                  description: WorkerCount is the total number of background workers.
+                  format: int32
+                  type: integer
+                workers:
+                  description: Workers contains detailed information about background
+                    workers.
+                  properties:
+                    busy:
+                      description: Busy is the number of busy/active workers.
+                      format: int32
+                      type: integer
+                    errored:
+                      description: Errored is the number of workers with errors.
+                      format: int32
+                      type: integer
+                    errors:
+                      description: Errors contains details about worker errors.
+                      items:
+                        description: WorkerError contains information about a worker
+                          error.
+                        properties:
+                          consecutiveErrors:
+                            description: ConsecutiveErrors is the count of consecutive
+                              errors.
+                            format: int32
+                            type: integer
+                          lastError:
+                            description: LastError is the last error message.
+                            type: string
+                          lastErrorSecsAgo:
+                            description: LastErrorSecsAgo is seconds since the last
+                              error.
+                            format: int64
+                            type: integer
+                          name:
+                            description: Name is the worker name.
+                            type: string
+                          workerId:
+                            description: WorkerID is the worker identifier.
+                            format: int64
+                            type: integer
+                        type: object
+                      type: array
+                    idle:
+                      description: Idle is the number of idle workers.
+                      format: int32
+                      type: integer
+                    total:
+                      description: Total is the total number of background workers.
+                      format: int32
+                      type: integer
+                    variables:
+                      additionalProperties:
+                        type: string
+                      description: Variables contains runtime worker configuration
+                        variables.
+                      type: object
+                  type: object
+                workersFailed:
+                  description: WorkersFailed is the number of failed workers.
+                  format: int32
+                  type: integer
+              required:
+                - replicas
+                - selector
               type: object
           required:
             - spec
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
+        scale:
+          labelSelectorPath: .status.selector
+          specReplicasPath: .spec.storage.replicas
+          statusReplicasPath: .status.storageReplicas
         status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: appcat
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: garage-operator
+    app.kubernetes.io/version: 0.6.15
+    control-plane: controller-manager
+    helm.sh/chart: garage-operator-0.6.15
+  name: garagekeys.garage.rajsingh.info
+spec:
+  group: garage.rajsingh.info
+  names:
+    kind: GarageKey
+    listKind: GarageKeyList
+    plural: garagekeys
+    shortNames:
+      - gk
+    singular: garagekey
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
     - additionalPrinterColumns:
         - jsonPath: .spec.clusterRef.name
           name: Cluster
@@ -10873,12 +14028,15 @@ spec:
                     \ by the\noperator (created directly via the S3 API). Plan accordingly."
                   properties:
                     owner:
+                      default: false
                       description: Owner allows bucket owner operations on all buckets
                       type: boolean
                     read:
+                      default: false
                       description: Read allows reading objects from all buckets
                       type: boolean
                     write:
+                      default: false
                       description: Write allows writing objects to all buckets
                       type: boolean
                   type: object
@@ -10926,13 +14084,16 @@ spec:
                           alias.
                         type: string
                       owner:
+                        default: false
                         description: Owner allows bucket owner operations (delete
                           bucket, configure website, etc.)
                         type: boolean
                       read:
+                        default: false
                         description: Read allows reading objects from the bucket.
                         type: boolean
                       write:
+                        default: false
                         description: Write allows writing objects to the bucket.
                         type: boolean
                     type: object
@@ -11051,6 +14212,7 @@ spec:
                     Note: For admin API access, use admin tokens configured in GarageCluster
                   properties:
                     createBucket:
+                      default: false
                       description: CreateBucket allows this key to create new buckets
                         via the S3 CreateBucket API
                       type: boolean
@@ -11148,12 +14310,15 @@ spec:
                           bucket
                         type: string
                       owner:
+                        default: false
                         description: Owner permission
                         type: boolean
                       read:
+                        default: false
                         description: Read permission
                         type: boolean
                       write:
+                        default: false
                         description: Write permission
                         type: boolean
                     type: object
@@ -11242,9 +14407,11 @@ spec:
                         description: BucketID is the bucket ID
                         type: string
                       owner:
+                        default: false
                         description: Owner permission
                         type: boolean
                       read:
+                        default: false
                         description: Read permission
                         type: boolean
                       source:
@@ -11252,6 +14419,7 @@ spec:
                           ("bucket", "key", or "both")
                         type: string
                       write:
+                        default: false
                         description: Write permission
                         type: boolean
                     type: object
@@ -11272,6 +14440,7 @@ spec:
                     key
                   properties:
                     createBucket:
+                      default: false
                       description: CreateBucket allows this key to create new buckets
                         via the S3 CreateBucket API
                       type: boolean
@@ -11313,15 +14482,15 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: garagenodes.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info
@@ -11334,1499 +14503,13 @@ spec:
     singular: garagenode
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.clusterRef.name
-          name: Cluster
-          type: string
-        - jsonPath: .spec.zone
-          name: Zone
-          type: string
-        - jsonPath: .spec.capacity
-          name: Capacity
-          type: string
-        - jsonPath: .spec.gateway
-          name: Gateway
-          type: boolean
-        - jsonPath: .status.connected
-          name: Connected
-          type: boolean
-        - jsonPath: .status.inLayout
-          name: InLayout
-          type: boolean
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
+    - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: GarageNode is the Schema for the garagenodes API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: |-
-                GarageNodeSpec defines the desired state of GarageNode.
-
-                GarageNode represents a node in the Garage cluster. When the parent GarageCluster
-                has layoutPolicy: Manual, each GarageNode creates its own StatefulSet (replica 1)
-                with independent storage configuration.
-
-                Use GarageNode when you need:
-                - Heterogeneous storage (different storage classes per node)
-                - Per-node resource configuration
-                - Fine-grained zone/capacity control
-                - External nodes (VMs, other K8s clusters)
-
-                Pod configuration (resources, nodeSelector, tolerations, etc.) is inherited from
-                the parent GarageCluster and can be overridden per-node.
-              properties:
-                affinity:
-                  description: |-
-                    Affinity overrides pod affinity rules.
-                    If not specified, inherits from GarageCluster.
-                  properties:
-                    nodeAffinity:
-                      description: Describes node affinity scheduling rules for the
-                        pod.
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            The scheduler will prefer to schedule pods to nodes that satisfy
-                            the affinity expressions specified by this field, but it may choose
-                            a node that violates one or more of the expressions. The node that is
-                            most preferred is the one with the greatest sum of weights, i.e.
-                            for each node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions, etc.),
-                            compute a sum by iterating through the elements of this field and adding
-                            "weight" to the sum if the node matches the corresponding matchExpressions; the
-                            node(s) with the highest sum are the most preferred.
-                          items:
-                            description: |-
-                              An empty preferred scheduling term matches all objects with implicit weight 0
-                              (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                            properties:
-                              preference:
-                                description: A node selector term, associated with
-                                  the corresponding weight.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              weight:
-                                description: Weight associated with matching the corresponding
-                                  nodeSelectorTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            If the affinity requirements specified by this field are not met at
-                            scheduling time, the pod will not be scheduled onto the node.
-                            If the affinity requirements specified by this field cease to be met
-                            at some point during pod execution (e.g. due to an update), the system
-                            may or may not try to eventually evict the pod from its node.
-                          properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms.
-                                The terms are ORed.
-                              items:
-                                description: |-
-                                  A null or empty node selector term matches no objects. The requirements of
-                                  them are ANDed.
-                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                            - nodeSelectorTerms
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      type: object
-                    podAffinity:
-                      description: Describes pod affinity scheduling rules (e.g. co-locate
-                        this pod in the same node, zone, etc. as some other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            The scheduler will prefer to schedule pods to nodes that satisfy
-                            the affinity expressions specified by this field, but it may choose
-                            a node that violates one or more of the expressions. The node that is
-                            most preferred is the one with the greatest sum of weights, i.e.
-                            for each node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions, etc.),
-                            compute a sum by iterating through the elements of this field and adding
-                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                            node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: |-
-                                      A label query over a set of resources, in this case pods.
-                                      If it's null, this PodAffinityTerm matches with no Pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  matchLabelKeys:
-                                    description: |-
-                                      MatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  mismatchLabelKeys:
-                                    description: |-
-                                      MismatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  namespaceSelector:
-                                    description: |-
-                                      A label query over the set of namespaces that the term applies to.
-                                      The term is applied to the union of the namespaces selected by this field
-                                      and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list means "this pod's namespace".
-                                      An empty selector ({}) matches all namespaces.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  namespaces:
-                                    description: |-
-                                      namespaces specifies a static list of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces listed in this field
-                                      and the ones selected by namespaceSelector.
-                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  topologyKey:
-                                    description: |-
-                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey matches that of any node on which any of the
-                                      selected pods is running.
-                                      Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: |-
-                                  weight associated with matching the corresponding podAffinityTerm,
-                                  in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            If the affinity requirements specified by this field are not met at
-                            scheduling time, the pod will not be scheduled onto the node.
-                            If the affinity requirements specified by this field cease to be met
-                            at some point during pod execution (e.g. due to a pod label update), the
-                            system may or may not try to eventually evict the pod from its node.
-                            When there are multiple elements, the lists of nodes corresponding to each
-                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: |-
-                              Defines a set of pods (namely those matching the labelSelector
-                              relative to the given namespace(s)) that this pod should be
-                              co-located (affinity) or not co-located (anti-affinity) with,
-                              where co-located is defined as running on a node whose value of
-                              the label with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: |-
-                                  A label query over a set of resources, in this case pods.
-                                  If it's null, this PodAffinityTerm matches with no Pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: |-
-                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                        relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            operator represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            values is an array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: |-
-                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              matchLabelKeys:
-                                description: |-
-                                  MatchLabelKeys is a set of pod label keys to select which pods will
-                                  be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                  to select the group of existing pods which pods will be taken into consideration
-                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                  pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              mismatchLabelKeys:
-                                description: |-
-                                  MismatchLabelKeys is a set of pod label keys to select which pods will
-                                  be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                  to select the group of existing pods which pods will be taken into consideration
-                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                  pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              namespaceSelector:
-                                description: |-
-                                  A label query over the set of namespaces that the term applies to.
-                                  The term is applied to the union of the namespaces selected by this field
-                                  and the ones listed in the namespaces field.
-                                  null selector and null or empty namespaces list means "this pod's namespace".
-                                  An empty selector ({}) matches all namespaces.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: |-
-                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                        relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            operator represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            values is an array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: |-
-                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              namespaces:
-                                description: |-
-                                  namespaces specifies a static list of namespace names that the term applies to.
-                                  The term is applied to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector.
-                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              topologyKey:
-                                description: |-
-                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches that of any node on which any of the
-                                  selected pods is running.
-                                  Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      type: object
-                    podAntiAffinity:
-                      description: Describes pod anti-affinity scheduling rules (e.g.
-                        avoid putting this pod in the same node, zone, etc. as some
-                        other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            The scheduler will prefer to schedule pods to nodes that satisfy
-                            the anti-affinity expressions specified by this field, but it may choose
-                            a node that violates one or more of the expressions. The node that is
-                            most preferred is the one with the greatest sum of weights, i.e.
-                            for each node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling anti-affinity expressions, etc.),
-                            compute a sum by iterating through the elements of this field and subtracting
-                            "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                            node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: |-
-                                      A label query over a set of resources, in this case pods.
-                                      If it's null, this PodAffinityTerm matches with no Pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  matchLabelKeys:
-                                    description: |-
-                                      MatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  mismatchLabelKeys:
-                                    description: |-
-                                      MismatchLabelKeys is a set of pod label keys to select which pods will
-                                      be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                      to select the group of existing pods which pods will be taken into consideration
-                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                      pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  namespaceSelector:
-                                    description: |-
-                                      A label query over the set of namespaces that the term applies to.
-                                      The term is applied to the union of the namespaces selected by this field
-                                      and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list means "this pod's namespace".
-                                      An empty selector ({}) matches all namespaces.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  namespaces:
-                                    description: |-
-                                      namespaces specifies a static list of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces listed in this field
-                                      and the ones selected by namespaceSelector.
-                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  topologyKey:
-                                    description: |-
-                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey matches that of any node on which any of the
-                                      selected pods is running.
-                                      Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: |-
-                                  weight associated with matching the corresponding podAffinityTerm,
-                                  in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: |-
-                            If the anti-affinity requirements specified by this field are not met at
-                            scheduling time, the pod will not be scheduled onto the node.
-                            If the anti-affinity requirements specified by this field cease to be met
-                            at some point during pod execution (e.g. due to a pod label update), the
-                            system may or may not try to eventually evict the pod from its node.
-                            When there are multiple elements, the lists of nodes corresponding to each
-                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: |-
-                              Defines a set of pods (namely those matching the labelSelector
-                              relative to the given namespace(s)) that this pod should be
-                              co-located (affinity) or not co-located (anti-affinity) with,
-                              where co-located is defined as running on a node whose value of
-                              the label with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: |-
-                                  A label query over a set of resources, in this case pods.
-                                  If it's null, this PodAffinityTerm matches with no Pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: |-
-                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                        relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            operator represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            values is an array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: |-
-                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              matchLabelKeys:
-                                description: |-
-                                  MatchLabelKeys is a set of pod label keys to select which pods will
-                                  be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                  to select the group of existing pods which pods will be taken into consideration
-                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                  pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              mismatchLabelKeys:
-                                description: |-
-                                  MismatchLabelKeys is a set of pod label keys to select which pods will
-                                  be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                  to select the group of existing pods which pods will be taken into consideration
-                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                  pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              namespaceSelector:
-                                description: |-
-                                  A label query over the set of namespaces that the term applies to.
-                                  The term is applied to the union of the namespaces selected by this field
-                                  and the ones listed in the namespaces field.
-                                  null selector and null or empty namespaces list means "this pod's namespace".
-                                  An empty selector ({}) matches all namespaces.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: |-
-                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                        relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: |-
-                                            operator represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: |-
-                                            values is an array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array is replaced during a strategic
-                                            merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: |-
-                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              namespaces:
-                                description: |-
-                                  namespaces specifies a static list of namespace names that the term applies to.
-                                  The term is applied to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector.
-                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              topologyKey:
-                                description: |-
-                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches that of any node on which any of the
-                                  selected pods is running.
-                                  Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      type: object
-                  type: object
-                capacity:
-                  anyOf:
-                    - type: integer
-                    - type: string
-                  description: |-
-                    Capacity is the storage capacity to report to Garage for this node.
-                    Required unless Gateway is true.
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                clusterRef:
-                  description: |-
-                    ClusterRef references the GarageCluster this node belongs to.
-                    The GarageNode inherits configuration from this cluster.
-                  properties:
-                    kubeConfigSecretRef:
-                      description: |-
-                        KubeConfigSecretRef references a secret containing kubeconfig for a remote cluster.
-                        Only used for cross-cluster references in multi-cluster federation scenarios.
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          default: ''
-                          description: |-
-                            Name of the referent.
-                            This field is effectively required, but due to backwards compatibility is
-                            allowed to be empty. Instances of this type with an empty value here are
-                            almost certainly wrong.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or its key must
-                            be defined
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    name:
-                      description: Name of the GarageCluster
-                      type: string
-                    namespace:
-                      description: Namespace of the GarageCluster (defaults to the
-                        same namespace as the referencing resource)
-                      type: string
-                  required:
-                    - name
-                  type: object
-                external:
-                  description: |-
-                    External marks this node as an external node (not managed by this operator).
-                    When set, no StatefulSet is created - the node is assumed to exist externally.
-                  properties:
-                    address:
-                      description: Address is the IP or hostname of the external node
-                      type: string
-                    port:
-                      default: 3901
-                      description: Port is the RPC port of the external node
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
-                    remoteClusterRef:
-                      description: RemoteClusterRef references a GarageCluster in
-                        another namespace/cluster
-                      properties:
-                        kubeConfigSecretRef:
-                          description: |-
-                            KubeConfigSecretRef references a secret containing kubeconfig for a remote cluster.
-                            Only used for cross-cluster references in multi-cluster federation scenarios.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              default: ''
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                            - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        name:
-                          description: Name of the GarageCluster
-                          type: string
-                        namespace:
-                          description: Namespace of the GarageCluster (defaults to
-                            the same namespace as the referencing resource)
-                          type: string
-                      required:
-                        - name
-                      type: object
-                  required:
-                    - address
-                  type: object
-                gateway:
-                  description: |-
-                    Gateway marks this node as a gateway-only node (no storage).
-                    Gateway nodes handle API requests but don't store data blocks.
-                  type: boolean
-                image:
-                  description: |-
-                    Image overrides the Garage container image.
-                    If not specified, inherits from GarageCluster.
-                  type: string
-                imageRepository:
-                  description: |-
-                    ImageRepository overrides just the repository portion of the Garage image.
-                    If not specified, inherits from GarageCluster.
-                    Ignored if image is set.
-                  type: string
-                nodeId:
-                  description: |-
-                    NodeID is the public key of the Garage node.
-                    If not specified, the operator will auto-discover from the pod.
-                  type: string
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    NodeSelector overrides node selection constraints.
-                    If not specified, inherits from GarageCluster.
-                  type: object
-                podAnnotations:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    PodAnnotations are additional annotations to add to this node's pod.
-                    Merged with annotations from GarageCluster (node-specific takes precedence).
-                  type: object
-                podLabels:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    PodLabels are additional labels to add to this node's pod.
-                    Merged with labels from GarageCluster (node-specific takes precedence).
-                  type: object
-                priorityClassName:
-                  description: |-
-                    PriorityClassName overrides the priority class for this node's pod.
-                    If not specified, inherits from GarageCluster.
-                  type: string
-                resources:
-                  description: |-
-                    Resources overrides compute resources for the Garage container.
-                    If not specified, inherits from GarageCluster.
-                  properties:
-                    claims:
-                      description: |-
-                        Claims lists the names of resources, defined in spec.resourceClaims,
-                        that are used by this container.
-
-                        This field depends on the
-                        DynamicResourceAllocation feature gate.
-
-                        This field is immutable. It can only be set for containers.
-                      items:
-                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                        properties:
-                          name:
-                            description: |-
-                              Name must match the name of one entry in pod.spec.resourceClaims of
-                              the Pod where this field is used. It makes that resource available
-                              inside a container.
-                            type: string
-                          request:
-                            description: |-
-                              Request is the name chosen for a request in the referenced claim.
-                              If empty, everything from the claim is made available, otherwise
-                              only the result of this request.
-                            type: string
-                        required:
-                          - name
-                        type: object
-                      type: array
-                      x-kubernetes-list-map-keys:
-                        - name
-                      x-kubernetes-list-type: map
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: |-
-                        Limits describes the maximum amount of compute resources allowed.
-                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: |-
-                        Requests describes the minimum amount of compute resources required.
-                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                      type: object
-                  type: object
-                storage:
-                  description: |-
-                    Storage configures storage volumes for this node's StatefulSet.
-                    Required when not using External.
-                  properties:
-                    data:
-                      description: |-
-                        Data volume configuration for block storage.
-                        Ignored if the node is a gateway (Gateway: true).
-                      properties:
-                        existingClaim:
-                          description: |-
-                            ExistingClaim references a pre-existing PVC by name.
-                            The PVC must exist in the same namespace as the GarageCluster.
-                            Mutually exclusive with Size.
-                          type: string
-                        size:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          description: |-
-                            Size for a dynamically provisioned PVC.
-                            The operator will create a PVC with this size if it doesn't exist.
-                            Mutually exclusive with ExistingClaim.
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        storageClassName:
-                          description: |-
-                            StorageClassName for dynamically provisioned PVC.
-                            Only used when Size is specified.
-                            If not specified, the cluster's default storage class is used.
-                          type: string
-                      type: object
-                    metadata:
-                      description: |-
-                        Metadata volume configuration for node identity and cluster state.
-                        Required for all nodes (storage and gateway).
-                      properties:
-                        existingClaim:
-                          description: |-
-                            ExistingClaim references a pre-existing PVC by name.
-                            The PVC must exist in the same namespace as the GarageCluster.
-                            Mutually exclusive with Size.
-                          type: string
-                        size:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          description: |-
-                            Size for a dynamically provisioned PVC.
-                            The operator will create a PVC with this size if it doesn't exist.
-                            Mutually exclusive with ExistingClaim.
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        storageClassName:
-                          description: |-
-                            StorageClassName for dynamically provisioned PVC.
-                            Only used when Size is specified.
-                            If not specified, the cluster's default storage class is used.
-                          type: string
-                      type: object
-                  type: object
-                tags:
-                  description: Tags are custom tags for this node in the Garage layout.
-                  items:
-                    type: string
-                  type: array
-                tolerations:
-                  description: |-
-                    Tolerations overrides pod tolerations.
-                    If not specified, inherits from GarageCluster.
-                  items:
-                    description: |-
-                      The pod this Toleration is attached to tolerates any taint that matches
-                      the triple <key,value,effect> using the matching operator <operator>.
-                    properties:
-                      effect:
-                        description: |-
-                          Effect indicates the taint effect to match. Empty means match all taint effects.
-                          When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: |-
-                          Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                          If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                        type: string
-                      operator:
-                        description: |-
-                          Operator represents a key's relationship to the value.
-                          Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
-                          Exists is equivalent to wildcard for value, so that a pod can
-                          tolerate all taints of a particular category.
-                          Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
-                        type: string
-                      tolerationSeconds:
-                        description: |-
-                          TolerationSeconds represents the period of time the toleration (which must be
-                          of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do not evict). Zero and
-                          negative values will be treated as 0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: |-
-                          Value is the taint value the toleration matches to.
-                          If the operator is Exists, the value should be empty, otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-                zone:
-                  description: |-
-                    Zone is the zone assignment for this node.
-                    Used for data placement and fault tolerance.
-                  type: string
-              required:
-                - clusterRef
-                - zone
-              type: object
-            status:
-              description: GarageNodeStatus defines the observed state of GarageNode
-              properties:
-                address:
-                  description: Address is the node's address in the cluster
-                  type: string
-                blockErrors:
-                  description: BlockErrors is the count of blocks with sync errors
-                    on this node
-                  format: int32
-                  type: integer
-                conditions:
-                  description: Conditions represent the current state
-                  items:
-                    description: Condition contains details for one aspect of the
-                      current state of this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False,
-                          Unknown.
-                        enum:
-                          - 'True'
-                          - 'False'
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                connected:
-                  description: Connected indicates if the node is currently connected
-                  type: boolean
-                dataPartition:
-                  description: |-
-                    DataPartition contains disk space info for the data partition
-                    Note: Garage reports a single partition even with multiple data paths
-                  properties:
-                    available:
-                      description: Available is the available disk space
-                      type: string
-                    total:
-                      description: Total is the total disk space
-                      type: string
-                    usedPercent:
-                      description: UsedPercent is the percentage of disk space used
-                        (0-100)
-                      format: int32
-                      type: integer
-                  type: object
-                dbEngine:
-                  description: DBEngine is the database engine used by this node (lmdb,
-                    sqlite, fjall)
-                  type: string
-                garageFeatures:
-                  description: GarageFeatures lists the enabled Cargo features on
-                    this node
-                  items:
-                    type: string
-                  type: array
-                hostname:
-                  description: Hostname is the hostname reported by this Garage node
-                  type: string
-                inLayout:
-                  description: InLayout indicates if this node is part of the current
-                    layout
-                  type: boolean
-                lastSeen:
-                  description: LastSeen is when the node was last seen connected
-                  format: date-time
-                  type: string
-                layoutVersion:
-                  description: LayoutVersion is the layout version when this node
-                    was added
-                  format: int64
-                  type: integer
-                metadataPartition:
-                  description: MetadataPartition contains disk space info for the
-                    metadata partition
-                  properties:
-                    available:
-                      description: Available is the available disk space
-                      type: string
-                    total:
-                      description: Total is the total disk space
-                      type: string
-                    usedPercent:
-                      description: UsedPercent is the percentage of disk space used
-                        (0-100)
-                      format: int32
-                      type: integer
-                  type: object
-                nodeId:
-                  description: NodeID is the discovered or assigned node ID
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation
-                  format: int64
-                  type: integer
-                partitions:
-                  description: Partitions is the number of partitions assigned to
-                    this node
-                  type: integer
-                phase:
-                  description: Phase represents the current phase
-                  type: string
-                repairInProgress:
-                  description: RepairInProgress indicates if a repair operation is
-                    running
-                  type: boolean
-                repairProgress:
-                  description: RepairProgress is a human-readable repair progress
-                    description
-                  type: string
-                repairType:
-                  description: RepairType is the type of repair operation in progress
-                  type: string
-                storedData:
-                  description: StoredData is the amount of data stored on this node
-                  type: string
-                tags:
-                  description: Tags are the tags assigned to this node in the layout
-                  items:
-                    type: string
-                  type: array
-                version:
-                  description: Version is the Garage version on this node
-                  type: string
-              type: object
-          required:
-            - spec
           type: object
-      served: true
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
       storage: false
-      subresources:
-        status: {}
     - additionalPrinterColumns:
         - jsonPath: .spec.clusterRef.name
           name: Cluster
@@ -13932,7 +15615,6 @@ spec:
                         procMount denotes the type of proc mount to use for the containers.
                         The default value is Default which uses the container runtime defaults for
                         readonly paths and masked paths.
-                        This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
@@ -14052,6 +15734,215 @@ spec:
                           type: string
                       type: object
                   type: object
+                env:
+                  description: |-
+                    Env overrides environment variables for this node's container. Merged with
+                    cluster-level env (from spec.storage.env or spec.gateway.env, depending on
+                    tier); per-node entries take precedence on key collision.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
+                        type: string
+                      value:
+                        description: |-
+                          Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the container and
+                          any service environment variables. If a variable cannot be resolved,
+                          the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                          Escaped references will never be expanded, regardless of whether the variable
+                          exists or not.
+                          Defaults to "".
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                default: ''
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fieldRef:
+                            description: |-
+                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                              - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing
+                                  the env file.
+                                type: string
+                            required:
+                              - key
+                              - path
+                              - volumeName
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          resourceFieldRef:
+                            description: |-
+                              Selects a resource of the container: only resources limits and requests
+                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                              - resource
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ''
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                envFrom:
+                  description: |-
+                    EnvFrom overrides envFrom sources for this node's container. Replaces (does
+                    not merge) the cluster-level envFrom when set.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                      or Secrets
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            default: ''
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      prefix:
+                        description: |-
+                          Optional text to prepend to the name of each environment variable.
+                          May consist of any printable ASCII characters except '='.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            default: ''
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  type: array
                 external:
                   description: |-
                     External marks this node as an external node (not managed by this operator).
@@ -14160,6 +16051,31 @@ spec:
                     If not specified, inherits from GarageCluster.
                     Ignored if image is set.
                   type: string
+                logging:
+                  description: |-
+                    Logging overrides cluster-level spec.logging for this node. A non-nil field
+                    here wins over the cluster value; a nil field falls through to the cluster.
+                  properties:
+                    journald:
+                      description: Journald enables logging to systemd journald. When
+                        nil, inherits cluster-level setting.
+                      type: boolean
+                    level:
+                      description: Level sets the log level using RUST_LOG format.
+                      type: string
+                    syslog:
+                      description: Syslog enables logging to syslog. When nil, inherits
+                        cluster-level setting.
+                      type: boolean
+                  type: object
+                maintenance:
+                  description: Maintenance configures maintenance mode for this node.
+                  properties:
+                    suspended:
+                      description: Suspended pauses operator reconciliation for this
+                        node when true.
+                      type: boolean
+                  type: object
                 network:
                   description: |-
                     Network configures per-node RPC address overrides.
@@ -14601,8 +16517,9 @@ spec:
                     Required for managed nodes (not External).
                   properties:
                     data:
-                      description: Data volume for block storage. Ignored for gateway
-                        nodes.
+                      description: |-
+                        Data volume for block storage. Ignored for gateway nodes.
+                        Mutually exclusive with DataPaths.
                       properties:
                         accessModes:
                           description: |-
@@ -14612,17 +16529,35 @@ spec:
                             type: string
                           type: array
                         existingClaim:
-                          description: |-
-                            ExistingClaim references a pre-existing PVC by name in the cluster namespace.
-                            Mutually exclusive with Size.
+                          description: ExistingClaim references a pre-existing PVC
+                            by name in the cluster namespace.
                           type: string
+                        path:
+                          description: "Path is the in-container mount path for this\
+                            \ volume. Only honored on\nmulti-HDD `storage.dataPaths[]`\
+                            \ entries \u2014 both the K8s volumeMount and\nthe rendered\
+                            \ garage.toml `data_dir = [{ path = ... }]` use this value.\n\
+                            Defaults to `/data/data-<i>` when unset. The legacy-STS\
+                            \ migration\npropagates `cluster.spec.storage.data.paths[i].path`\
+                            \ so that on first\nboot Garage's DataLayout sees the\
+                            \ same paths it stored under\npre-migration, avoiding\
+                            \ partition reassignment and unnecessary\ncross-peer block\
+                            \ refetch (../garage src/block/layout.rs)."
+                          type: string
+                        readOnly:
+                          description: |-
+                            ReadOnly marks the entry as a legacy read-only path on multi-HDD
+                            `storage.dataPaths[]`. Renders as garage.toml `read_only = true`;
+                            no `capacity` is emitted. Ignored on `storage.{metadata,data}`.
+                          type: boolean
                         size:
                           anyOf:
                             - type: integer
                             - type: string
                           description: |-
-                            Size creates a dynamically provisioned PVC with this capacity.
-                            Mutually exclusive with ExistingClaim.
+                            Size creates a dynamically provisioned PVC with this capacity. For
+                            multi-HDD `storage.dataPaths[]` entries it may also be set alongside
+                            `existingClaim` to declare the capacity advertised to Garage.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         storageClassName:
@@ -14648,6 +16583,83 @@ spec:
                         DataFsync enables fsync on data block writes for this node.
                         Overrides the cluster-level storage.dataFsync setting.
                       type: boolean
+                    dataPaths:
+                      description: |-
+                        DataPaths configures multiple data directories for multi-HDD nodes.
+                        Each entry produces a separate volume/mount/PVC at /var/lib/garage/data-<idx>
+                        and the corresponding garage.toml `data_dir = [...]` array form. Use this for
+                        multi-HDD nodes; mutually exclusive with .data.
+                      items:
+                        description: "NodeVolumeConfig defines the source of a storage\
+                          \ volume for a GarageNode.\nParallel to GarageCluster's\
+                          \ VolumeConfig, extended with existingClaim for\npre-provisioned\
+                          \ PVCs. Either ExistingClaim or Size must be specified.\n\
+                          \nExistingClaim and Size may also be set together inside\
+                          \ a multi-HDD\n`storage.dataPaths[]` entry \u2014 there\
+                          \ ExistingClaim binds the PVC and Size\nis the capacity\
+                          \ advertised to Garage in `data_dir = [{path, capacity}]`.\n\
+                          Combining them on `storage.{metadata,data}` is allowed by\
+                          \ the webhook but\nhas no effect since those slots don't\
+                          \ emit a TOML capacity field."
+                        properties:
+                          accessModes:
+                            description: |-
+                              AccessModes for the dynamically provisioned PVC.
+                              Defaults to [ReadWriteOnce] if not specified.
+                            items:
+                              type: string
+                            type: array
+                          existingClaim:
+                            description: ExistingClaim references a pre-existing PVC
+                              by name in the cluster namespace.
+                            type: string
+                          path:
+                            description: "Path is the in-container mount path for\
+                              \ this volume. Only honored on\nmulti-HDD `storage.dataPaths[]`\
+                              \ entries \u2014 both the K8s volumeMount and\nthe rendered\
+                              \ garage.toml `data_dir = [{ path = ... }]` use this\
+                              \ value.\nDefaults to `/data/data-<i>` when unset. The\
+                              \ legacy-STS migration\npropagates `cluster.spec.storage.data.paths[i].path`\
+                              \ so that on first\nboot Garage's DataLayout sees the\
+                              \ same paths it stored under\npre-migration, avoiding\
+                              \ partition reassignment and unnecessary\ncross-peer\
+                              \ block refetch (../garage src/block/layout.rs)."
+                            type: string
+                          readOnly:
+                            description: |-
+                              ReadOnly marks the entry as a legacy read-only path on multi-HDD
+                              `storage.dataPaths[]`. Renders as garage.toml `read_only = true`;
+                              no `capacity` is emitted. Ignored on `storage.{metadata,data}`.
+                            type: boolean
+                          size:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            description: |-
+                              Size creates a dynamically provisioned PVC with this capacity. For
+                              multi-HDD `storage.dataPaths[]` entries it may also be set alongside
+                              `existingClaim` to declare the capacity advertised to Garage.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          storageClassName:
+                            description: |-
+                              StorageClassName for the dynamically provisioned PVC.
+                              Uses the cluster default if not specified.
+                            type: string
+                          type:
+                            allOf:
+                              - enum:
+                                  - PersistentVolumeClaim
+                                  - EmptyDir
+                              - enum:
+                                  - PVC
+                                  - EmptyDir
+                            description: |-
+                              Type specifies the volume type. Defaults to PVC.
+                              Use EmptyDir for ephemeral storage (e.g. testing).
+                            type: string
+                        type: object
+                      type: array
                     metadata:
                       description: Metadata volume for node identity and cluster state.
                       properties:
@@ -14659,17 +16671,35 @@ spec:
                             type: string
                           type: array
                         existingClaim:
-                          description: |-
-                            ExistingClaim references a pre-existing PVC by name in the cluster namespace.
-                            Mutually exclusive with Size.
+                          description: ExistingClaim references a pre-existing PVC
+                            by name in the cluster namespace.
                           type: string
+                        path:
+                          description: "Path is the in-container mount path for this\
+                            \ volume. Only honored on\nmulti-HDD `storage.dataPaths[]`\
+                            \ entries \u2014 both the K8s volumeMount and\nthe rendered\
+                            \ garage.toml `data_dir = [{ path = ... }]` use this value.\n\
+                            Defaults to `/data/data-<i>` when unset. The legacy-STS\
+                            \ migration\npropagates `cluster.spec.storage.data.paths[i].path`\
+                            \ so that on first\nboot Garage's DataLayout sees the\
+                            \ same paths it stored under\npre-migration, avoiding\
+                            \ partition reassignment and unnecessary\ncross-peer block\
+                            \ refetch (../garage src/block/layout.rs)."
+                          type: string
+                        readOnly:
+                          description: |-
+                            ReadOnly marks the entry as a legacy read-only path on multi-HDD
+                            `storage.dataPaths[]`. Renders as garage.toml `read_only = true`;
+                            no `capacity` is emitted. Ignored on `storage.{metadata,data}`.
+                          type: boolean
                         size:
                           anyOf:
                             - type: integer
                             - type: string
                           description: |-
-                            Size creates a dynamically provisioned PVC with this capacity.
-                            Mutually exclusive with ExistingClaim.
+                            Size creates a dynamically provisioned PVC with this capacity. For
+                            multi-HDD `storage.dataPaths[]` entries it may also be set alongside
+                            `existingClaim` to declare the capacity advertised to Garage.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         storageClassName:
@@ -14690,12 +16720,28 @@ spec:
                             Use EmptyDir for ephemeral storage (e.g. testing).
                           type: string
                       type: object
+                    metadataAutoSnapshotInterval:
+                      description: |-
+                        MetadataAutoSnapshotInterval overrides the cluster-level
+                        storage.metadataAutoSnapshotInterval (garage.toml `metadata_auto_snapshot_interval`)
+                        for this node.
+                      pattern: ^(\d+(\.\d+)?\s*(ns|us|ms|s|m|h|d|w|M|y)\s*)+$
+                      type: string
                     metadataFsync:
                       description: |-
                         MetadataFsync enables fsync on metadata writes for this node.
                         Overrides the cluster-level storage.metadataFsync setting.
                       type: boolean
+                    metadataSnapshotsDir:
+                      description: |-
+                        MetadataSnapshotsDir overrides the cluster-level storage.metadataSnapshotsDir
+                        (garage.toml `metadata_snapshots_dir`) for this node.
+                      type: string
                   type: object
+                  x-kubernetes-validations:
+                    - message: storage.data and storage.dataPaths are mutually exclusive
+                      rule: '!(has(self.data) && has(self.dataPaths) && size(self.dataPaths)
+                        > 0)'
                 tags:
                   description: Tags are custom tags for this node in the Garage layout.
                   items:
@@ -14942,6 +16988,42 @@ spec:
                     on this node
                   format: int32
                   type: integer
+                clusterAdminEndpoint:
+                  description: |-
+                    ClusterAdminEndpoint is the resolved Garage Admin API endpoint last used
+                    to manage this node's layout entry. Captured on each successful reconcile
+                    so that a delete-time finalizer can still attempt to drop the layout
+                    entry when the parent GarageCluster CR has already been deleted (edge
+                    gateway pattern via spec.connectTo.adminApiEndpoint).
+                  type: string
+                clusterAdminTokenSecretRef:
+                  description: |-
+                    ClusterAdminTokenSecretRef references the Admin API token secret last
+                    used to manage this node's layout entry. The secret lives in the same
+                    namespace as the GarageNode. Paired with ClusterAdminEndpoint to enable
+                    best-effort finalize against an external admin API after the parent
+                    GarageCluster CR is gone.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      default: ''
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    optional:
+                      description: Specify whether the Secret or its key must be defined
+                      type: boolean
+                  required:
+                    - key
+                  type: object
+                  x-kubernetes-map-type: atomic
                 conditions:
                   description: Conditions represent the current state
                   items:
@@ -15006,6 +17088,28 @@ spec:
                 connected:
                   description: Connected indicates if the node is currently connected
                   type: boolean
+                cyclePhase:
+                  description: |-
+                    CyclePhase tracks progress of a graceful node cycle triggered by the
+                    garage.rajsingh.info/cycle annotation. Empty when no cycle is active.
+                    Used to make the add-before-remove state machine resumable/idempotent
+                    across requeues: a non-empty value means a sibling has already been
+                    provisioned, so the operator continues the swap rather than re-provisioning.
+                  enum:
+                    - Provisioning
+                    - Syncing
+                    - Draining
+                  type: string
+                cycleSiblingName:
+                  description: |-
+                    CycleSiblingName is the name of the sibling GarageNode provisioned for an
+                    in-progress cycle (the replacement that takes over this node's layout slot).
+                  type: string
+                cycleSiblingNodeId:
+                  description: |-
+                    CycleSiblingNodeID is the discovered Garage node ID of the cycle sibling,
+                    used to check its layout sync tracker before this node is removed.
+                  type: string
                 dataPartition:
                   description: |-
                     DataPartition contains disk space info for the data partition
@@ -15144,15 +17248,15 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: garagereferencegrants.garage.rajsingh.info
 spec:
   group: garage.rajsingh.info

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/deployment.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/deployment.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator
   namespace: syn-garage-operator
 spec:
@@ -40,7 +40,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: ghcr.io/rajsinghtech/garage-operator:v0.4.10
+          image: ghcr.io/rajsinghtech/garage-operator:v0.6.15
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/metrics-rbac.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/metrics-rbac.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-metrics-auth-role
 rules:
   - apiGroups:
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-metrics-reader
 rules:
   - nonResourceURLs:
@@ -47,9 +47,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/prometheusrules.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/prometheusrules.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
     syn: 'true'
     syn_component: appcat
     syn_team: schedar

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/role.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/role.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-leader-election-role
   namespace: syn-garage-operator
 rules:

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/rolebinding.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/rolebinding.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-leader-election-rolebinding
   namespace: syn-garage-operator
 roleRef:

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/service.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/service.yaml
@@ -2,12 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-metrics
   namespace: syn-garage-operator
 spec:

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/serviceaccount.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator
   namespace: syn-garage-operator

--- a/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/webhooks.yaml
+++ b/tests/golden/dev/appcat/appcat/garage_operator/garage-operator/templates/webhooks.yaml
@@ -5,9 +5,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-webhook
   namespace: syn-garage-operator
 spec:
@@ -28,9 +28,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-webhook-cert
   namespace: syn-garage-operator
 spec:
@@ -53,9 +53,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-selfsigned-issuer
   namespace: syn-garage-operator
 spec:
@@ -70,9 +70,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-mutating
 webhooks:
   - admissionReviewVersions:
@@ -165,9 +165,9 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: garage-operator
-    app.kubernetes.io/version: 0.4.10
+    app.kubernetes.io/version: 0.6.15
     control-plane: controller-manager
-    helm.sh/chart: garage-operator-0.4.10
+    helm.sh/chart: garage-operator-0.6.15
   name: appcat-garage-operator-validating
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-master-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:v4.189.0-func
+  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-master-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
+  package: ghcr.io/vshn/appcat:v4.189.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/exodev/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/exodev/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.1.0
+  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.2.1
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-kubernetes

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -6401,7 +6401,6 @@ spec:
                         procMount denotes the type of proc mount to use for the containers.
                         The default value is Default which uses the container runtime defaults for
                         readonly paths and masked paths.
-                        This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
@@ -11943,7 +11942,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -13517,7 +13515,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -14002,7 +13999,6 @@ spec:
                             When set to false, a new userns is created for the pod. Setting false is useful for
                             mitigating container breakout vulnerabilities even allowing users to run their
                             containers as root without actually having root privileges on the host.
-                            This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                           type: boolean
                         hostname:
                           description: |-
@@ -15173,7 +15169,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -15742,6 +15737,14 @@ spec:
 
                               It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                               Containers that need access to the ResourceClaim reference it with this name.
+
+                              When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                              belongs to a PodGroup, a PodResourceClaim is matched to a
+                              PodGroupResourceClaim if all of their fields are equal (Name,
+                              ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                              a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                              the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                              Pods.
                             properties:
                               name:
                                 description: |-
@@ -15766,6 +15769,16 @@ spec:
                                   will also be deleted. The pod name and resource name, along with a
                                   generated component, will be used to form a unique name for the
                                   ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                  belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                  Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                  ResourceClaim generated for the PodGroup. All pods in the group that
+                                  define an equivalent PodResourceClaim matching the
+                                  PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                  generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                  owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                  instead of any individual pod.
 
                                   This field is immutable and no changes will be made to the
                                   corresponding ResourceClaim by the control plane after creating the
@@ -15893,6 +15906,28 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        schedulingGroup:
+                          description: |-
+                            SchedulingGroup provides a reference to the immediate scheduling runtime
+                            grouping object that this Pod belongs to.
+                            This field is used by the scheduler to identify the group and apply the
+                            correct group scheduling policies. The association with a group also
+                            impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                            of scheduling like preemption, resource attachment, etc. If not specified,
+                            the Pod is treated as a single unit in all of these aspects.
+                            The group object referenced by this field may not exist at the time the
+                            Pod is created.
+                            This field is immutable, but a group object with the same name may be
+                            recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            podGroupName:
+                              description: |-
+                                PodGroupName specifies the name of the standalone PodGroup object
+                                that represents the runtime instance of this group.
+                                Must be a DNS subdomain.
+                              type: string
+                          type: object
                         securityContext:
                           description: |-
                             SecurityContext holds pod-level security attributes and common container settings.
@@ -17326,7 +17361,7 @@ spec:
                                   A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                   The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                   The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  The volume will be mounted read-only (ro).
                                   Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                   The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                 properties:
@@ -17499,8 +17534,7 @@ spec:
                                 description: |-
                                   portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                   Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                  are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                  is on.
+                                  are redirected to the pxd.portworx.com CSI driver.
                                 properties:
                                   fsType:
                                     description: |-
@@ -18330,42 +18364,6 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
-                        workloadRef:
-                          description: |-
-                            WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                            This field is used by the scheduler to identify the PodGroup and apply the
-                            correct group scheduling policies. The Workload object referenced
-                            by this field may not exist at the time the Pod is created.
-                            This field is immutable, but a Workload object with the same name
-                            may be recreated with different policies. Doing this during pod scheduling
-                            may result in the placement not conforming to the expected policies.
-                          properties:
-                            name:
-                              description: |-
-                                Name defines the name of the Workload object this Pod belongs to.
-                                Workload must be in the same namespace as the Pod.
-                                If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                until a Workload object is created and observed by the kube-scheduler.
-                                It must be a DNS subdomain.
-                              type: string
-                            podGroup:
-                              description: |-
-                                PodGroup is the name of the PodGroup within the Workload that this Pod
-                                belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                the Pod will remain unschedulable until the Workload object is recreated
-                                and observed by the kube-scheduler. It must be a DNS label.
-                              type: string
-                            podGroupReplicaKey:
-                              description: |-
-                                PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                Pod belongs. It is used to distinguish pods belonging to different replicas
-                                of the same pod group. The pod group policy is applied separately to each replica.
-                                When set, it must be a DNS label.
-                              type: string
-                          required:
-                            - name
-                            - podGroup
-                          type: object
                       required:
                         - containers
                       type: object

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
-        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
-        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
+        checksum/config: e8a7810ca1b5a05169150af99605e9c4d990a21fad6d5f33111074c7c329afb1
+        checksum/monitoring-config: 69d7106d91691ffded680b977394afab7b1c004594ce5a197c9d4ff094a31ed1
+        checksum/rbac: de28f52a82bc0ae7bedd16f87c0eddaa9df54204697ff0e218ac9f984a9a3bbf
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,7 +36,7 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -47,7 +47,7 @@ spec:
               value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -21,11 +21,11 @@ data:
             , state
             , usename
             , COALESCE(application_name, '') AS application_name
-            , COUNT(*)
-            , COALESCE(EXTRACT (EPOCH FROM (max(now() - xact_start))), 0) AS max_tx_secs
+            , pg_catalog.count(*)
+            , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs
           FROM pg_catalog.pg_stat_activity
           GROUP BY datname, state, usename, application_name
-        ) sa ON states.state = sa.state
+        ) sa ON states.state OPERATOR(pg_catalog.=) sa.state
         WHERE sa.usename IS NOT NULL
       metrics:
         - datname:
@@ -49,10 +49,10 @@ data:
 
     backends_waiting:
       query: |
-        SELECT count(*) AS total
+        SELECT pg_catalog.count(*) AS total
         FROM pg_catalog.pg_locks blocked_locks
         JOIN pg_catalog.pg_locks blocking_locks
-          ON blocking_locks.locktype = blocked_locks.locktype
+          ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype
           AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
           AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
           AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
@@ -62,8 +62,8 @@ data:
           AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
           AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
           AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
-          AND blocking_locks.pid != blocked_locks.pid
-        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+          AND blocking_locks.pid OPERATOR(pg_catalog.<>) blocked_locks.pid
+        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid
         WHERE NOT blocked_locks.granted
       metrics:
         - total:
@@ -105,14 +105,14 @@ data:
       query: |
         SELECT CASE WHEN (
             NOT pg_catalog.pg_is_in_recovery()
-            OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
+            OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())
           THEN 0
           ELSE GREATEST (0,
-            EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
+            EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))
           END AS lag,
           pg_catalog.pg_is_in_recovery() AS in_recovery,
-          EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-          (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
+          EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,
+          (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
       metrics:
         - lag:
             usage: "GAUGE"
@@ -160,17 +160,17 @@ data:
       query: |
         SELECT archived_count
           , failed_count
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_archived_time)), -1) AS seconds_since_last_archival
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_failed_time)), -1) AS seconds_since_last_failure
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure
           , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time
           , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
           , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
         FROM pg_catalog.pg_stat_archiver
       predicate_query: |
         SELECT NOT pg_catalog.pg_is_in_recovery()
-          OR pg_catalog.current_setting('archive_mode') = 'always'
+          OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'
       metrics:
         - archived_count:
             usage: "COUNTER"
@@ -456,12 +456,12 @@ data:
     pg_extensions:
       query: |
         SELECT
-          current_database() as datname,
+          pg_catalog.current_database() as datname,
           name as extname,
           default_version,
           installed_version,
           CASE
-            WHEN default_version = installed_version THEN 0
+            WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0
             ELSE 1
         END AS update_available
         FROM pg_catalog.pg_available_extensions
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
+    app.kubernetes.io/version: 1.29.1
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.28.0
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/exodev/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
+    app.kubernetes.io/version: 2.3.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.2.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: crossplane-2.2.2
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: crossplane-2.2.2
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/exodev/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-master-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:v4.189.0-func
+  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-master-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
+  package: ghcr.io/vshn/appcat:v4.189.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-cloud/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.1.0
+  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.2.1
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-kubernetes

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -37,7 +37,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.38'
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.1.9
+          chartVersion: 7.2.0
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           controlNamespace: syn-appcat-control

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -35,7 +35,7 @@ spec:
           billingEnabled: 'false'
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
-          busybox_image_tag: '1.37'
+          busybox_image_tag: '1.38'
           chartRepository: https://codecentric.github.io/helm-charts
           chartVersion: 7.1.9
           cloudProvider: cloudscale

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -69,7 +69,7 @@ spec:
             "8Gi"}}}'
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:3.0.7
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.9
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -34,7 +34,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.38'
           chartRepository: https://nextcloud.github.io/helm/
-          chartVersion: 9.0.5
+          chartVersion: 9.1.3
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           collaboraCPULimit: '1'

--- a/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -32,7 +32,7 @@ spec:
           billingEnabled: 'false'
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
-          busybox_image_tag: '1.37'
+          busybox_image_tag: '1.38'
           chartRepository: https://nextcloud.github.io/helm/
           chartVersion: 9.0.5
           cloudProvider: cloudscale

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -6401,7 +6401,6 @@ spec:
                         procMount denotes the type of proc mount to use for the containers.
                         The default value is Default which uses the container runtime defaults for
                         readonly paths and masked paths.
-                        This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
@@ -11943,7 +11942,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -13517,7 +13515,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -14002,7 +13999,6 @@ spec:
                             When set to false, a new userns is created for the pod. Setting false is useful for
                             mitigating container breakout vulnerabilities even allowing users to run their
                             containers as root without actually having root privileges on the host.
-                            This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                           type: boolean
                         hostname:
                           description: |-
@@ -15173,7 +15169,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -15742,6 +15737,14 @@ spec:
 
                               It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                               Containers that need access to the ResourceClaim reference it with this name.
+
+                              When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                              belongs to a PodGroup, a PodResourceClaim is matched to a
+                              PodGroupResourceClaim if all of their fields are equal (Name,
+                              ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                              a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                              the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                              Pods.
                             properties:
                               name:
                                 description: |-
@@ -15766,6 +15769,16 @@ spec:
                                   will also be deleted. The pod name and resource name, along with a
                                   generated component, will be used to form a unique name for the
                                   ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                  belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                  Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                  ResourceClaim generated for the PodGroup. All pods in the group that
+                                  define an equivalent PodResourceClaim matching the
+                                  PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                  generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                  owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                  instead of any individual pod.
 
                                   This field is immutable and no changes will be made to the
                                   corresponding ResourceClaim by the control plane after creating the
@@ -15893,6 +15906,28 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        schedulingGroup:
+                          description: |-
+                            SchedulingGroup provides a reference to the immediate scheduling runtime
+                            grouping object that this Pod belongs to.
+                            This field is used by the scheduler to identify the group and apply the
+                            correct group scheduling policies. The association with a group also
+                            impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                            of scheduling like preemption, resource attachment, etc. If not specified,
+                            the Pod is treated as a single unit in all of these aspects.
+                            The group object referenced by this field may not exist at the time the
+                            Pod is created.
+                            This field is immutable, but a group object with the same name may be
+                            recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            podGroupName:
+                              description: |-
+                                PodGroupName specifies the name of the standalone PodGroup object
+                                that represents the runtime instance of this group.
+                                Must be a DNS subdomain.
+                              type: string
+                          type: object
                         securityContext:
                           description: |-
                             SecurityContext holds pod-level security attributes and common container settings.
@@ -17326,7 +17361,7 @@ spec:
                                   A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                   The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                   The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  The volume will be mounted read-only (ro).
                                   Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                   The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                 properties:
@@ -17499,8 +17534,7 @@ spec:
                                 description: |-
                                   portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                   Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                  are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                  is on.
+                                  are redirected to the pxd.portworx.com CSI driver.
                                 properties:
                                   fsType:
                                     description: |-
@@ -18330,42 +18364,6 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
-                        workloadRef:
-                          description: |-
-                            WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                            This field is used by the scheduler to identify the PodGroup and apply the
-                            correct group scheduling policies. The Workload object referenced
-                            by this field may not exist at the time the Pod is created.
-                            This field is immutable, but a Workload object with the same name
-                            may be recreated with different policies. Doing this during pod scheduling
-                            may result in the placement not conforming to the expected policies.
-                          properties:
-                            name:
-                              description: |-
-                                Name defines the name of the Workload object this Pod belongs to.
-                                Workload must be in the same namespace as the Pod.
-                                If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                until a Workload object is created and observed by the kube-scheduler.
-                                It must be a DNS subdomain.
-                              type: string
-                            podGroup:
-                              description: |-
-                                PodGroup is the name of the PodGroup within the Workload that this Pod
-                                belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                the Pod will remain unschedulable until the Workload object is recreated
-                                and observed by the kube-scheduler. It must be a DNS label.
-                              type: string
-                            podGroupReplicaKey:
-                              description: |-
-                                PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                Pod belongs. It is used to distinguish pods belonging to different replicas
-                                of the same pod group. The pod group policy is applied separately to each replica.
-                                When set, it must be a DNS label.
-                              type: string
-                          required:
-                            - name
-                            - podGroup
-                          type: object
                       required:
                         - containers
                       type: object

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
-        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
-        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
+        checksum/config: e8a7810ca1b5a05169150af99605e9c4d990a21fad6d5f33111074c7c329afb1
+        checksum/monitoring-config: 69d7106d91691ffded680b977394afab7b1c004594ce5a197c9d4ff094a31ed1
+        checksum/rbac: de28f52a82bc0ae7bedd16f87c0eddaa9df54204697ff0e218ac9f984a9a3bbf
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,7 +36,7 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0-ubi9
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1-ubi9
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -47,7 +47,7 @@ spec:
               value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0-ubi9
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1-ubi9
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -21,11 +21,11 @@ data:
             , state
             , usename
             , COALESCE(application_name, '') AS application_name
-            , COUNT(*)
-            , COALESCE(EXTRACT (EPOCH FROM (max(now() - xact_start))), 0) AS max_tx_secs
+            , pg_catalog.count(*)
+            , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs
           FROM pg_catalog.pg_stat_activity
           GROUP BY datname, state, usename, application_name
-        ) sa ON states.state = sa.state
+        ) sa ON states.state OPERATOR(pg_catalog.=) sa.state
         WHERE sa.usename IS NOT NULL
       metrics:
         - datname:
@@ -49,10 +49,10 @@ data:
 
     backends_waiting:
       query: |
-        SELECT count(*) AS total
+        SELECT pg_catalog.count(*) AS total
         FROM pg_catalog.pg_locks blocked_locks
         JOIN pg_catalog.pg_locks blocking_locks
-          ON blocking_locks.locktype = blocked_locks.locktype
+          ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype
           AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
           AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
           AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
@@ -62,8 +62,8 @@ data:
           AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
           AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
           AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
-          AND blocking_locks.pid != blocked_locks.pid
-        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+          AND blocking_locks.pid OPERATOR(pg_catalog.<>) blocked_locks.pid
+        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid
         WHERE NOT blocked_locks.granted
       metrics:
         - total:
@@ -105,14 +105,14 @@ data:
       query: |
         SELECT CASE WHEN (
             NOT pg_catalog.pg_is_in_recovery()
-            OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
+            OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())
           THEN 0
           ELSE GREATEST (0,
-            EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
+            EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))
           END AS lag,
           pg_catalog.pg_is_in_recovery() AS in_recovery,
-          EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-          (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
+          EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,
+          (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
       metrics:
         - lag:
             usage: "GAUGE"
@@ -160,17 +160,17 @@ data:
       query: |
         SELECT archived_count
           , failed_count
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_archived_time)), -1) AS seconds_since_last_archival
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_failed_time)), -1) AS seconds_since_last_failure
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure
           , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time
           , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
           , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
         FROM pg_catalog.pg_stat_archiver
       predicate_query: |
         SELECT NOT pg_catalog.pg_is_in_recovery()
-          OR pg_catalog.current_setting('archive_mode') = 'always'
+          OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'
       metrics:
         - archived_count:
             usage: "COUNTER"
@@ -456,12 +456,12 @@ data:
     pg_extensions:
       query: |
         SELECT
-          current_database() as datname,
+          pg_catalog.current_database() as datname,
           name as extname,
           default_version,
           installed_version,
           CASE
-            WHEN default_version = installed_version THEN 0
+            WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0
             ELSE 1
         END AS update_available
         FROM pg_catalog.pg_available_extensions
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
+    app.kubernetes.io/version: 1.29.1
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.28.0
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
+    app.kubernetes.io/version: 2.3.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.2.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: crossplane-2.2.2
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: crossplane-2.2.2
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/vshn-cloud/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-master-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:v4.189.0-func
+  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_function_appcat.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: '-40'
   name: function-appcat-master-71faf2172a4967a7c94ed8df196a83613d23bae3
 spec:
-  package: ghcr.io/vshn/appcat:71faf2172a4967a7c94ed8df196a83613d23bae3-func
+  package: ghcr.io/vshn/appcat:v4.189.0-func
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: function-appcat

--- a/tests/golden/vshn-managed/appcat/appcat/10_provider_kubernetes.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/10_provider_kubernetes.yaml
@@ -8,7 +8,7 @@ metadata:
     name: provider-kubernetes
   name: provider-kubernetes
 spec:
-  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.1.0
+  package: ghcr.io/crossplane-contrib/provider-kubernetes:v1.2.1
   packagePullPolicy: IfNotPresent
   runtimeConfigRef:
     name: provider-kubernetes

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -37,7 +37,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.38'
           chartRepository: https://codecentric.github.io/helm-charts
-          chartVersion: 7.1.9
+          chartVersion: 7.2.0
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           controlNamespace: syn-appcat-control

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_keycloak.yaml
@@ -35,7 +35,7 @@ spec:
           billingEnabled: 'false'
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
-          busybox_image_tag: '1.37'
+          busybox_image_tag: '1.38'
           chartRepository: https://codecentric.github.io/helm-charts
           chartVersion: 7.1.9
           cloudProvider: cloudscale

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_mariadb.yaml
@@ -69,7 +69,7 @@ spec:
             "8Gi"}}}'
           proxysqlCPULimit: 500m
           proxysqlCPURequests: 50m
-          proxysqlImage: docker.io/proxysql/proxysql:3.0.7
+          proxysqlImage: docker.io/proxysql/proxysql:3.0.9
           proxysqlMemoryLimit: 256Mi
           proxysqlMemoryRequests: 64Mi
           quotasEnabled: 'false'

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -34,7 +34,7 @@ spec:
           busybox_image: docker.io/library/busybox
           busybox_image_tag: '1.38'
           chartRepository: https://nextcloud.github.io/helm/
-          chartVersion: 9.0.5
+          chartVersion: 9.1.3
           cloudProvider: cloudscale
           clusterName: c-green-test-1234
           collaboraCPULimit: '1'

--- a/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/21_composition_vshn_nextcloud.yaml
@@ -32,7 +32,7 @@ spec:
           billingEnabled: 'false'
           bucketRegion: lpg
           busybox_image: docker.io/library/busybox
-          busybox_image_tag: '1.37'
+          busybox_image_tag: '1.38'
           chartRepository: https://nextcloud.github.io/helm/
           chartVersion: 9.0.5
           cloudProvider: cloudscale

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/config.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-controller-manager-config
   namespace: syn-cnpg-system

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/crds/crds.yaml
@@ -6401,7 +6401,6 @@ spec:
                         procMount denotes the type of proc mount to use for the containers.
                         The default value is Default which uses the container runtime defaults for
                         readonly paths and masked paths.
-                        This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
@@ -11943,7 +11942,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -13517,7 +13515,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -14002,7 +13999,6 @@ spec:
                             When set to false, a new userns is created for the pod. Setting false is useful for
                             mitigating container breakout vulnerabilities even allowing users to run their
                             containers as root without actually having root privileges on the host.
-                            This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                           type: boolean
                         hostname:
                           description: |-
@@ -15173,7 +15169,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -15742,6 +15737,14 @@ spec:
 
                               It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                               Containers that need access to the ResourceClaim reference it with this name.
+
+                              When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                              belongs to a PodGroup, a PodResourceClaim is matched to a
+                              PodGroupResourceClaim if all of their fields are equal (Name,
+                              ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                              a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                              the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                              Pods.
                             properties:
                               name:
                                 description: |-
@@ -15766,6 +15769,16 @@ spec:
                                   will also be deleted. The pod name and resource name, along with a
                                   generated component, will be used to form a unique name for the
                                   ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                  belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                  Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                  ResourceClaim generated for the PodGroup. All pods in the group that
+                                  define an equivalent PodResourceClaim matching the
+                                  PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                  generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                  owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                  instead of any individual pod.
 
                                   This field is immutable and no changes will be made to the
                                   corresponding ResourceClaim by the control plane after creating the
@@ -15893,6 +15906,28 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        schedulingGroup:
+                          description: |-
+                            SchedulingGroup provides a reference to the immediate scheduling runtime
+                            grouping object that this Pod belongs to.
+                            This field is used by the scheduler to identify the group and apply the
+                            correct group scheduling policies. The association with a group also
+                            impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                            of scheduling like preemption, resource attachment, etc. If not specified,
+                            the Pod is treated as a single unit in all of these aspects.
+                            The group object referenced by this field may not exist at the time the
+                            Pod is created.
+                            This field is immutable, but a group object with the same name may be
+                            recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            podGroupName:
+                              description: |-
+                                PodGroupName specifies the name of the standalone PodGroup object
+                                that represents the runtime instance of this group.
+                                Must be a DNS subdomain.
+                              type: string
+                          type: object
                         securityContext:
                           description: |-
                             SecurityContext holds pod-level security attributes and common container settings.
@@ -17326,7 +17361,7 @@ spec:
                                   A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                   The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                   The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  The volume will be mounted read-only (ro).
                                   Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                   The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                 properties:
@@ -17499,8 +17534,7 @@ spec:
                                 description: |-
                                   portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                   Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                  are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                  is on.
+                                  are redirected to the pxd.portworx.com CSI driver.
                                 properties:
                                   fsType:
                                     description: |-
@@ -18330,42 +18364,6 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
-                        workloadRef:
-                          description: |-
-                            WorkloadRef provides a reference to the Workload object that this Pod belongs to.
-                            This field is used by the scheduler to identify the PodGroup and apply the
-                            correct group scheduling policies. The Workload object referenced
-                            by this field may not exist at the time the Pod is created.
-                            This field is immutable, but a Workload object with the same name
-                            may be recreated with different policies. Doing this during pod scheduling
-                            may result in the placement not conforming to the expected policies.
-                          properties:
-                            name:
-                              description: |-
-                                Name defines the name of the Workload object this Pod belongs to.
-                                Workload must be in the same namespace as the Pod.
-                                If it doesn't match any existing Workload, the Pod will remain unschedulable
-                                until a Workload object is created and observed by the kube-scheduler.
-                                It must be a DNS subdomain.
-                              type: string
-                            podGroup:
-                              description: |-
-                                PodGroup is the name of the PodGroup within the Workload that this Pod
-                                belongs to. If it doesn't match any existing PodGroup within the Workload,
-                                the Pod will remain unschedulable until the Workload object is recreated
-                                and observed by the kube-scheduler. It must be a DNS label.
-                              type: string
-                            podGroupReplicaKey:
-                              description: |-
-                                PodGroupReplicaKey specifies the replica key of the PodGroup to which this
-                                Pod belongs. It is used to distinguish pods belonging to different replicas
-                                of the same pod group. The pod group policy is applied separately to each replica.
-                                When set, it must be a DNS label.
-                              type: string
-                          required:
-                            - name
-                            - podGroup
-                          type: object
                       required:
                         - containers
                       type: object

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 spec:
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 56d725ea97a55993d7f42d93fe7974c31e245cf5fa8b439fdea821f810ba4c05
-        checksum/monitoring-config: 37437453fb93c6f815f2f155cf7d1350d485a2a778744671278a416a198b1e5a
-        checksum/rbac: 8565c693194f2b37739e98c27f3ae4df3793db75d117e4f4f576c733b1fa7531
+        checksum/config: e8a7810ca1b5a05169150af99605e9c4d990a21fad6d5f33111074c7c329afb1
+        checksum/monitoring-config: 69d7106d91691ffded680b977394afab7b1c004594ce5a197c9d4ff094a31ed1
+        checksum/rbac: de28f52a82bc0ae7bedd16f87c0eddaa9df54204697ff0e218ac9f984a9a3bbf
       labels:
         app.kubernetes.io/instance: appcat
         app.kubernetes.io/name: cloudnative-pg
@@ -36,7 +36,7 @@ spec:
             - /manager
           env:
             - name: OPERATOR_IMAGE_NAME
-              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0-ubi9
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1-ubi9
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -47,7 +47,7 @@ spec:
               value: 'true'
             - name: EXPIRING_CHECK_THRESHOLD
               value: '15'
-          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0-ubi9
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1-ubi9
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/monitoring-configmap.yaml
@@ -21,11 +21,11 @@ data:
             , state
             , usename
             , COALESCE(application_name, '') AS application_name
-            , COUNT(*)
-            , COALESCE(EXTRACT (EPOCH FROM (max(now() - xact_start))), 0) AS max_tx_secs
+            , pg_catalog.count(*)
+            , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs
           FROM pg_catalog.pg_stat_activity
           GROUP BY datname, state, usename, application_name
-        ) sa ON states.state = sa.state
+        ) sa ON states.state OPERATOR(pg_catalog.=) sa.state
         WHERE sa.usename IS NOT NULL
       metrics:
         - datname:
@@ -49,10 +49,10 @@ data:
 
     backends_waiting:
       query: |
-        SELECT count(*) AS total
+        SELECT pg_catalog.count(*) AS total
         FROM pg_catalog.pg_locks blocked_locks
         JOIN pg_catalog.pg_locks blocking_locks
-          ON blocking_locks.locktype = blocked_locks.locktype
+          ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype
           AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
           AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
           AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
@@ -62,8 +62,8 @@ data:
           AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
           AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
           AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
-          AND blocking_locks.pid != blocked_locks.pid
-        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+          AND blocking_locks.pid OPERATOR(pg_catalog.<>) blocked_locks.pid
+        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid
         WHERE NOT blocked_locks.granted
       metrics:
         - total:
@@ -105,14 +105,14 @@ data:
       query: |
         SELECT CASE WHEN (
             NOT pg_catalog.pg_is_in_recovery()
-            OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
+            OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())
           THEN 0
           ELSE GREATEST (0,
-            EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
+            EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))
           END AS lag,
           pg_catalog.pg_is_in_recovery() AS in_recovery,
-          EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-          (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
+          EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,
+          (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
       metrics:
         - lag:
             usage: "GAUGE"
@@ -160,17 +160,17 @@ data:
       query: |
         SELECT archived_count
           , failed_count
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_archived_time)), -1) AS seconds_since_last_archival
-          , COALESCE(EXTRACT(EPOCH FROM (now() - last_failed_time)), -1) AS seconds_since_last_failure
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure
           , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time
           , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
-          , COALESCE(CAST(CAST('x'||pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
           , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
         FROM pg_catalog.pg_stat_archiver
       predicate_query: |
         SELECT NOT pg_catalog.pg_is_in_recovery()
-          OR pg_catalog.current_setting('archive_mode') = 'always'
+          OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'
       metrics:
         - archived_count:
             usage: "COUNTER"
@@ -456,12 +456,12 @@ data:
     pg_extensions:
       query: |
         SELECT
-          current_database() as datname,
+          pg_catalog.current_database() as datname,
           name as extname,
           default_version,
           installed_version,
           CASE
-            WHEN default_version = installed_version THEN 0
+            WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0
             ELSE 1
         END AS update_available
         FROM pg_catalog.pg_available_extensions
@@ -490,8 +490,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
+    app.kubernetes.io/version: 1.29.1
     cnpg.io/reload: ''
-    helm.sh/chart: cloudnative-pg-0.28.0
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-default-monitoring
   namespace: syn-cnpg-system

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
   namespace: syn-cnpg-system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 rules:
   - apiGroups:
@@ -261,8 +261,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-view
 rules:
   - apiGroups:
@@ -293,8 +293,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg-edit
 rules:
   - apiGroups:
@@ -327,8 +327,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: appcat-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-webhook-service
   namespace: syn-cnpg-system
 spec:

--- a/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/cnpg/helmchart/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: appcat
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.29.0
-    helm.sh/chart: cloudnative-pg-0.28.0
+    app.kubernetes.io/version: 1.29.1
+    helm.sh/chart: cloudnative-pg-0.28.2
   name: cnpg-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrole.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
+    app.kubernetes.io/version: 2.3.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.2.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-crossplane: 'true'
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: crossplane-2.2.2
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -76,7 +76,7 @@ spec:
               value: crossplane-tls-client
             - name: TLS_CLIENT_CERTS_DIR
               value: /tls/client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           ports:
@@ -152,7 +152,7 @@ spec:
               value: crossplane-tls-server
             - name: TLS_CLIENT_SECRET_NAME
               value: crossplane-tls-client
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-allowed-provider-permissions.yaml
@@ -14,6 +14,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane:allowed-provider-permissions

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrole.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 rules:
   - apiGroups:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-clusterrolebinding.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-deployment.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-rbac-manager
   namespace: syn-crossplane
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: crossplane-2.2.2
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: appcat
     spec:
       containers:
@@ -58,7 +58,7 @@ spec:
                   resource: limits.memory
             - name: LEADER_ELECTION
               value: 'true'
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane
           resources:
@@ -90,7 +90,7 @@ spec:
                   containerName: crossplane-init
                   divisor: '1'
                   resource: limits.memory
-          image: xpkg.crossplane.io/crossplane/crossplane:v2.2.2
+          image: xpkg.crossplane.io/crossplane/crossplane:v2.3.2
           imagePullPolicy: IfNotPresent
           name: crossplane-init
           resources:

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -14,8 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 ---
 aggregationRule:
@@ -34,8 +34,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-edit
 ---
 aggregationRule:
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-view
 ---
 aggregationRule:
@@ -74,8 +74,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-browse
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-admin: 'true'
   name: crossplane:aggregate-to-admin
 rules:
@@ -177,8 +177,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-edit: 'true'
   name: crossplane:aggregate-to-edit
 rules:
@@ -247,8 +247,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-view: 'true'
   name: crossplane:aggregate-to-view
 rules:
@@ -321,8 +321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-browse: 'true'
   name: crossplane:aggregate-to-browse
 rules:
@@ -355,8 +355,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: rbac-manager
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: appcat
   name: crossplane-webhooks
   namespace: syn-crossplane

--- a/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
+++ b/tests/golden/vshn-managed/appcat/appcat/crossplane/helmchart/crossplane/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.2.2
-    helm.sh/chart: crossplane-2.2.2
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
   namespace: syn-crossplane


### PR DESCRIPTION
## Summary

This updates our dependencies:

- Crossplane to v2.3.2
- Provider Kubernetes to v1.2.1
- Busybox to v1.38
- Keycloak Chart to 7.2.0
- CNPG Chart to 0.28.2
- Garage operator to 0.6.15
- Proxysql to 3.0.9
- Nextcloud Chart to 9.1.3

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] I run `make e2e-test` against local kindev and all checks passed
- [ ] If no changes have been made you can self approve but otherwise at least two reviews are required
- [ ] Link this PR to related issues or PRs.
