### PR TITLE
Use fully qualified name for vshn crds

### DIFF
--- a/tests/e2e/nextcloud/61-assert-pg.yaml
+++ b/tests/e2e/nextcloud/61-assert-pg.yaml
@@ -25,7 +25,7 @@ spec:
     service:
       vacuumEnabled: true
       repackEnabled: true
-      majorVersion: "15"
+      majorVersion: "18"
       serviceLevel: besteffort
     size:
       plan: standard-2

--- a/tests/e2e/postgresqlcnpg/scripts/check-maintenance.sh
+++ b/tests/e2e/postgresqlcnpg/scripts/check-maintenance.sh
@@ -3,7 +3,7 @@
 set -ex
 
 NAMESPACE="${NAMESPACE:-appcat-e2e}"
-ns=$(kubectl -n "$NAMESPACE" get vshnpostgresql pg-cnpg-e2e  -oyaml | yq -r '.status.instanceNamespace')
+ns=$(kubectl -n "$NAMESPACE" get vshnpostgresql.vshn.appcat.vshn.io pg-cnpg-e2e  -oyaml | yq -r '.status.instanceNamespace')
 
 # Initial maintenance should be completed
 job=$(kubectl -n "$ns" get job -o name | grep "initial-maintenance")

--- a/tests/e2e/postgresqlcnpg/scripts/major-version-upgrade.sh
+++ b/tests/e2e/postgresqlcnpg/scripts/major-version-upgrade.sh
@@ -5,15 +5,15 @@ NAMESPACE="${NAMESPACE:-appcat-e2e}"
 RESOURCE="pg-cnpg-e2e"
 DEADLINE=$(($(date +%s) + 1800))
 
-CURRENT=$(kubectl get vshnpostgresql "$RESOURCE" -n "$NAMESPACE" -o jsonpath='{.status.currentVersion}')
+CURRENT=$(kubectl get vshnpostgresql.vshn.appcat.vshn.io "$RESOURCE" -n "$NAMESPACE" -o jsonpath='{.status.currentVersion}')
 TARGET=$((CURRENT + 1))
 
 echo "Upgrading PostgreSQL major version: $CURRENT -> $TARGET"
 
-kubectl patch vshnpostgresql "$RESOURCE" -n "$NAMESPACE" --type=merge \
+kubectl patch vshnpostgresql.vshn.appcat.vshn.io "$RESOURCE" -n "$NAMESPACE" --type=merge \
   -p "{\"spec\":{\"parameters\":{\"service\":{\"majorVersion\":\"$TARGET\"}}}}"
 
-ns=$(kubectl -n "$NAMESPACE" get vshnpostgresql "$RESOURCE" -o jsonpath='{.status.instanceNamespace}')
+ns=$(kubectl -n "$NAMESPACE" get vshnpostgresql.vshn.appcat.vshn.io "$RESOURCE" -o jsonpath='{.status.instanceNamespace}')
 
 # Wait for composition function to reconcile and update the imageCatalogRef
 kubectl wait --for=jsonpath='{.spec.imageCatalogRef.major}'="$TARGET" \

--- a/tests/e2e/postgresqlsg/scripts/check-backup.sh
+++ b/tests/e2e/postgresqlsg/scripts/check-backup.sh
@@ -8,8 +8,8 @@ echo "=== Starting PostgreSQL backup test ==="
 echo "Namespace: $NAMESPACE"
 
 echo "Getting instance namespace and cluster name..."
-instancens=$(kubectl -n "$NAMESPACE" get vshnpostgresql pg-sg-e2e -oyaml | yq -r '.status.instanceNamespace')
-comp=$(kubectl -n "$NAMESPACE" get vshnpostgresql pg-sg-e2e -oyaml | yq -r '.spec.resourceRef.name')
+instancens=$(kubectl -n "$NAMESPACE" get vshnpostgresql.vshn.appcat.vshn.io pg-sg-e2e -oyaml | yq -r '.status.instanceNamespace')
+comp=$(kubectl -n "$NAMESPACE" get vshnpostgresql.vshn.appcat.vshn.io pg-sg-e2e -oyaml | yq -r '.spec.resourceRef.name')
 
 echo "Instance namespace: $instancens"
 echo "Cluster name: $comp"

--- a/tests/e2e/postgresqlsg/scripts/restart-sgcluster.sh
+++ b/tests/e2e/postgresqlsg/scripts/restart-sgcluster.sh
@@ -6,10 +6,10 @@ NAMESPACE="${NAMESPACE:-appcat-e2e}"
 
 echo "=== Finding SGCluster namespace for pg-sg-e2e from control plane ==="
 
-COMPOSITE_NAME=$(kubectl -n ${NAMESPACE} get vshnpostgresql pg-sg-e2e -o jsonpath='{.spec.resourceRef.name}')
+COMPOSITE_NAME=$(kubectl -n ${NAMESPACE} get vshnpostgresql.vshn.appcat.vshn.io pg-sg-e2e -o jsonpath='{.spec.resourceRef.name}')
 echo "Composite resource name: ${COMPOSITE_NAME}"
 
-INSTANCE_NAMESPACE=$(kubectl -n "$NAMESPACE" get vshnpostgresql pg-sg-e2e -oyaml | yq -r '.status.instanceNamespace')
+INSTANCE_NAMESPACE=$(kubectl -n "$NAMESPACE" get vshnpostgresql.vshn.appcat.vshn.io pg-sg-e2e -oyaml | yq -r '.status.instanceNamespace')
 echo "SGCluster namespace: ${INSTANCE_NAMESPACE}"
 
 if [ -z "$INSTANCE_NAMESPACE" ]; then


### PR DESCRIPTION
We also use the same shortname for Appcat 2.0 which causes issues when only using the short form

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] I run `make e2e-test` against local kindev and all checks passed
- [ ] If no changes have been made you can self approve but otherwise at least two reviews are required
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
