### PR TITLE
Fix issue where prometheusRule is deployed, when slo is disabled

### DIFF
--- a/component/vshn_alerting.jsonnet
+++ b/component/vshn_alerting.jsonnet
@@ -46,6 +46,6 @@ local pinnedTagStaleRule = {
   },
 };
 
-if params.slos.alertsEnabled && vars.isSingleOrServiceCluster then {
+if params.slos.enabled && params.slos.alertsEnabled && vars.isSingleOrServiceCluster then {
   'sli_exporter/90_VSHNPinnedImageTagStale': pinnedTagStaleRule,
 } else {}


### PR DESCRIPTION
The prometheusRule `pinnedTagStaleRule` is deployed even when SLOs are disabled. This leads to argoCD failures, because it tries to put the alert in a namespace that doesn't exist

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [x] If no changes have been made you can self approve but otherwise at least two reviews are required
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
